### PR TITLE
Disallow column mode (DECSET/DECRST 3) by default

### DIFF
--- a/VT100Terminal.m
+++ b/VT100Terminal.m
@@ -2330,7 +2330,7 @@ static VT100TCC decode_string(unsigned char *datap,
         TRACE = NO;
 
         strictAnsiMode = NO;
-        allowColumnMode = YES;
+        allowColumnMode = NO;
         allowKeypadMode = YES;
 
         streamOffset = 0;
@@ -2487,7 +2487,7 @@ static VT100TCC decode_string(unsigned char *datap,
     TRACE = NO;
 
     strictAnsiMode = NO;
-    allowColumnMode = YES;
+    allowColumnMode = NO;
     [SCREEN reset];
 }
 


### PR DESCRIPTION
GNU Screen sends the following sequence and resets DECCOLM(set to 80 column mode) at the start up time.

> ESC [ ? 3 ; 4 l

With this sequence, current iTerm2 resizes its screen size to 80 columns, since VT100Termnal.allowColumnMode (DECSET/DECRST 40) is YES by default.
This behavior seems to be incompatible with other major PC-terminals (such as xterm). So I propose that we change the default value of allowColumnMode to NO.
