### PR TITLE
Use the correct case for PTYSession.h

### DIFF
--- a/CoprocessTrigger.m
+++ b/CoprocessTrigger.m
@@ -7,7 +7,7 @@
 //
 
 #import "CoprocessTrigger.h"
-#import "PTYsession.h"
+#import "PTYSession.h"
 
 @implementation CoprocessTrigger
 


### PR DESCRIPTION
Otherwise iTerm2 does not build on a case-sensitive filesystem.
