### PR TITLE
Fix CPR behavior

### DIFF
--- a/VT100Screen.m
+++ b/VT100Screen.m
@@ -3985,19 +3985,9 @@ void DumpBuf(screen_char_t* p, int n) {
             break;
 
         case 6: // Command from host -- Please report active position
-        {
-            int x, y;
-
-            if ([TERMINAL originMode]) {
-                x = cursorX + 1;
-                y = cursorY - SCROLL_TOP + 1;
-            }
-            else {
-                x = cursorX + 1;
-                y = cursorY + 1;
-            }
-            report = [TERMINAL reportActivePositionWithX:x Y:y withQuestion:question];
-        }
+            report = [TERMINAL reportActivePositionWithX:cursorX + 1
+                                                       Y:cursorY + 1
+                                            withQuestion:question];
             break;
 
         case 0: // Response from VT100 -- Ready, No malfuctions detected


### PR DESCRIPTION
This patch fixes the following behavior.
- CPR report should not respect origin mode

```
$ echo -e "\033c\033[?6h\033[5;10r\033[2;2H\033[6n" && cat
^[[2;2R
```

It should be "^[[6;2R"
I think it was influenced by Terminal.app's curious behavior.
I have already sent the bug report to Apple for this issue.
