### PR TITLE
disable AppNap if supported

### DIFF
--- a/sources/iTermApplicationDelegate.m
+++ b/sources/iTermApplicationDelegate.m
@@ -85,6 +85,8 @@ static BOOL hasBecomeActive = NO;
 @interface iTermApplicationDelegate () <iTermPasswordManagerDelegate>
 
 @property(nonatomic, readwrite) BOOL workspaceSessionActive;
+@property (strong) id activity;
+
 
 @end
 
@@ -313,6 +315,10 @@ static BOOL hasBecomeActive = NO;
         [[NSProcessInfo processInfo] disableAutomaticTermination:@"User Preference"];
     }
     [iTermFontPanel makeDefault];
+    
+    if ([[NSProcessInfo processInfo] respondsToSelector:@selector(beginActivityWithOptions:reason:)]) {
+        self.activity = [[NSProcessInfo processInfo] beginActivityWithOptions:0x00FFFFFF reason:@"no reason"];
+    }
 
     finishedLaunching_ = YES;
     // Create the app support directory


### PR DESCRIPTION
That's a quick and dirty patch which may not be suitable for merging as is but could be a start :)

My use case is that I have my terminal in the background with an utility running in it which is monitoring the disk and run the tests when a file is changed, with the latest release I get a really annoying behavior when AppNap kicks in: the terminal takes more time to refresh and show me the test results.

that may be an edge case but I never want AppNap to be triggered for iTerm2 but maybe it could be implemented as an option for a more general use.
