### PR TITLE
makeMainWindow is required when the terminal is in another space for steal focus to work

### DIFF
--- a/VT100Terminal.m
+++ b/VT100Terminal.m
@@ -2678,6 +2678,7 @@ static VT100TCC decode_string(unsigned char *datap,
         } else if ([key isEqualToString:@"StealFocus"]) {
             [NSApp activateIgnoringOtherApps:YES];
             [[[SCREEN display] window]makeKeyAndOrderFront:nil];
+            [[[SCREEN display] window]makeMainWindow];
         }
     } else if (token.type == XTERMCC_SET_PALETTE) {
         NSString* argument = token.u.string;


### PR DESCRIPTION
Sorry to go back on this one.  I should have tested this case...
if the terminal is in another space (in spaces or mission control/fullscreen in lion) then focus does not completely happen unless we issue a makeMainWindow.
