### PR TITLE
Adding MRU iteration of tabs via Ctrl-Tab

### DIFF
--- a/PTYTabView.m
+++ b/PTYTabView.m
@@ -249,7 +249,7 @@
         theIndex = 0;
     }
     NSTabViewItem* next = [mruTabs objectAtIndex:theIndex];
-	[self selectTabViewItem:next];
+    [self selectTabViewItem:next];
 }
 
 - (BOOL)onKeyPressed:(NSEvent*)event


### PR DESCRIPTION
This feature allows tabs to be changed via Ctrl-Tab. It is implemented as a stack of most-recently used/viewed tabs. This is handy when flipping between multiple tabs in quick succession. 

Please take a look and try this out. The hotkey should probably be configurable and perhaps also the feature should have a configurable toggle as well.

What do you think?
