### PR TITLE
Reset terminal modes with RIS

### DIFF
--- a/VT100Terminal.m
+++ b/VT100Terminal.m
@@ -4009,7 +4009,7 @@ static VT100TCC decode_string(unsigned char *datap,
             break;
 
         case ANSI_RIS:
-            [delegate_ terminalResetPreservingPrompt:NO];
+            [self resetPreservingPrompt:NO];
             break;
         case VT100CSI_RM:
             break;


### PR DESCRIPTION
"\033c"(RIS - hard reset) is expected to reset the terminal to "power-on state".
But in current HEAD of master, the following example is not work well.

```
    $ printf "\033[?1003h\033[?7l"
    $ reset
```

With above command, the mouse mode should be "off" and the auto-wrap mode should be "on".
