### PR TITLE
Don't check for test releases by default

### DIFF
--- a/sources/iTermPreferences.m
+++ b/sources/iTermPreferences.m
@@ -131,7 +131,7 @@ static NSMutableDictionary *gObservers;
                   kPreferenceKeySavePasteAndCommandHistory: @NO,
                   kPreferenceKeyAddBonjourHostsToProfiles: @NO,
                   kPreferenceKeyCheckForUpdatesAutomatically: @YES,
-                  kPreferenceKeyCheckForTestReleases: @YES,
+                  kPreferenceKeyCheckForTestReleases: @NO,
                   kPreferenceKeyLoadPrefsFromCustomFolder: @NO,
                   kPreferenceKeyCustomFolder: [NSNull null],
                   kPreferenceKeySelectionCopiesText: @YES,


### PR DESCRIPTION
When downloading the great iTerm2 from iterm2.com, it directly asks me to update to a new version.
Turns out the app uses the test release line by default.
