### PR TITLE
Change "Bookmark" to "Profile" in context menu

### DIFF
--- a/ProfilesWindow.m
+++ b/ProfilesWindow.m
@@ -220,7 +220,7 @@ typedef enum {
 
     int count = [[profileTable selectedGuids] count];
     if (count == 1) {
-        [menu addItemWithTitle:@"Edit Bookmark..."
+        [menu addItemWithTitle:@"Edit Profile..."
                         action:@selector(editSelectedBookmark:)
                  keyEquivalent:@""];
         [menu addItemWithTitle:@"Open in New Tab"


### PR DESCRIPTION
Right clicking a profile in the "Profiles" dialog offers the option to "Edit Bookmark..." which is outdated and confusing terminology. Just a string change.
