### PR TITLE
found a resource leak in PTYTextArea trackingRects.

### DIFF
--- a/PTYTextView.m
+++ b/PTYTextView.m
@@ -308,6 +308,10 @@ static CGFloat PerceivedBrightness(CGFloat r, CGFloat g, CGFloat b) {
 - (void)viewDidMoveToWindow
 {
     if ([self window]) {
+        if (trackingRectTag) {
+                [self removeTrackingRect:trackingRectTag];
+        }
+
         trackingRectTag = [self addTrackingRect:[self frame]
                                           owner:self
                                        userData:nil


### PR DESCRIPTION
With long periods of usage, iTerm2 windows slow down while switching tabs.
All of this time, apparently, was being spent in _CGSRemoveTrackingArea().

Instrumenting calls to {add,remove}TrackingRect showed unbalanced allocation caused by -[PTYTextView refresh] being called on tabs after they were removed from view.
This "phantom refresh tracking rect" was then dropped/forgotten when the tab came back into view during viewDidMoveToWindow, which did not verify there was not already a tracking rect.
While there may actually be a more underlying bug with "phantom refresh", this patch should solve the resource/speed leak by guaranteeing we never allocate an extra tracking rect.
