### PR TITLE
If ComplexCharToStr returns nil, set drawable = NO

### DIFF
--- a/PTYTextView.m
+++ b/PTYTextView.m
@@ -6097,7 +6097,9 @@ static double EuclideanDistance(NSPoint p1, NSPoint p2) {
             if (theLine[i].complexChar) {
                 thisChar.runType = kCharacterRunSingleCharWithCombiningMarks;
                 thisCharString = ComplexCharToStr(theLine[i].code);
-                drawable = YES;  // TODO: not all unicode is drawable
+                // TODO: not all unicode is drawable
+                // What we know is that `nil' is NOT drawable
+                drawable = (thisCharString != nil);
             } else {
                 // Non-complex char
                 thisChar.runType = kCharacterRunMultipleSimpleChars;


### PR DESCRIPTION
This does not fix the issue of not checking whether a unicode code point
is actually drawable, but it avoids the following assertion:

```
Assertion failed: (growBy > 0),
    function -[SharedCharacterRunData growAllocation:by:],
    file /Users/georgen/v2/SharedCharacterRunData.m,
    line 74.
```

This assertion fails when attaching to a previously detached tmux
session that has multiple horizontal and vertical splits with

```
tmux -C attach
```

The assertion did not fail in all cases, but often enough to make
tmux integration unusable.
