### PR TITLE
Warnings when launching new iTerm session via AppleScript

### DIFF
--- a/iTerm.scriptSuite
+++ b/iTerm.scriptSuite
@@ -273,6 +273,8 @@
 			</dict>
 			<key>CommandClass</key>
 			<string>NSScriptCommand</string>
+			<key>ResultAppleEventCode</key>
+			<string>Pssn</string>
             <key>Type</key>
             <string>PTYSession</string>
 		</dict>


### PR DESCRIPTION
I believe this fixes this issue: 

http://code.google.com/p/iterm2/issues/detail?id=2232&start=500

Fixes these console warnings:

scriptSuite warning for result type of command 'launch' in suite
'iTerm': the type PTYSession ('Pssn') doesn't match the result Apple
event code ('').

Cocoa scripting error for '(null)': four character codes must be four
characters long.

(However, I've only tested on 10.8.2) 
