### PR TITLE
Use lineHeight instead of the character height as the cursor height.

### DIFF
--- a/PTYTextView.m
+++ b/PTYTextView.m
@@ -6758,13 +6758,7 @@ static double EuclideanDistance(NSPoint p1, NSPoint p2) {
 
 - (double)cursorHeight
 {
-    double cursorHeight;
-    if (lineHeight < charHeightWithoutSpacing) {
-        cursorHeight = lineHeight;
-    } else {
-        cursorHeight = charHeightWithoutSpacing;
-    }
-    return cursorHeight;
+    return MAX(lineHeight, charHeightWithoutSpacing);
 }
 
 - (void)_drawCursor


### PR DESCRIPTION
This resolves a visual difference between reverse-text mode (which
reverses entire lines at full height) and the block/bar cursors when
there's line spacing on the main terminal font.

(This is just a logic inversion, as I could not locate a reason for using the character height - it only appears to cause visual aberrations.)
