### PR TITLE
Show main menu when right clicking empty tabBar region

### DIFF
--- a/ThirdParty/PSMTabBarControl/source/PSMTabBarControl.m
+++ b/ThirdParty/PSMTabBarControl/source/PSMTabBarControl.m
@@ -1551,6 +1551,13 @@ NSString *const kPSMTabModifierKey = @"TabModifier";
     if (item && [[self delegate] respondsToSelector:@selector(tabView:menuForTabViewItem:)]) {
         menu = [[self delegate] tabView:tabView menuForTabViewItem:item];
     }
+    else if (!item) {
+        // when the "LSUIElement hack" (issue #954) is enabled, the menu bar is inaccessible,
+        // so show it as a context menu when right-clicking empty tabBar region
+        if ([[[NSBundle mainBundle] infoDictionary] objectForKey:@"LSUIElement"]) {
+            menu = [NSApp mainMenu];
+        }
+    }
     return menu;
 }
 


### PR DESCRIPTION
When using the "[LSUIElement hack](https://code.google.com/p/iterm2/issues/detail?id=954)" to hide dock icon, the menu bar also disappears, leaving users with no way to reach the main menu.

<img src="https://cloud.githubusercontent.com/assets/1256911/6201649/b61c52ee-b46a-11e4-8eea-1a68787a6a9d.png" width="500" />