### PR TITLE
prevent DoS with SU/SD's large parameter

### DIFF
--- a/VT100Screen.m
+++ b/VT100Screen.m
@@ -58,6 +58,7 @@
 #import "TmuxStateParser.h"
 
 #define MAX_SCROLLBACK_LINES 1000000
+#define MAX_SCROLL_AT_ONCE 1024
 #define DIRTY_MAGIC 0x76  // Used to ensure we don't go off end of dirty array
 
 // Wait this long between calls to NSBeep().
@@ -1801,11 +1802,13 @@ static char* FormatCont(int c)
             [[[SESSION tab] parentWindow] windowOrderBack: nil];
         break;
     case XTERMCC_SU:
-        for (i=0; i<token.u.csi.p[0]; i++) [self scrollUp];
+        for (i=0; i<MIN(MAX_SCROLL_AT_ONCE, token.u.csi.p[0]); i++)
+            [self scrollUp];
         [SESSION clearTriggerLine];
         break;
     case XTERMCC_SD:
-        for (i=0; i<token.u.csi.p[0]; i++) [self scrollDown];
+        for (i=0; i<MIN(MAX_SCROLL_AT_ONCE, token.u.csi.p[0]); i++)
+            [self scrollDown];
         [SESSION clearTriggerLine];
         break;
     case XTERMCC_REPORT_WIN_STATE:


### PR DESCRIPTION
Hi, this is a Quick Fix for preventing DoS (for master branch).

iTerm2 hangs with following escape sequences.

echo -en "\e[2147483647S" // SU
echo -en "\e[2147483647T" // SD

Some similar issues were found:

vte - https://bugzilla.gnome.org/show_bug.cgi?id=676090
mintty - http://code.google.com/p/mintty/issues/detail?id=306
mosh - https://github.com/keithw/mosh/issues/271

Expediently, this patch restricts SU/SD's parameter to 1024.
