### PR TITLE
Force new splits into their own new window when Option key pressed

### DIFF
--- a/ProfilesWindow.m
+++ b/ProfilesWindow.m
@@ -115,7 +115,14 @@ typedef enum {
 
 - (IBAction)openBookmarkInVerticalPane:(id)sender
 {
-    BOOL windowExists = [[iTermController sharedInstance] currentTerminal] != nil;
+    BOOL windowExists;
+    if (([[NSApp currentEvent] modifierFlags] & NSAlternateKeyMask) != 0) {
+        // Force open in new window when Option key pressed
+        windowExists = false;
+    }
+    else {
+        windowExists = [[iTermController sharedInstance] currentTerminal] != nil;
+    }
     [self _openBookmarkInTab:YES firstInWindow:!windowExists inPane:VERTICAL_PANE];
     if ([closeAfterOpeningBookmark_ state] == NSOnState) {
         [[self window] close];
@@ -124,7 +131,14 @@ typedef enum {
 
 - (IBAction)openBookmarkInHorizontalPane:(id)sender
 {
-    BOOL windowExists = [[iTermController sharedInstance] currentTerminal] != nil;
+    BOOL windowExists;
+    if (([[NSApp currentEvent] modifierFlags] & NSAlternateKeyMask) != 0) {
+        // Force open in new window when Option key pressed
+        windowExists = false;
+    }
+    else {
+        windowExists = [[iTermController sharedInstance] currentTerminal] != nil;
+    }
     [self _openBookmarkInTab:YES firstInWindow:!windowExists inPane:HORIZONTAL_PANE];
     if ([closeAfterOpeningBookmark_ state] == NSOnState) {
         [[self window] close];


### PR DESCRIPTION
From the profiles window, holding down the option key when pressing either split button will force new sessions into their own new window instead of putting them into the current front window.

There is no visual indication that holding down the option key does this however.
