### PR TITLE
Move the cursor to the home position when DECOM is set or reset

### DIFF
--- a/VT100Terminal.m
+++ b/VT100Terminal.m
@@ -3303,7 +3303,10 @@ static VT100TCC decode_string(unsigned char *datap,
                 case 3:  COLUMN_MODE = mode; break;
                 case 4:  SCROLL_MODE = mode; break;
                 case 5:  SCREEN_MODE = mode; [SCREEN setDirty]; break;
-                case 6:  ORIGIN_MODE = mode; break;
+                case 6:
+                    ORIGIN_MODE = mode;
+                    [SCREEN cursorToX:1 Y:1];
+                    break;
                 case 7:  WRAPAROUND_MODE = mode; break;
                 case 8:  AUTOREPEAT_MODE = mode; break;
                 case 9:  INTERLACE_MODE  = mode; break;


### PR DESCRIPTION
This patch is a small fix for origin mode.

The cursor should be moved to the home position when origin mode is set or reset.

This behavior is described in the section of DECOM at VT100 User Guide(http://www.vt100.net/docs/vt100-ug/chapter3.html).

> The cursor is moved to the new home position when this mode is set or reset.
