### PR TITLE
prevent OSC parser with entering infinite loop

### DIFF
--- a/VT100Terminal.m
+++ b/VT100Terminal.m
@@ -824,7 +824,7 @@ static VT100TCC decode_xterm(unsigned char *datap,
         if (*datap == 7) {
             str_end = YES;
         }
-        if (!str_end && datalen == 0) {
+        if (!str_end && datalen == 0 && !unrecognized) {
             // Ran out of data before terminator. Keep trying.
             *rmlen = 0;
         } else {


### PR DESCRIPTION
Hello.

With this change(https://github.com/gnachman/iTerm2/commit/b2794f890536e03f72cd954dfbffe5b0876dbe1f#L0L843), 
unrecognized OSC terminated with ^G (ex. echo -en "\033]abc\007") come to be correctly skipped.

But other hand, following commands will cause infinite loop.

echo -en "\033]\033\\"; sleep 1
echo -en "\033]abc\033\\"; sleep 1
