### PR TITLE
Fix handling of shift+alt from Synergy

### DIFF
--- a/PTYSession.m
+++ b/PTYSession.m
@@ -4046,6 +4046,10 @@ static long long timeInTenthsOfSeconds(struct timeval t)
       DebugLog(@"Terminal already dead");
       return;
     }
+
+    BOOL rightAltPressed = (modflag & NSRightAlternateKeyMask) == NSRightAlternateKeyMask;
+    BOOL leftAltPressed = (modflag & NSAlternateKeyMask) == NSAlternateKeyMask && !rightAltPressed;
+
     // No special binding for this key combination.
     if (modflag & NSFunctionKeyMask) {
       if (debugKeyDown) {
@@ -4106,12 +4110,8 @@ static long long timeInTenthsOfSeconds(struct timeval t)
         send_str = (unsigned char *)[keydat bytes];
         send_strlen = [keydat length];
       }
-    } else if (((modflag & NSLeftAlternateKeyMask) == NSLeftAlternateKeyMask &&
-                ([self optionKey] != OPT_NORMAL)) ||
-               (modflag == NSAlternateKeyMask &&
-                ([self optionKey] != OPT_NORMAL)) ||  /// synergy
-               ((modflag & NSRightAlternateKeyMask) == NSRightAlternateKeyMask &&
-                ([self rightOptionKey] != OPT_NORMAL))) {
+    } else if ((leftAltPressed && [self optionKey] != OPT_NORMAL) ||
+               (rightAltPressed && [self rightOptionKey] != OPT_NORMAL)) {
                  if (debugKeyDown) {
                    NSLog(@"PTYSession keyDown opt + key -> modkey");
                  }
@@ -4119,10 +4119,10 @@ static long long timeInTenthsOfSeconds(struct timeval t)
                  // A key was pressed while holding down option and the option key
                  // is not behaving normally. Apply the modified behavior.
                  int mode;  // The modified behavior based on which modifier is pressed.
-                 if ((modflag == NSAlternateKeyMask) ||  // synergy
-                     (modflag & NSLeftAlternateKeyMask) == NSLeftAlternateKeyMask) {
+                 if (leftAltPressed) {
                    mode = [self optionKey];
                  } else {
+                   assert(rightAltPressed);
                    mode = [self rightOptionKey];
                  }
 

--- a/PTYTextView.m
+++ b/PTYTextView.m
@@ -2360,6 +2360,8 @@ NSMutableArray* screens=0;
     unsigned int modflag = [event modifierFlags];
     unsigned short keyCode = [event keyCode];
     BOOL prev = [self hasMarkedText];
+    BOOL rightAltPressed = (modflag & NSRightAlternateKeyMask) == NSRightAlternateKeyMask;
+    BOOL leftAltPressed = (modflag & NSAlternateKeyMask) == NSAlternateKeyMask && !rightAltPressed;
 
     keyIsARepeat = [event isARepeat];
     if (debugKeyDown) {
@@ -2369,9 +2371,8 @@ NSMutableArray* screens=0;
         NSLog(@"modFlag & (NSNumericPadKeyMask | NSFUnctionKeyMask)=%d", (modflag & (NSNumericPadKeyMask | NSFunctionKeyMask)));
         NSLog(@"charactersIgnoringModififiers length=%d", (int)[[event charactersIgnoringModifiers] length]);
         NSLog(@"delegate optionkey=%d, delegate rightOptionKey=%d", (int)[delegate optionKey], (int)[delegate rightOptionKey]);
-        NSLog(@"modflag & leftAlt == leftAlt && optionKey != NORMAL = %d", (int)((modflag & NSLeftAlternateKeyMask) == NSLeftAlternateKeyMask && [delegate optionKey] != OPT_NORMAL));
-        NSLog(@"modflag == alt && optionKey != NORMAL = %d", (int)(modflag == NSAlternateKeyMask && [delegate optionKey] != OPT_NORMAL));
-        NSLog(@"modflag & rightAlt == rightAlt && rightOptionKey != NORMAL = %d", (int)((modflag & NSRightAlternateKeyMask) == NSRightAlternateKeyMask && [delegate rightOptionKey] != OPT_NORMAL));
+        NSLog(@"leftAltPressed && optionKey != NORMAL = %d", (int)(leftAltPressed && [delegate optionKey] != OPT_NORMAL));
+        NSLog(@"rightAltPressed && rightOptionKey != NORMAL = %d", (int)(rightAltPressed && [delegate rightOptionKey] != OPT_NORMAL));
         NSLog(@"isControl=%d", (int)(modflag & NSControlKeyMask));
         NSLog(@"keycode is slash=%d, is backslash=%d", (keyCode == 0x2c), (keyCode == 0x2a));
         NSLog(@"event is repeated=%d", keyIsARepeat);
@@ -2396,9 +2397,8 @@ NSMutableArray* screens=0;
         ([delegate hasActionableKeyMappingForEvent:event] ||       // delegate will do something useful
          (modflag & (NSNumericPadKeyMask | NSFunctionKeyMask)) ||  // is an arrow key, f key, etc.
          ([[event charactersIgnoringModifiers] length] > 0 &&      // Will send Meta/Esc+ (length is 0 if it's a dedicated dead key)
-          (((modflag & NSLeftAlternateKeyMask) == NSLeftAlternateKeyMask && [delegate optionKey] != OPT_NORMAL) ||
-           (modflag == NSAlternateKeyMask && [delegate optionKey] != OPT_NORMAL) ||  // Synergy sends an Alt key that's neither left nor right!
-           ((modflag & NSRightAlternateKeyMask) == NSRightAlternateKeyMask && [delegate rightOptionKey] != OPT_NORMAL))) ||
+          ((leftAltPressed && [delegate optionKey] != OPT_NORMAL) ||
+           (rightAltPressed && [delegate rightOptionKey] != OPT_NORMAL))) ||
          ((modflag & NSControlKeyMask) &&                          // a few special cases
           (keyCode == 0x2c /* slash */ || keyCode == 0x2a /* backslash */)))) {
         if (debugKeyDown) {


### PR DESCRIPTION
Synergy doesn't send a keyDown event with its modifierFlags
having a left or right directionality set with NSAlternateKeyMask.
Before this change, we distinguished Synergy's event by using
"modifierFlags == NSAlternateKeyMask." This logic doesn't work
when the user has both the "alt" and "shift" keys held down from
Synergy.

With this change we trigger the "left" option key actions in
PTYSession/PTYTextView whenever NSAlternateKeyMask is set and no right
directionality is set on modifierFlags (instead of testing for a left
directionality). This covers both the physical "left alt" button press
and the Synergy case. The trigger for "right" option actions are left
untouched.
