### PR TITLE
Improve DECSTR behavior

### DIFF
--- a/VT100Screen.m
+++ b/VT100Screen.m
@@ -2029,6 +2029,7 @@ static BOOL XYIsBeforeXY(int px1, int py1, int px2, int py2) {
     case VT100CSI_DECSTR: {
         // VT100CSI_DECSC
         // See note in xterm-terminfo.txt (search for DECSTR).
+        [self showCursor: YES];
 
         // save cursor (fixes origin-mode side-effect)
         [self saveCursorPosition];

--- a/VT100Terminal.m
+++ b/VT100Terminal.m
@@ -3461,6 +3461,9 @@ static VT100TCC decode_string(unsigned char *datap,
         case VT100CSI_DECSTR:
             WRAPAROUND_MODE = YES;
             ORIGIN_MODE = NO;
+            INSERT_MODE = NO;
+            KEYPAD_MODE = NO;
+            CURSOR_MODE = NO;
             break;
     }
 }
@@ -3564,7 +3567,9 @@ static VT100TCC decode_string(unsigned char *datap,
             }
         }
     } else if (token.type == VT100CSI_DECSTR) {
+        CHARSET = 0;
         [self resetSGR];
+        [self saveCursorAttributes];
     }
 }
 


### PR DESCRIPTION
This patch Improves DECSTR(soft reset) behavior.
- Make the cursor visible.
- Reset insert mode/keypad mode/cursor mode.
- Reset character set state.
- Reset the saved attributes with sc.
