### PR TITLE
Fix off-by-one issue of CPR on the right edge of terminal

### DIFF
--- a/VT100Screen.m
+++ b/VT100Screen.m
@@ -2803,7 +2803,7 @@ static const double kInterBellQuietPeriod = 0.1;
 }
 
 - (int)terminalCursorX {
-    return [self cursorX];
+    return MIN([self cursorX], [self width]);
 }
 
 - (int)terminalCursorY {

--- a/VT100Terminal.m
+++ b/VT100Terminal.m
@@ -4090,8 +4090,8 @@ static VT100TCC decode_string(unsigned char *datap,
 
             case 6: // Command from host -- Please report active position
                 if ([self originMode]) {
-                    // This is compatible with Terminal but not xterm :(. xterm seems to always do what
-                    // we do in the else clause.
+                    // This is compatible with Terminal but not old xterm :(. it always did what
+                    // we do in the else clause. This behavior of xterm is fixed by Patch #297.
                     [delegate_ terminalSendReport:[self reportActivePositionWithX:[delegate_ terminalRelativeCursorX]
                                                                                 Y:[delegate_ terminalRelativeCursorY]
                                                                      withQuestion:withQuestion]];


### PR DESCRIPTION
resize(1) command (distributed with xterm) sometimes move cursor to (999, 999) and get CPR response for retrieve current dimensions of terminal text area.
On xterm, this command behaves as follows:

```
% resize -s 24 80
COLUMNS=80;
LINES=24;
export COLUMNS LINES;

% resize
COLUMNS=80;
LINES=24;
export COLUMNS LINES;
```

But on current iTerm2, this shows as follows:

```
% resize -s 24 80
COLUMNS=80;
LINES=24;
export COLUMNS LINES;

% resize
COLUMNS=81;
LINES=24;
export COLUMNS LINES;
```

For one more example:

```
% printf "\033[8;24;80t\033[999;999H\033[6n";cat
```

The report for above sequence in iTerm2 is

```
^[[24;81R
```

but it should be:

```
^[[24;80R
```

This patch will fix above problem.
