### PR TITLE
Fix off-by-one denominator in color conversion

### DIFF
--- a/PTYSession.m
+++ b/PTYSession.m
@@ -2230,13 +2230,13 @@ static NSString *kTmuxFontChanged = @"kTmuxFontChanged";
     }
     for (i = 0; i < 216; i++) {
         [self setColorTable:i+16
-                      color:[NSColor colorWithCalibratedRed:(i/36) ? ((i/36)*40+55)/256.0 : 0
-                                                      green:(i%36)/6 ? (((i%36)/6)*40+55)/256.0:0
-                                                       blue:(i%6) ?((i%6)*40+55)/256.0:0
+                      color:[NSColor colorWithCalibratedRed:(i/36) ? ((i/36)*40+55)/255.0 : 0
+                                                      green:(i%36)/6 ? (((i%36)/6)*40+55)/255.0:0
+                                                       blue:(i%6) ?((i%6)*40+55)/255.0:0
                                                       alpha:1]];
     }
     for (i = 0; i < 24; i++) {
-        [self setColorTable:i+232 color:[NSColor colorWithCalibratedWhite:(i*10+8)/256.0 alpha:1]];
+        [self setColorTable:i+232 color:[NSColor colorWithCalibratedWhite:(i*10+8)/255.0 alpha:1]];
     }
 
     // background image

--- a/VT100Terminal.m
+++ b/VT100Terminal.m
@@ -3620,7 +3620,7 @@ static VT100TCC decode_string(unsigned char *datap,
             g >= 0 && g <= 255 &&
             b >= 0 && b <= 255) {
             [[SCREEN session] setColorTable:theIndex
-                                              color:[NSColor colorWithCalibratedRed:r/256.0 green:g/256.0 blue:b/256.0 alpha:1]];
+                                              color:[NSColor colorWithCalibratedRed:r/255.0 green:g/255.0 blue:b/255.0 alpha:1]];
         }
     } else if (token.type == XTERMCC_SET_KVP) {
         // argument is of the form key=value
@@ -3725,9 +3725,9 @@ static VT100TCC decode_string(unsigned char *datap,
                 g <= 255 &&
                 b >= 0 &&
                 b <= 255) {
-                NSColor* theColor = [NSColor colorWithCalibratedRed:((double)r)/256.0
-                                                              green:((double)g)/256.0
-                                                               blue:((double)b)/256.0
+                NSColor* theColor = [NSColor colorWithCalibratedRed:((double)r)/255.0
+                                                              green:((double)g)/255.0
+                                                               blue:((double)b)/255.0
                                                               alpha:1];
                 switch (n) {
                     case 16:


### PR DESCRIPTION
Color conversion from 00-ff to [0, 1.0] shall use 255.0 as denominator.
