### PR TITLE
Change reset shorcut from CMD+r to CMD+R

### DIFF
--- a/Interfaces/MainMenu.xib
+++ b/Interfaces/MainMenu.xib
@@ -615,7 +615,7 @@ DQ
                             <menuItem isSeparatorItem="YES" id="908">
                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                             </menuItem>
-                            <menuItem title="Reset" keyEquivalent="r" id="907">
+                            <menuItem title="Reset" keyEquivalent="R" id="907">
                                 <connections>
                                     <action selector="reset:" target="-1" id="909"/>
                                 </connections>


### PR DESCRIPTION
Developers who use vim under Mac may accidently press CMD+r when
they try to refresh the web browser when the focus was still on
vim window, it will break the buffer on vim, this change will make
user to use CMD+SHIFT+R, which could somehow resolve the conflicts