### PR TITLE
Fix redraw-bug in split-panes on Retina displays.

### DIFF
--- a/PTYTextView.m
+++ b/PTYTextView.m
@@ -1472,7 +1472,7 @@ NSMutableArray* screens=0;
 
     double excess = [self excess];
 
-    if ((int)(height + excess + imeOffset * lineHeight) != frame.size.height) {
+    if ((int)(height + excess + imeOffset * lineHeight) != (int)frame.size.height) {
         // The old iTerm code had a comment about a hack at this location
         // that worked around an (alleged) bug in NSClipView not respecting
         // setCopiesOnScroll:YES and a gross workaround. The workaround caused


### PR DESCRIPTION
The check for resized frame sometimes failed when a horisontal split
-pane is in use, since it might have non-integer height due to
fractional pixels - possibly only in scaled resolutions.

In my case, this resulted in only the bottom three lines being scrolled,
while the rest of the pane remained static.
