### PR TITLE
Fix Issue 2245: iterm2+GNU screen+vim+long wrapped lines = massive corruption

### DIFF
--- a/VT100Terminal.m
+++ b/VT100Terminal.m
@@ -2785,7 +2785,7 @@ static VT100TCC decode_string(unsigned char *datap,
             [self saveCursorAttributes];
             break;
         case VT100CSI_DECSTR:
-            WRAPAROUND_MODE = NO;
+            WRAPAROUND_MODE = YES;
             ORIGIN_MODE = NO;
             break;
     }


### PR DESCRIPTION
As discussed in http://code.google.com/p/iterm2/issues/detail?id=2245
