### PR TITLE
support for cp949

### DIFF
--- a/VT100Terminal.m
+++ b/VT100Terminal.m
@@ -62,7 +62,7 @@
 #define isbig5(c)    ((c) >= 0xa1 && (c) <= 0xfe)
 #define issjiskanji(c)  (((c) >= 0x81 && (c) <= 0x9f) ||  \
                          ((c) >= 0xe0 && (c) <= 0xef))
-#define iseuckr(c)   ((c) >= 0xa1 && (c) <= 0xfe)
+#define iseuckr(c)   ((c) >= 0x81 && (c) <= 0xfe)
 
 #define isGBEncoding(e)     ((e)==0x80000019||(e)==0x80000421|| \
                              (e)==0x80000631||(e)==0x80000632|| \


### PR DESCRIPTION
Apart from euc-kr, there are also cp949 for Korean encoding. It's default encoding for Korean Windows OS thus widely accepted in Korea.

cp949 is superset for euc-kr, so there are additional characters especially in 0x8140-0xa0ff.
(see http://www.i18nl10n.com/korean/cp949l.html#hangul2)

Strictly 0x8140-0xa0ff range is not euc-kr encoding, but this will temporarily support cp949 encoding in iTerm.
