### PR TITLE
Quick fix for multiline prompt support in Shell Integration features

### DIFF
--- a/VT100Screen.m
+++ b/VT100Screen.m
@@ -3194,13 +3194,13 @@ static NSString *const kInlineFileBase64String = @"base64 string";  // NSMutable
     _lastCommandOutputRange.end = currentGrid_.cursor;
     _lastCommandOutputRange.end.y += [self numberOfScrollbackLines];
     _lastCommandOutputRange.start = nextCommandOutputStart_;
-
-    // FinalTerm uses this to define the start of a collapsable region. That would be a nightmare
-    // to add to iTerm, and our answer to this is marks, which already existed anyway.
-    [delegate_ screenAddMarkOnLine:[self numberOfScrollbackLines] + self.cursorY - 1];
 }
 
 - (void)terminalCommandDidStart {
+    // FinalTerm uses this to define the start of a collapsable region. That would be a nightmare
+    // to add to iTerm, and our answer to this is marks, which already existed anyway.
+    [delegate_ screenAddMarkOnLine:[self numberOfScrollbackLines] + self.cursorY - 1];
+
     commandStartX_ = currentGrid_.cursorX;
     commandStartY_ = currentGrid_.cursorY + [self numberOfScrollbackLines] + [self totalScrollbackOverflow];
     [delegate_ screenCommandDidChangeWithRange:[self commandRange]];


### PR DESCRIPTION
Existing implementation sets mark in `terminalPromptDidStart` and
assumes `terminalCommandDidStart` will occur on the same line (which is
later checked in `terminalCommandDidEnd` (well, ultimately in `screenCommandDidEndWithRange`, which uses the range set by `terminalPromptDidStart`).

This patch leaves setting the mark to the last line of the prompt so command return value stuff
works properly, whilst leaving the `terminalPromptDidStart` stuff to track the end
of the output from the previous command.

It's a bit of a hack, and I'd prefer to have the prompt marker set at the beginning (first line)
rather than the one the actual command is input on, but it's not immediately clear how I'd do that
without changing things quite a lot.

One possible approach might be to add a separate `_promptRange` ivar along with `_lastCommandOutputRange` and `commandRange`  instead of assuming that prompt.y == command.y == lastOutput.end.y + 1. That might also allow better click-prompt actions in future instead of being on the tiny mark or a submenu for the whole line.
