### PR TITLE
Add hidden setting (AlternateMouseScroll) for arrow keys on mouse scroll

### DIFF
--- a/PTYTextView.m
+++ b/PTYTextView.m
@@ -2869,18 +2869,16 @@ NSMutableArray* screens=0;
                 break;
             case MOUSE_REPORTING_NONE:
                 if ([[PreferencePanel sharedInstance] alternateMouseScroll] &&
-                    terminal.isAlternate) {
+                    [_dataSource isAlternate]) {
                     CGFloat deltaY = [event deltaY];
+                    NSData* keyMove;
                     if (deltaY > 0) {
-                        NSData* keyMove = [terminal.output keyArrowUp:[event modifierFlags]];
-                        for (int i = (int)ceil(deltaY); i > 0; --i) {
-                            [_delegate writeTask:keyMove];
-                        }
+                        keyMove = [terminal.output keyArrowUp:[event modifierFlags]];
                     } else if (deltaY < 0) {
-                        NSData* keyMove = [terminal.output keyArrowDown:[event modifierFlags]];
-                        for (int i = (int)ceil(-deltaY); i > 0; --i) {
-                            [_delegate writeTask:keyMove];
-                        }
+                        keyMove = [terminal.output keyArrowDown:[event modifierFlags]];
+                    }
+                    for (int i = 0; i < ceil(fabs(deltaY)); i++) {
+                        [_delegate writeTask:keyMove];
                     }
                     return;
                 }

--- a/PTYTextViewDataSource.h
+++ b/PTYTextViewDataSource.h
@@ -103,6 +103,9 @@ typedef enum {
 - (SCPPath *)scpPathForFile:(NSString *)filename onLine:(int)line;
 - (VT100RemoteHost *)remoteHostOnLine:(int)line;
 
+// Check whether in alternate screen mode
+- (BOOL)isAlternate;
+
 - (void)clearBuffer;
 
 @end

--- a/PreferencePanel.m
+++ b/PreferencePanel.m
@@ -3960,7 +3960,7 @@ static NSString * const kRebuildColorPresetsMenuNotification = @"kRebuildColorPr
 - (BOOL) alternateMouseScroll
 {
     assert(prefs);
-    return [prefs objectForKey:@"AlternateMouseScroll"] ? [[prefs objectForKey:@"AlternateMouseScroll"] boolValue] : NO;
+    return [[NSUserDefaults standardUserDefaults] boolForKey:@"AlternateMouseScroll"];
 }
 
 - (float) hotkeyTermAnimationDuration

--- a/VT100Screen.m
+++ b/VT100Screen.m
@@ -74,7 +74,6 @@ static NSString *const kInlineFileBase64String = @"base64 string";  // NSMutable
                                                                          kDefaultScreenRows)
                                               delegate:self];
         currentGrid_ = primaryGrid_;
-        terminal_.isAlternate = false;
 
         maxScrollbackLines_ = kDefaultMaxScrollbackLines;
         tabStops_ = [[NSMutableSet alloc] init];
@@ -2711,14 +2710,17 @@ static NSString *const kInlineFileBase64String = @"base64 string";  // NSMutable
     currentGrid_ = altGrid_;
     currentGrid_.cursor = primaryGrid_.cursor;
 
-    terminal_.isAlternate = true;
-
     [self swapNotes];
     [self reloadMarkCache];
 
     [currentGrid_ markAllCharsDirty:YES];
     [delegate_ screenNeedsRedraw];
     commandStartX_ = commandStartY_ = -1;
+}
+
+- (BOOL)isAlternate
+{
+    return (currentGrid_ == altGrid_);
 }
 
 - (void)hideOnScreenNotesAndTruncateSpanners
@@ -2745,7 +2747,6 @@ static NSString *const kInlineFileBase64String = @"base64 string";  // NSMutable
     if (currentGrid_ == altGrid_) {
         [self hideOnScreenNotesAndTruncateSpanners];
         currentGrid_ = primaryGrid_;
-        terminal_.isAlternate = false;
         commandStartX_ = commandStartY_ = -1;
         [self swapNotes];
         [self reloadMarkCache];

--- a/VT100Terminal.h
+++ b/VT100Terminal.h
@@ -26,7 +26,6 @@
 @property(nonatomic, readonly) BOOL originMode;
 @property(nonatomic, assign) BOOL wraparoundMode;
 @property(nonatomic, readonly) BOOL isAnsi;
-@property(nonatomic, assign) BOOL isAlternate;
 @property(nonatomic, readonly) BOOL autorepeatMode;
 @property(nonatomic, assign) BOOL insertMode;
 @property(nonatomic, readonly) int charset;  // G0 through G3


### PR DESCRIPTION
The hidden defaults setting AlternateMouseScroll turns on "mouse wheel scrolling support when a terminal is in MOUSE_REPORTING_NONE mouse mode and is using an alternate screen by translating them to arrow up/down terminfo escape sequences. (ala MouseTerm)"

Activate it with

```
$ defaults write com.googlecode.iterm2 AlternateMouseScroll -bool true
```

This patch was submitted and adapted in https://code.google.com/p/iterm2/issues/detail?id=974 and then wrapped in a hidden setting by me
