### PR TITLE
zip with preserved symlinks in full_release.sh

### DIFF
--- a/full_release.sh
+++ b/full_release.sh
@@ -4,7 +4,7 @@ MINORVERSION=$1
 BUGVERSION=$2
 NAME=1.$MINORVERSION.$BUGVERSION
 cd build/Deployment
-zip -r iTerm2-${NAME}.zip iTerm.app
+zip -ry iTerm2-${NAME}.zip iTerm.app
 vi ../../appcasts/full_changes.html
 LENGTH=$(ls -l iTerm2-${NAME}.zip | awk '{print $5}')
 ruby "/Users/georgen/Downloads/Sparkle 1.5b6/Extras/Signing Tools/sign_update.rb" iTerm2-${NAME}.zip $PRIVKEY > /tmp/sig.txt


### PR DESCRIPTION
This ensures that frameworks aren't turned 3x as large by duplicating
Resources, Headers and Versions/Current.

This fixes https://code.google.com/p/iterm2/issues/detail?id=2387
