### PR TITLE
Use (NSFont*)convertWeight:ofFont: to get bold font

### DIFF
--- a/sources/PTYFontInfo.m
+++ b/sources/PTYFontInfo.m
@@ -31,7 +31,7 @@
 
 - (PTYFontInfo *)computedBoldVersion {
     NSFontManager* fontManager = [NSFontManager sharedFontManager];
-    NSFont* boldFont = [fontManager convertFont:font_ toHaveTrait:NSBoldFontMask];
+    NSFont* boldFont = [fontManager convertWeight:YES ofFont:font_];
     if (boldFont && ([fontManager traitsOfFont:boldFont] & NSBoldFontMask)) {
         return [PTYFontInfo fontInfoWithFont:boldFont baseline:baselineOffset_];
     } else {


### PR DESCRIPTION
This changes the behavior for fonts with many weight variants. Currently, if a font has the variants Light, Medium and Bold and user normally uses Light, the Bold font will be jarringly bold. With this change, Medium will be selected instead which fits better visually. I.e, given this screenshot:

![screen shot 2014-11-11 at 13 09 07](https://cloud.githubusercontent.com/assets/125426/4992711/b5bd2d2a-69a4-11e4-87b3-97ef575c5ef0.png)

The top left terminal uses Input Mono Extra Light and this patch. The bold text in the shell prompt looks nice. The top right terminal is the unpatched version, which goes all the way up to the Bold variant of the font, which looks out of place.

The two bottom terminals use the standard Menlo font that doesn't have many variants, showing that there's no difference introduced in that case.
