### PR TITLE
Clear broken double-width characters on ICH/ECH/DCH

### DIFF
--- a/VT100Screen.m
+++ b/VT100Screen.m
@@ -2154,6 +2154,9 @@ static BOOL XYIsBeforeXY(int px1, int py1, int px2, int py2) {
             int endOffset = 0;
 
             j = token.u.csi.p[0];
+            if (j <= 0) {
+                break;
+            }
             aLine = [self getLineAtScreenIndex:cursorY];
             if (cursorX > 0 && aLine[cursorX].code == DWC_RIGHT) {
                 aLine[cursorX - 1].code = 0;


### PR DESCRIPTION
This patch clears broken double-width characters teared up by ICH/ECH/DCH.
- DCH

```
$ echo -en "\u3042\x1b[G\x1b[Pabc"
```

Current behavior:
![2013-08-16 2 02 03](https://f.cloud.github.com/assets/1162739/969896/7808f0f0-05cc-11e3-8c7d-caf4ca55b988.png)

I think this should be as below:
![2013-08-16 2 02 58](https://f.cloud.github.com/assets/1162739/969904/9986bfe6-05cc-11e3-9cc4-74c00bcf5af9.png)

```
$ echo -en "\u3042\x1b[2G\x1b[Pabc"
```

Current behavior:
![2013-08-16 1 50 36](https://f.cloud.github.com/assets/1162739/969799/e9324404-05ca-11e3-9b01-1976dc449e34.png)

I think this should be as below:
![2013-08-16 1 52 09](https://f.cloud.github.com/assets/1162739/969821/19e7d960-05cb-11e3-8a25-982103e1b9bb.png)
- ECH

```
$ echo -en "\u3042\x1b[2G\x1b[Xabc"
```

Current behavior:
![2013-08-16 1 58 56](https://f.cloud.github.com/assets/1162739/969875/1de91532-05cc-11e3-8166-5b3353d393cf.png)

I think this should be as below:
![2013-08-16 2 00 30](https://f.cloud.github.com/assets/1162739/969887/57981c56-05cc-11e3-9990-543189fed92d.png)
- ICH

```
$ echo -en "\u3042\x1b[2G\x1b[@abc"
```

Current behavior:
![2013-08-16 2 04 57](https://f.cloud.github.com/assets/1162739/969915/dc8d32e8-05cc-11e3-8b48-7629037d3caf.png)

I think this should be as below:
![2013-08-16 2 06 19](https://f.cloud.github.com/assets/1162739/969927/0eb94a9a-05cd-11e3-95e4-d107dab1b2a1.png)
