### PR TITLE
Use VT100 colors as sRGB, calibrating them after

### DIFF
--- a/sources/VT100Terminal.m
+++ b/sources/VT100Terminal.m
@@ -1654,10 +1654,11 @@ static const int kMaxScreenRows = 4096;
                         }
                     }
                     if (ok) {
-                        NSColor *theColor = [NSColor colorWithCalibratedRed:colors[0]
-                                                                      green:colors[1]
-                                                                       blue:colors[2]
-                                                                      alpha:1];
+                        NSColor *srgb = [NSColor colorWithSRGBRed:colors[0]
+                                                            green:colors[1]
+                                                             blue:colors[2]
+                                                            alpha:1];
+                        NSColor *theColor = [srgb colorUsingColorSpaceName:NSCalibratedRGBColorSpace];
                         [delegate_ terminalSetColorTableEntryAtIndex:theIndex
                                                                color:theColor];
                     }


### PR DESCRIPTION
This is inspired by: #149

Printing 24bit colors #133 on iTerm is great, it would be even greater if the colors were more accurately matched what we expect. This adds support for this.
Makes it great to use things like https://github.com/chriskempson/base16-shell

In all honesty, I'm not a Cocoa developer, this is my best effort to solve this problem and it works well for me. Please give any feedback about what other consequences this might have that I couldn't foresee.

Thanks!
