### PR TITLE
Add symbolic constants for `§` key in Keys prefs display

### DIFF
--- a/iTermKeyBindingMgr.m
+++ b/iTermKeyBindingMgr.m
@@ -160,6 +160,15 @@ static NSString *const kFactoryDefaultsGlobalPreset = @"Factory Defaults";
                                                          [NSBundle bundleForClass:[self class]],
                                                          @"Key Names");
             break;
+
+        // For no apparent reason, these are standard on Apple en_GB keyboards where ~/`
+        // typically goes (between esc and tab).
+        case 0xa7:
+            aString = @"§";
+            break;
+        case 0xb1: // shifted version of above.
+            aString = @"±";
+            break;
         case '0':
         case '1':
         case '2':


### PR DESCRIPTION
Not sure about the `±` one, since it's the shifted version of `§`, and so appears as something like: `⇧⌘ ±` due to the shift modifier also getting a symbol.
