### PR TITLE
Rename Bundle Name to “iTerm” from “iTerm2”

### DIFF
--- a/plists/iTerm2.plist
+++ b/plists/iTerm2.plist
@@ -69,7 +69,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>iTerm2</string>
+	<string>iTerm</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>


### PR DESCRIPTION
There are two reason for this pull request:

1. More consistent naming between what the app presents in the Finder/Dock and what is presented in the menu bar.
2. More subjectively, the absence of numbers in the menu bar is preferable. Very few Mac applications have a numeral in Bundle name.