### PR TITLE
Change the shortcut of reset to CMD+Shift+R

### DIFF
--- a/English.lproj/MainMenu.xib
+++ b/English.lproj/MainMenu.xib
@@ -598,7 +598,7 @@ DQ
                             <menuItem isSeparatorItem="YES" id="908">
                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                             </menuItem>
-                            <menuItem title="Reset" keyEquivalent="r" id="907">
+                            <menuItem title="Reset" keyEquivalent="R" id="907">
                                 <connections>
                                     <action selector="reset:" target="-1" id="909"/>
                                 </connections>


### PR DESCRIPTION
In web development, it is very easy for developer press CMD+R button in VIM instead of the browser windows, it will break the VIM display completely.

This fix will change the shortcut key to CMD+Shift+R
