### PR TITLE
Changed pasting of files to be joined by a space rather than new line.

### DIFF
--- a/PTYSession.m
+++ b/PTYSession.m
@@ -1977,7 +1977,7 @@ static NSString *kTmuxFontChanged = @"kTmuxFontChanged";
             [escapedFilenames addObject:[filename stringWithEscapedShellCharacters]];
         }
         if (escapedFilenames.count > 0) {
-            info = [escapedFilenames componentsJoinedByString:@"\n"];
+            info = [escapedFilenames componentsJoinedByString:@" "];
         }
         if ([info length] == 0) {
             info = nil;


### PR DESCRIPTION
The functionality of Mac OS X's default terminal is to paste files joined by a space. This is for a very good reason.

Main uses include:
1. Pasting multiple files as arguments to rm to remove each file.
2. Pasting multiple files as arguments to other commands.

The only thing I can think of it being useful to paste with new lines are...
1. If you have a bunch of scripts which you want to run, you copy them and paste.

There is an easy workaround for this though. You can open a text editor, paste the files in there, copy and paste back into iTerm.
