### PR TITLE
hidden setting for traditional visual bell

### DIFF
--- a/PTYTextView.m
+++ b/PTYTextView.m
@@ -2229,7 +2229,14 @@ NSMutableArray* screens=0;
         NSImage* image = nil;
         switch (flashImage_) {
             case FlashBell:
-                image = bellImage;
+                if ([[PreferencePanel sharedInstance] traditionalVisualBell]) {
+                    image = [[[NSImage alloc] initWithSize: frame.size] autorelease];
+                    [image lockFocus];
+                    [defaultFGColor drawSwatchInRect:NSMakeRect(0, 0, frame.size.width, frame.size.width)];
+                    [image unlockFocus];
+                } else {
+                    image = bellImage;
+                }
                 break;
 
             case FlashWrapToTop:
@@ -6625,7 +6632,11 @@ static double EuclideanDistance(NSPoint p1, NSPoint p2) {
                                         repeats:NO];
     }
     // Turn the image to opaque and ask to redraw the screen.
-    flashing_ = 1;
+    if ([[PreferencePanel sharedInstance] traditionalVisualBell]) {
+        flashing_ = 0.33;
+    } else {
+        flashing_ = 1;
+    }
     [self setNeedsDisplay:YES];
 }
 

--- a/PreferencePanel.h
+++ b/PreferencePanel.h
@@ -705,6 +705,7 @@ typedef enum {
 - (int)minTabWidth;
 - (int)minCompactTabWidth;
 - (int)optimumTabWidth;
+- (BOOL)traditionalVisualBell;
 - (float)hotkeyTermAnimationDuration;
 - (NSString *)searchCommand;
 - (Profile *)handlerBookmarkForURL:(NSString *)url;

--- a/PreferencePanel.m
+++ b/PreferencePanel.m
@@ -3402,10 +3402,11 @@ static NSString * const kRebuildColorPresetsMenuNotification = @"kRebuildColorPr
 
 // The following are preferences with no UI, but accessible via "defaults read/write"
 // examples:
-//  defaults write net.sourceforge.iTerm UseUnevenTabs -bool true
-//  defaults write net.sourceforge.iTerm MinTabWidth -int 100
-//  defaults write net.sourceforge.iTerm MinCompactTabWidth -int 120
-//  defaults write net.sourceforge.iTerm OptimumTabWidth -int 100
+//  defaults write com.googlecode.iterm2 UseUnevenTabs -bool true
+//  defaults write com.googlecode.iterm2 MinTabWidth -int 100
+//  defaults write com.googlecode.iterm2 MinCompactTabWidth -int 120
+//  defaults write com.googlecode.iterm2 OptimumTabWidth -int 100
+//  defaults write com.googlecode.iterm2 TraditionalVisualBell -bool true
 
 - (BOOL)useUnevenTabs
 {
@@ -3429,6 +3430,12 @@ static NSString * const kRebuildColorPresetsMenuNotification = @"kRebuildColorPr
 {
     assert(prefs);
     return [prefs objectForKey:@"OptimumTabWidth"] ? [[prefs objectForKey:@"OptimumTabWidth"] intValue] : 175;
+}
+
+- (BOOL) traditionalVisualBell
+{
+    assert(prefs);
+    return [prefs objectForKey:@"TraditionalVisualBell"] ? [[prefs objectForKey:@"TraditionalVisualBell"] boolValue] : NO;
 }
 
 - (float) hotkeyTermAnimationDuration


### PR DESCRIPTION
I implemented a hidden setting for using a traditional visual bell (i.e. flash the whole screen) instead of showing the picture with a bell:

``` bash
defaults write com.googlecode.iterm2 TraditionalVisualBell -bool true
```

This only has an impact if "Flash visual bell" is enabled in the preference pane. I haven't written much in Objective-C before, so please let me know if I did something wrong.

Related: https://code.google.com/p/iterm2/issues/detail?id=1919
