### PR TITLE
fix Exposé display when blur is enabled (seriously)

### DIFF
--- a/PTYWindow.m
+++ b/PTYWindow.m
@@ -103,7 +103,7 @@
     NSDictionary *optionsDict = [NSDictionary dictionaryWithObject:[NSNumber numberWithFloat:2.0] forKey:@"inputRadius"];
     CGSSetCIFilterValuesFromDictionary(con, blurFilter, (CFDictionaryRef)optionsDict);
 
-    CGSAddWindowFilter(con, [self windowNumber], blurFilter, kCGWindowFilterUnderlay);
+    CGSAddWindowFilter(con, [self windowNumber], blurFilter, kCGWindowFilterDock);
 #endif
 }
 


### PR DESCRIPTION
Passing `kCGWindowFilterDock` (0x3001) as the last parameter to `CGSAddWindowFilter` worked for Blurminal and it works for iTerm2. Too. I won't pretend to understand it, but [there it is](http://i.imgur.com/tx85l.png).

I used this hack for several months and saw no ill effects, and just confirmed tonight that it still works on Lion. Everything works as expected. It looks a little sketch, but then so does any undocumented goodness—such as, say, `CGSAddWindowFilter`. C:

I can't take credit for the discovery—all the glory should go @mkhl, who originally [used this hack in _his_ Blurminal fork](https://github.com/mkhl/Blurminal/commit/3dd23162aceab9af0eafa306e7ba48607529f220). Thank you kindly, sir!

![a bit of proof pudding for your eyes](http://i.imgur.com/tx85l.png)
