### PR TITLE
set $ITERM2_COPROCESS env var inside coprocesses

### DIFF
--- a/Coprocess.h
+++ b/Coprocess.h
@@ -26,7 +26,8 @@
 @property (nonatomic, assign) BOOL eof;
 @property (nonatomic, assign) BOOL mute;
 
-+ (Coprocess *)launchedCoprocessWithCommand:(NSString *)command;
++ (Coprocess *)launchedCoprocessWithCommand:(NSString *)command
+                                        tty:(NSString *)tty;
 
 // This has the side-effect of making the file descriptors non-blocking so
 // it should only be called after exec.

--- a/Coprocess.m
+++ b/Coprocess.m
@@ -52,6 +52,7 @@ static NSString *kCoprocessMruKey = @"Coprocess MRU";
 }
 
 + (Coprocess *)launchedCoprocessWithCommand:(NSString *)command
+                                        tty:(NSString *)tty
 {
         [Coprocess addCommandToMostRecentlyUsed:command];
     int inputPipe[2];
@@ -77,6 +78,7 @@ static NSString *kCoprocessMruKey = @"Coprocess MRU";
             }
         }
 
+        setenv("ITERM2_COPROCESS_TTY", [tty UTF8String], 1);
         signal(SIGCHLD, SIG_DFL);
         execl("/bin/sh", "/bin/sh", "-c", [command UTF8String], 0);
 

--- a/PTYSession.m
+++ b/PTYSession.m
@@ -3232,7 +3232,7 @@ static long long timeInTenthsOfSeconds(struct timeval t)
 
 - (void)launchCoprocessWithCommand:(NSString *)command mute:(BOOL)mute
 {
-    Coprocess *coprocess = [Coprocess launchedCoprocessWithCommand:command];
+    Coprocess *coprocess = [Coprocess launchedCoprocessWithCommand:command tty:[_shell tty]];
     coprocess.mute = mute;
     [_shell setCoprocess:coprocess];
     [_textview setNeedsDisplay:YES];


### PR DESCRIPTION
It might be nice for coprocesses to be able to detect that they are being run in that environment.
This patch sets an environment variable `$ITERM2_COPROCESS`.
The value might as well hold something useful: `ttyname()` from the originating interactive terminal.
