### PR TITLE
Fix issue 2479

### DIFF
--- a/VT100Terminal.m
+++ b/VT100Terminal.m
@@ -366,12 +366,6 @@ static int getCSIParam(unsigned char *datap,
                 param->count++;
             // reset the parameter flag
             readNumericParameter = NO;
-
-            if (param->count >= VT100CSIPARAM_MAX) {
-                // broken
-                param->cmd = 0xff;
-                unrecognized = YES;
-            }
         }
         else if (isalpha(*datap)||*datap=='@') {
             datalen--;


### PR DESCRIPTION
http://code.google.com/p/iterm2/issues/detail?id=2479

Now normal parser cancels parsing process when parameter length goes over VT100CSIPARAM_MAX.
Canonical parser parses it completely, but ignores it.

I think there are no reason to cancel or ignore long parameter CSI sequence.

tests/iso6429csi.py (missing now) includes some tests for long parameter CSI sequence. use it if you need.
