### PR TITLE
Add alternate scroll mode (xterm)

### DIFF
--- a/PTYTextView.m
+++ b/PTYTextView.m
@@ -2827,22 +2827,25 @@ NSMutableArray* screens=0;
                 }
                 break;
             case MOUSE_REPORTING_NONE:
-                if ([[PreferencePanel sharedInstance] alternateMouseScroll] &&
-                    [_dataSource showingAlternateScreen]) {
-                    CGFloat deltaY = [event deltaY];
-                    NSData *keyMove = nil;
-                    if (deltaY > 0) {
-                        keyMove = [terminal.output keyArrowUp:[event modifierFlags]];
-                    } else if (deltaY < 0) {
-                        keyMove = [terminal.output keyArrowDown:[event modifierFlags]];
+                if ([[PreferencePanel sharedInstance] alternateMouseScroll] ||
+                    [terminal alternateScrollMode]) {
+                    if ([_dataSource showingAlternateScreen]) {
+                        CGFloat deltaY = [event deltaY];
+                        NSData *keyMove = nil;
+                        if (deltaY > 0) {
+                            keyMove = [terminal.output keyArrowUp:[event modifierFlags]];
+                        } else if (deltaY < 0) {
+                            keyMove = [terminal.output keyArrowDown:[event modifierFlags]];
+                        }
+                        if (keyMove) {
+                          for (int i = 0; i < ceil(fabs(deltaY)); i++) {
+                              [_delegate writeTask:keyMove];
+                          }
+                        }
+                        return;
                     }
-                    if (keyMove) {
-                      for (int i = 0; i < ceil(fabs(deltaY)); i++) {
-                          [_delegate writeTask:keyMove];
-                      }
-                    }
-                    return;
                 }
+                break;
             case MOUSE_REPORTING_HILITE:
                 // fall through
                 break;

--- a/VT100Terminal.h
+++ b/VT100Terminal.h
@@ -31,6 +31,7 @@
 @property(nonatomic, readonly) int charset;  // G0 through G3
 @property(nonatomic, assign) MouseMode mouseMode;
 @property(nonatomic, assign) MouseFormat mouseFormat;
+@property(nonatomic, assign) BOOL alternateScrollMode;
 
 // The current foreground/background color to display (they're swapped when reverseVideo is on).
 @property(nonatomic, readonly) screen_char_t foregroundColorCode;

--- a/VT100Terminal.m
+++ b/VT100Terminal.m
@@ -523,7 +523,8 @@ static const int kMaxScreenRows = 4096;
                         }
                         break;
 
-                    case 1007:
+                    case 1007:  // xterm style
+                    case 7786:  // mintty style
                         self.alternateScrollMode = mode;
                         break;
 

--- a/VT100Terminal.m
+++ b/VT100Terminal.m
@@ -145,6 +145,7 @@ static const int kMaxScreenRows = 4096;
         bgColorCode_ = ALTSEM_DEFAULT;
         bgColorMode_ = ColorModeAlternate;
         _mouseMode = MOUSE_REPORTING_NONE;
+        _alternateScrollMode = NO;
         _mouseFormat = MOUSE_FORMAT_XTERM;
 
         _allowKeypadMode = YES;
@@ -261,6 +262,7 @@ static const int kMaxScreenRows = 4096;
     self.keypadMode = NO;
     self.insertMode = NO;
     self.bracketedPasteMode = NO;
+    self.alternateScrollMode = NO;
     _charset = 0;
     xon_ = YES;
     bold_ = italic_ = blink_ = reversed_ = under_ = NO;
@@ -519,6 +521,10 @@ static const int kMaxScreenRows = 4096;
                         } else {
                             self.mouseFormat = MOUSE_FORMAT_XTERM;
                         }
+                        break;
+
+                    case 1007:
+                        self.alternateScrollMode = mode;
                         break;
 
                     case 1015:


### PR DESCRIPTION
Some days ago, the "alternate scroll" feature was introduced by #164.
I think this should be also implemented as a terminal mode.
This patch do it.

Additionally, we may had better to rename the hidden preference "alternateMouseScroll" to "forceAlternateMouseScroll".

_Usage_: 

To use this with vim, add the following code to your .vimrc.
(This also works on mintty, xterm, TeraTerm, RLogin, mlterm, tanasinn, ...etc)

```
  set mouse=
  let &t_ti = &t_ti . "\e[?1007;7786h"
  let &t_te = "\e[?1007;7786l" . &t_te
```

_Note_: 

This patch uses the "alternate screen mode" state as the trigger of enabling/disabling alternate scrolling feature (This behavior is compatible with XTerm).
But Tera Term dares to use "application cursor mode" (DEC specific mode 1) instead of that.
This hack has the following merits:
- On some systems(such as FreeBSD), alternate scroll is not enabled by fullscreen applications such as less/vi because the default termcap for xterm is modified and does not include ti/te. But ks/ke are always invoked.
- tmux does not sends internal state of "alternate screen mode" to outer terminals. But it sends "application cursor mode" state.
- Some people disables alternate screen feature by using custom terminfo or terminal preferences.
