### PR TITLE
Make it possible to choose the bouncing type for dock icon (once, infini...

### DIFF
--- a/BounceTrigger.h
+++ b/BounceTrigger.h
@@ -14,6 +14,7 @@
 
 - (NSString *)title;
 - (BOOL)takesParameter;
+- (BOOL)paramIsPopupButton;
 - (void)performActionWithValues:(NSArray *)values inSession:(PTYSession *)aSession;
 
 @end

--- a/BounceTrigger.m
+++ b/BounceTrigger.m
@@ -7,6 +7,10 @@
 
 #import "BounceTrigger.h"
 
+enum {
+    kBounceUntilFocus,
+    kBounceOnce,
+};
 
 @implementation BounceTrigger
 
@@ -15,14 +19,73 @@
     return @"Bounce Dock Icon";
 }
 
+- (NSString *)paramPlaceholder
+{
+    return @"";
+}
+
 - (BOOL)takesParameter
 {
-    return NO;
+    return YES;
+}
+
+- (BOOL)paramIsPopupButton
+{
+    return YES;
+}
+
+- (int)indexOfTag:(int)theTag
+{
+    int i = 0;
+    for (NSNumber *n in [self tagsSortedByValueInDict:[self menuItemsForPoupupButton]]) {
+        if ([n intValue] == theTag) {
+            return i;
+        }
+        i++;
+    }
+    return -1;
+}
+
+- (int)tagAtIndex:(int)index
+{
+    int i = 0;
+
+    for (NSNumber *n in [self tagsSortedByValueInDict:[self menuItemsForPoupupButton]]) {
+        if (i == index) {
+            return [n intValue];
+        }
+        i++;
+    }
+    return -1;
+}
+
+- (NSDictionary *)menuItemsForPoupupButton
+{
+    return [NSDictionary dictionaryWithObjectsAndKeys:
+            @"Bounce until focus", [NSNumber numberWithInt:(int)kBounceUntilFocus],
+            @"Bounce once", [NSNumber numberWithInt:(int)kBounceOnce],
+
+            nil];
+}
+
+- (NSRequestUserAttentionType)bounceType
+{
+    switch ([self.param intValue]) {
+        case kBounceUntilFocus:
+            return NSCriticalRequest;
+
+        case kBounceOnce:
+            return NSInformationalRequest;
+
+        default:
+            break;
+    }
+    return NSCriticalRequest;
 }
 
 - (void)performActionWithValues:(NSArray *)values inSession:(PTYSession *)aSession
 {
-    [NSApp requestUserAttention:NSCriticalRequest];
+    [NSApp requestUserAttention:[self bounceType]];
 }
 
 @end


### PR DESCRIPTION
Hey there, some review necessary, as it is my first Objective-C work (basically copied other code I found in the project).

This commit makes it possible to choose whether the dock icon bounces once or to infinity in the trigger. Some issues I am not sure about:
- It changes the params, so maybe there is something to do about profile configurations?
- I am not sure how the default value is choosen with that.
- Can't `NSRequestUserAttentionType` be used as values directly in the dictionary?
- Is there a test suite in the project?

Feedback much appreciated! Another patch coming after those things are figured out!
