### PR TITLE
Make cursor opaque

### DIFF
--- a/sources/PTYTextView.m
+++ b/sources/PTYTextView.m
@@ -7202,13 +7202,12 @@ static double EuclideanDistance(NSPoint p1, NSPoint p2) {
         return [self _randomColor];
     }
 
-    CGFloat alpha = [self transparencyAlpha];
     if (_useSmartCursorColor) {
         return [[self smartCursorColorForChar:screenChar
                                          column:column
-                                    lineOfChars:theLine] colorWithAlphaComponent:alpha];
+                                    lineOfChars:theLine] colorWithAlphaComponent:1.0];
     } else {
-        return [[_colorMap colorForKey:kColorMapCursor] colorWithAlphaComponent:alpha];
+        return [[_colorMap colorForKey:kColorMapCursor] colorWithAlphaComponent:1.0];
     }
 }
 


### PR DESCRIPTION
Not sure if this was an intentional design decision, but having a transparent cursor can be a bit distracting when content bleeds through it. The text doesn't use transparency, so I figured the cursor should be the same.

Here's an animation showing the change:

![iterm_animation](https://cloud.githubusercontent.com/assets/1256911/6015216/98c1ff98-ab26-11e4-8bcd-6537c092eccc.gif)
