### PR TITLE
Use sRGB when changing color palette using "Proprietary Escape Codes"

### DIFF
--- a/sources/VT100Terminal.m
+++ b/sources/VT100Terminal.m
@@ -858,10 +858,11 @@ static const int kMaxScreenRows = 4096;
             g <= 255 &&
             b >= 0 &&
             b <= 255) {
-            NSColor* theColor = [NSColor colorWithCalibratedRed:((double)r)/255.0
-                                                          green:((double)g)/255.0
-                                                           blue:((double)b)/255.0
-                                                          alpha:1];
+            NSColor* srgb = [NSColor colorWithSRGBRed:((double)r)/255.0
+                                                green:((double)g)/255.0
+                                                 blue:((double)b)/255.0
+                                                alpha:1];
+            NSColor *theColor = [srgb colorUsingColorSpaceName:NSCalibratedRGBColorSpace];
             *numberPtr = n;
             return theColor;
         }


### PR DESCRIPTION
As @chriskempson stated in #191 , changing color palette is still using generic RGB, which is not consistent after merged #191. This fix it.
