### PR TITLE
Add CurrentDir escape code to set the current directory.

### DIFF
--- a/Headers/iTerm/PTYTextView.h
+++ b/Headers/iTerm/PTYTextView.h
@@ -546,6 +546,7 @@ typedef enum {
 
 // Snapshot working directory for Trouter
 - (void)logWorkingDirectoryAtLine:(long long)line;
+- (void)logWorkingDirectoryAtLine:(long long)line withDirectory:(NSString *)workingDirectory;
 - (NSString *)getWorkingDirectoryAtLine:(long long)line;
 
 // Trouter change directory

--- a/PTYTextView.m
+++ b/PTYTextView.m
@@ -6605,6 +6605,11 @@ static bool IsUrlChar(NSString* str)
 - (void)logWorkingDirectoryAtLine:(long long)line
 {
     NSString *workingDirectory = [[dataSource shellTask] getWorkingDirectory];
+    [self logWorkingDirectoryAtLine:line withDirectory:workingDirectory];
+}
+
+- (void)logWorkingDirectoryAtLine:(long long)line withDirectory:(NSString *)workingDirectory
+{
     [workingDirectoryAtLines addObject:[NSArray arrayWithObjects:
           [NSNumber numberWithLongLong:line],
           workingDirectory,

--- a/VT100Terminal.m
+++ b/VT100Terminal.m
@@ -2679,6 +2679,10 @@ static VT100TCC decode_string(unsigned char *datap,
             [NSApp activateIgnoringOtherApps:YES];
             [[[SCREEN display] window]makeKeyAndOrderFront:nil];
             [[[SCREEN display] window]makeMainWindow];
+        } else if ([key isEqualToString:@"CurrentDir"]) {
+            long long lineNumber = [SCREEN absoluteLineNumberOfCursor];
+            [[[SCREEN session] TEXTVIEW] logWorkingDirectoryAtLine:lineNumber
+                                                     withDirectory:value];
         }
     } else if (token.type == XTERMCC_SET_PALETTE) {
         NSString* argument = token.u.string;


### PR DESCRIPTION
Can be set using:

```
echo -e -n "\033]50;CurrentDir=/Path/To/Directory\007"
```

This is really useful in an SSH session if you use SSHFS:

```
PROMPT_COMMAND='echo -ne "\e]50;CurrentDir=/Volumes/${HOSTNAME}$(pwd)\007"'
```
