### PR TITLE
Use handleEvent instead of interpretKeyEvents.

### DIFF
--- a/sources/PTYTextView.m
+++ b/sources/PTYTextView.m
@@ -116,6 +116,7 @@ static const int kBadgeRightMargin = 10;
     BOOL _nonasciiAntiAlias;  // Only used if self.useNonAsciiFont is set.
 
     // NSTextInputClient support
+    NSEvent* _keydownEvent;
     BOOL _inputMethodIsInserting;
     NSRange _inputMethodSelectedRange;
     NSRange _inputMethodMarkedRange;
@@ -2208,7 +2209,8 @@ NSMutableArray* screens=0;
         // track the instance of PTYTextView that is currently handling a key event and rerouting
         // calls as needed in -insertText and -doCommandBySelector.
         gCurrentKeyEventTextView = [[self retain] autorelease];
-        [self interpretKeyEvents:[NSArray arrayWithObject:event]];
+        _keydownEvent = event;
+        _inputMethodIsInserting = [self.inputContext handleEvent:event];
         gCurrentKeyEventTextView = nil;
 
         // If the IME didn't want it, pass it on to the delegate
@@ -4783,8 +4785,10 @@ static double EuclideanDistance(NSPoint p1, NSPoint p2) {
         // See comment in -keyDown:
         DLog(@"Rerouting doCommandBySelector from %@ to %@", self, gCurrentKeyEventTextView);
         [gCurrentKeyEventTextView doCommandBySelector:aSelector];
+        [self.delegate keyDown:_keydownEvent];
         return;
     }
+    [self.delegate keyDown:_keydownEvent];
     DLog(@"doCommandBySelector:%@", NSStringFromSelector(aSelector));
 }
 


### PR DESCRIPTION
This patch is related with https://code.google.com/p/iterm2/issues/detail?id=2629 but not same.

## What steps will reproduce the problem?
1. Install AquaSKK.
2. Give focus a window of iTerm2 and make AquaSKK enable.
3. Change the mode to Japane Hirakana Input mode.
4. Press l to turn on ASCII input mode.

## What is the expected output?
The [A] icon with orange background is displayed at the location by the cursor in an iTerm window, and any characters are not inputted in the iTerm window.

## What do you see instead?
The [あ] icon with orange background is displayed at the location by the cursor in an iTerm window, and a newline character is inputted in the iTerm window.

## What OS version are you using?
MacOS X 10.10.2

## Solution
Because some IME(e.g. AquaSKK) consume event without insert any text, `_inputMethodIsInserting` is not enough.

So, we need use handleEvent instead of interpretKeyEvents.