### PR TITLE
titleless window via window pref

### DIFF
--- a/English.lproj/PreferencePanel.xib
+++ b/English.lproj/PreferencePanel.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="4514" systemVersion="13A2093" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="4514" systemVersion="13B42" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
-        <deployment version="1070" defaultVersion="1070" identifier="macosx"/>
+        <deployment version="1070" defaultVersion="1090" identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="4514"/>
     </dependencies>
     <objects>
@@ -147,6 +147,7 @@
                 <outlet property="hideMenuBarInFullscreen" destination="awA-hH-ziY" id="zyE-TX-Uzo"/>
                 <outlet property="hideScrollbar" destination="4561" id="4613"/>
                 <outlet property="hideTab" destination="4462" id="4614"/>
+                <outlet property="hideTitleBar" destination="W86-Co-PMj" id="lN3-B8-zHU"/>
                 <outlet property="highlightTabLabels" destination="4467" id="4615"/>
                 <outlet property="hotkey" destination="5104" id="5121"/>
                 <outlet property="hotkeyAutoHides" destination="rG7-dO-Nxw" id="JTl-kM-C6D"/>
@@ -1301,6 +1302,18 @@ Gw
                                             <connections>
                                                 <action selector="settingChanged:" target="-2" id="5755"/>
                                                 <outlet property="nextKeyView" destination="4560" id="5756"/>
+                                            </connections>
+                                        </button>
+                                        <button id="W86-Co-PMj">
+                                            <rect key="frame" x="456" y="42" width="390" height="18"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <buttonCell key="cell" type="check" title="Hide Title Bar" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="szQ-1i-XZq">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                            </buttonCell>
+                                            <connections>
+                                                <action selector="settingChanged:" target="-2" id="PIp-Oh-ZPC"/>
+                                                <outlet property="nextKeyView" destination="4560" id="RRa-cX-joe"/>
                                             </connections>
                                         </button>
                                         <button id="5144">
@@ -3374,11 +3387,11 @@ Gw
                                                                 <rect key="frame" x="17" y="130" width="525" height="246"/>
                                                                 <autoresizingMask key="autoresizingMask"/>
                                                                 <clipView key="contentView" id="Flq-2t-wqn">
-                                                                    <rect key="frame" x="1" y="17" width="507" height="228"/>
+                                                                    <rect key="frame" x="1" y="17" width="508" height="228"/>
                                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                     <subviews>
                                                                         <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" multipleSelection="NO" autosaveName="KeyBingingTable" headerView="2460" id="2463">
-                                                                            <rect key="frame" x="0.0" y="0.0" width="507" height="228"/>
+                                                                            <rect key="frame" x="0.0" y="0.0" width="508" height="228"/>
                                                                             <autoresizingMask key="autoresizingMask"/>
                                                                             <size key="intercellSpacing" width="3" height="2"/>
                                                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -3398,7 +3411,7 @@ Gw
                                                                                     </textFieldCell>
                                                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                                                 </tableColumn>
-                                                                                <tableColumn identifier="1" editable="NO" width="303.101" minWidth="42.10107" maxWidth="1000" id="2465">
+                                                                                <tableColumn identifier="1" editable="NO" width="304.101" minWidth="42.10107" maxWidth="1000" id="2465">
                                                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Action">
                                                                                         <font key="font" metaFont="smallSystem"/>
                                                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
@@ -3425,7 +3438,7 @@ Gw
                                                                     <autoresizingMask key="autoresizingMask"/>
                                                                 </scroller>
                                                                 <scroller key="verticalScroller" verticalHuggingPriority="750" horizontal="NO" id="2462">
-                                                                    <rect key="frame" x="508" y="17" width="16" height="228"/>
+                                                                    <rect key="frame" x="509" y="17" width="15" height="228"/>
                                                                     <autoresizingMask key="autoresizingMask"/>
                                                                 </scroller>
                                                                 <tableHeaderView key="headerView" id="2460">
@@ -4098,11 +4111,11 @@ Gw
                                             <rect key="frame" x="363" y="30" width="508" height="379"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <clipView key="contentView" id="Dzn-LP-RyA">
-                                                <rect key="frame" x="1" y="17" width="506" height="361"/>
+                                                <rect key="frame" x="1" y="17" width="491" height="361"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" multipleSelection="NO" autosaveName="KeyBingingTable" headerView="3855" id="3852">
-                                                        <rect key="frame" x="0.0" y="0.0" width="506" height="361"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="491" height="361"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                         <size key="intercellSpacing" width="3" height="2"/>
                                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -4122,7 +4135,7 @@ Gw
                                                                 </textFieldCell>
                                                                 <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                             </tableColumn>
-                                                            <tableColumn identifier="1" editable="NO" width="302.101" minWidth="42.10107" maxWidth="1000" id="3856">
+                                                            <tableColumn identifier="1" editable="NO" width="287.101" minWidth="42.10107" maxWidth="1000" id="3856">
                                                                 <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Action">
                                                                     <font key="font" metaFont="smallSystem"/>
                                                                     <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
@@ -4149,7 +4162,7 @@ Gw
                                                 <autoresizingMask key="autoresizingMask"/>
                                             </scroller>
                                             <scroller key="verticalScroller" verticalHuggingPriority="750" horizontal="NO" id="3853">
-                                                <rect key="frame" x="491" y="17" width="16" height="361"/>
+                                                <rect key="frame" x="492" y="17" width="15" height="361"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                             </scroller>
                                             <tableHeaderView key="headerView" id="3855">
@@ -4392,7 +4405,7 @@ Gw
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="none" alternatingRowBackgroundColors="YES" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" headerView="6206" id="6091">
-                                                        <rect key="frame" x="0.0" y="0.0" width="849" height="229"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="849" height="228"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                         <size key="intercellSpacing" width="3" height="2"/>
                                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>

--- a/PreferencePanel.h
+++ b/PreferencePanel.h
@@ -195,6 +195,7 @@ typedef enum {
 - (NSTextField*)hotkeyField;
 
 - (BOOL)showWindowBorder;
+- (BOOL)hideTitleBar;
 - (BOOL)lionStyleFullscreen;
 - (BOOL)dimInactiveSplitPanes;
 - (BOOL)dimBackgroundWindows;

--- a/PreferencePanel.m
+++ b/PreferencePanel.m
@@ -226,6 +226,10 @@ static NSString * const kRebuildColorPresetsMenuNotification = @"kRebuildColorPr
     IBOutlet NSButton* showWindowBorder;
     BOOL defaultShowWindowBorder;
     
+    // Title bar
+    IBOutlet NSButton* hideTitleBar;
+    BOOL defaultHideTitleBar;
+    
     // Lion-style fullscreen
     IBOutlet NSButton* lionStyleFullscreen;
     BOOL defaultLionStyleFullscreen;
@@ -990,6 +994,7 @@ static NSString * const kRebuildColorPresetsMenuNotification = @"kRebuildColorPr
                sender == threeFingerEmulatesMiddle ||
                sender == autoHideTmuxClientSession ||
                sender == showWindowBorder ||
+               sender == hideTitleBar ||
                sender == hotkeyAutoHides) {
         defaultWindowStyle = [windowStyle indexOfSelectedItem];
         defaultOpenTmuxWindowsIn = [[openTmuxWindows selectedItem] tag];
@@ -1007,6 +1012,7 @@ static NSString * const kRebuildColorPresetsMenuNotification = @"kRebuildColorPr
         defaultDimOnlyText = ([dimOnlyText state] == NSOnState);
         defaultDimmingAmount = [dimmingAmount floatValue];
         defaultShowWindowBorder = ([showWindowBorder state] == NSOnState);
+        defaultHideTitleBar = ([hideTitleBar state] == NSOnState);
         defaultThreeFingerEmulatesMiddle=([threeFingerEmulatesMiddle state] == NSOnState);
         defaultHideScrollbar = ([hideScrollbar state] == NSOnState);
         defaultDisableFullscreenTransparency = ([disableFullscreenTransparency state] == NSOnState);
@@ -3017,6 +3023,7 @@ static NSString * const kRebuildColorPresetsMenuNotification = @"kRebuildColorPr
     defaultDimOnlyText = [prefs objectForKey:@"DimOnlyText"]?[[prefs objectForKey:@"DimOnlyText"] boolValue]: NO;
     defaultDimmingAmount = [prefs objectForKey:@"SplitPaneDimmingAmount"] ? [[prefs objectForKey:@"SplitPaneDimmingAmount"] floatValue] : 0.4;
     defaultShowWindowBorder = [[prefs objectForKey:@"UseBorder"] boolValue];
+    defaultHideTitleBar = [prefs objectForKey:@"HideTitleBar"] ? [[prefs objectForKey:@"HideTitleBar"] boolValue] : NO;
     defaultLionStyleFullscreen = [prefs objectForKey:@"UseLionStyleFullscreen"] ? [[prefs objectForKey:@"UseLionStyleFullscreen"] boolValue] : YES;
     defaultLoadPrefsFromCustomFolder = [prefs objectForKey:@"LoadPrefsFromCustomFolder"] ? [[prefs objectForKey:@"LoadPrefsFromCustomFolder"] boolValue] : NO;
     defaultPrefsCustomFolder = [prefs objectForKey:@"PrefsCustomFolder"] ? [prefs objectForKey:@"PrefsCustomFolder"] : @"";
@@ -3145,6 +3152,7 @@ static NSString * const kRebuildColorPresetsMenuNotification = @"kRebuildColorPr
     [prefs setBool:defaultDimOnlyText forKey:@"DimOnlyText"];
     [prefs setFloat:defaultDimmingAmount forKey:@"SplitPaneDimmingAmount"];
     [prefs setBool:defaultShowWindowBorder forKey:@"UseBorder"];
+    [prefs setBool:defaultHideTitleBar forKey:@"HideTitleBar"];
     [prefs setBool:defaultLionStyleFullscreen forKey:@"UseLionStyleFullscreen"];
     [prefs setBool:defaultLoadPrefsFromCustomFolder forKey:@"LoadPrefsFromCustomFolder"];
     [prefs setObject:defaultPrefsCustomFolder forKey:@"PrefsCustomFolder"];
@@ -3895,6 +3903,11 @@ static NSString * const kRebuildColorPresetsMenuNotification = @"kRebuildColorPr
     return defaultShowWindowBorder;
 }
 
+- (BOOL)hideTitleBar
+{
+    return defaultHideTitleBar;
+}
+
 - (BOOL)lionStyleFullscreen
 {
     return defaultLionStyleFullscreen;
@@ -4211,6 +4224,7 @@ static NSString * const kRebuildColorPresetsMenuNotification = @"kRebuildColorPr
     [dimOnlyText setState:defaultDimOnlyText?NSOnState:NSOffState];
     [dimmingAmount setFloatValue:defaultDimmingAmount];
     [showWindowBorder setState:defaultShowWindowBorder?NSOnState:NSOffState];
+    [hideTitleBar setState:defaultHideTitleBar?NSOnState:NSOffState];
     [lionStyleFullscreen setState:defaultLionStyleFullscreen?NSOnState:NSOffState];
     [loadPrefsFromCustomFolder setState:defaultLoadPrefsFromCustomFolder?NSOnState:NSOffState];
     [prefsCustomFolder setStringValue:defaultPrefsCustomFolder ? defaultPrefsCustomFolder : @""];

--- a/PseudoTerminal.m
+++ b/PseudoTerminal.m
@@ -600,6 +600,9 @@ NSString *kSessionsKVCKey = @"sessions";
 
     // set the style of tabs to match window style
     [self setTabBarStyle];
+    
+    // update with user-set window style
+    [self updateWindowStyle];
 
     [[[self window] contentView] setAutoresizesSubviews: YES];
     [[self window] setDelegate: self];
@@ -5089,6 +5092,9 @@ NSString *kSessionsKVCKey = @"sessions";
 
     // If tab style or position changed.
     [self repositionWidgets];
+    
+    // If window style was changed.
+    [self updateWindowStyle];
 
     // In case scrollbars came or went:
     for (PTYTab *aTab in [self tabs]) {
@@ -5541,6 +5547,24 @@ NSString *kSessionsKVCKey = @"sessions";
     PtyLog(@"repositionWidgets - update tab bar");
     [tabBarControl update];
     PtyLog(@"repositionWidgets - return.");
+}
+
+// Update the window style with user-set settings.
+- (void)updateWindowStyle
+{
+    // On normal windows, turn the title bar on or off.
+    if (windowType_ == WINDOW_TYPE_NORMAL) {
+        NSUInteger styleMask = [[self ptyWindow] styleMask];
+        if ([[PreferencePanel sharedInstance] hideTitleBar]) {
+            // Hide the title bar.
+            styleMask &= ~NSTitledWindowMask;
+        }
+        else {
+            // Show the title bar.
+            styleMask |= NSTitledWindowMask;
+        }
+        [[self ptyWindow] setStyleMask: styleMask];
+    }
 }
 
 // Returns the width of characters in pixels in the session with the widest


### PR DESCRIPTION
Simple change to allow a title-less window (set in `Preferences->Appearance`)
![screenshot 2014-02-24 22 12 59 copy](https://f.cloud.github.com/assets/868700/2255205/69715476-9df0-11e3-86cd-9ca66c03bd8b.png)

I also experimented with adding a title-less window style (`Preferences->Profile->Window->Style`), but I wasn't sure how to preserve `windowType_` in `PseudoTerminal.m`.
Commit here: https://github.com/bmwang/iTerm2/commit/374bbd05358a713ac3c13ec8f2e5831221e686da . `windowType_` will eventually be set back to `WINDOW_TYPE_NORMAL` if you go to/from fullscreen. It works in this case because `WINDOW_TYPE_NORMAL` and `WINDOW_TYPE_NORMAL_TITLELESS` are identical except for the WindowMasks that go into them when they're created, but having `windowType_` out of sync seems messy.
