### PR TITLE
Shell escape path as well when passing to external scripts

### DIFF
--- a/Trouter.m
+++ b/Trouter.m
@@ -203,7 +203,7 @@
     if ([[prefs_ objectForKey:kTrouterActionKey] isEqualToString:kTrouterRawCommandAction]) {
         NSString *script = [prefs_ objectForKey:kTrouterTextKey];
         script = [script stringByReplacingBackreference:1
-                                             withString:path ? path : @""];
+                                             withString:path ? [path stringWithEscapedShellCharacters] : @""];
             script = [script stringByReplacingBackreference:2
                                                  withString:lineNumber ? lineNumber : @""];
         script = [script stringByReplacingBackreference:3
@@ -223,7 +223,7 @@
 
     if ([[prefs_ objectForKey:kTrouterActionKey] isEqualToString:kTrouterCommandAction]) {
         NSString *script = [prefs_ objectForKey:kTrouterTextKey];
-        script = [script stringByReplacingBackreference:1 withString:path ? path : @""];
+        script = [script stringByReplacingBackreference:1 withString:path ? [path stringWithEscapedShellCharacters] : @""];
         script = [script stringByReplacingBackreference:2 withString:lineNumber ? lineNumber : @""];
         script = [script stringByReplacingBackreference:3 withString:[prefix stringWithEscapedShellCharacters]];
         script = [script stringByReplacingBackreference:4 withString:[suffix stringWithEscapedShellCharacters]];


### PR DESCRIPTION
I noticed that the path wasn't being escaped properly so any shell script trying to get the arguments would get something like this:

"/Users/chendo/Library/Application Support", "/Users/chendo/Library/Application", "Support/Screen", "Sharing"

Pull request contains a simple fix of shell escaping the path.
