### PR TITLE
Fix DECALN behavior

### DIFF
--- a/VT100Screen.m
+++ b/VT100Screen.m
@@ -2077,6 +2077,12 @@ static BOOL XYIsBeforeXY(int px1, int py1, int px2, int py2) {
             }
             aLine[WIDTH].code = EOL_HARD;
         }
+        // reset scroll region
+        SCROLL_TOP = 0;
+        SCROLL_BOTTOM = HEIGHT - 1;
+        // set cursor to (1, 1)
+        [self setCursorX:0 Y:0];
+
         DebugLog(@"putToken DECALN");
         [self setDirty];
         break;


### PR DESCRIPTION
This patch is small improvement for DECALN behavior.

http://www.vt100.net/docs/vt510-rm/DECALN

> DECALN sets the margins to the extremes of the page, and moves the cursor to the home position.

This fix is not so important but it will conflict with current my another working branch.
So I decide to send this patch at first.
