### PR TITLE
Add "clear" command to iTerm's AppleScript dictionary.

### DIFF
--- a/English.lproj/iTerm.scriptTerminology
+++ b/English.lproj/iTerm.scriptTerminology
@@ -240,6 +240,13 @@
 			<key>Name</key>
 			<string>terminate</string>
 		</dict>
+    <key>clear</key>
+    <dict>
+      <key>Description</key>
+      <string>Clears a session; same as Cmd+K in a session.</string>
+      <key>Name</key>
+      <string>clear</string>
+    </dict>
 		<key>write</key>
 		<dict>
 			<key>Arguments</key>

--- a/PTYSession.h
+++ b/PTYSession.h
@@ -588,6 +588,7 @@ typedef enum {
 -(void)handleTerminateScriptCommand: (NSScriptCommand *)command;
 -(void)handleSelectScriptCommand: (NSScriptCommand *)command;
 -(void)handleWriteScriptCommand: (NSScriptCommand *)command;
+-(void)handleClearScriptCommand: (NSScriptCommand *)command;
 
 @end
 

--- a/PTYSession.m
+++ b/PTYSession.m
@@ -4353,6 +4353,11 @@ static long long timeInTenthsOfSeconds(struct timeval t)
     [[[[self tab] parentWindow] tabView] selectTabViewItemWithIdentifier:[self tab]];
 }
 
+-(void)handleClearScriptCommand:(NSScriptCommand *)command
+{
+    [self clearBuffer];
+}
+
 -(void)handleWriteScriptCommand:(NSScriptCommand *)command
 {
     // Get the command's arguments:

--- a/iTerm.scriptSuite
+++ b/iTerm.scriptSuite
@@ -104,6 +104,8 @@
 				<string>handleTerminateScriptCommand:</string>
 				<key>write</key>
 				<string>handleWriteScriptCommand:</string>
+				<key>clear</key>
+				<string>handleClearScriptCommand:</string>
 			</dict>
 			<key>ToOneRelationships</key>
 			<dict>
@@ -293,6 +295,15 @@
 			<string>ITRM</string>
 			<key>AppleEventCode</key>
 			<string>Strm</string>
+			<key>CommandClass</key>
+			<string>NSScriptCommand</string>
+		</dict>
+		<key>clear</key>
+		<dict>
+			<key>AppleEventClassCode</key>
+			<string>ITRM</string>
+			<key>AppleEventCode</key>
+			<string>Sclr</string>
 			<key>CommandClass</key>
 			<string>NSScriptCommand</string>
 		</dict>


### PR DESCRIPTION
Now, a script can ask a session to clear its buffer before writing a command.

This helps in the follow scenario:
An iTerm session is holding an ssh session to a remote server. By injecting commands,
a script can very quickly execute commands on the remote server (without wasting time
on opening a connection).
If that command is a build command, it is desirable for the session to only contain the results
of the last invocation. 
In addition, this simplifies polling iTerm for when the command is finished: the reduced buffer size
makes this much faster and less CPU-cycle consuming.

In short, this will bring happiness to the world and we should definitely have this feature in iTerm :)
