### PR TITLE
Don't forget about processes that were alive when we tried to reap them

### DIFF
--- a/sources/TaskNotifier.m
+++ b/sources/TaskNotifier.m
@@ -171,7 +171,11 @@ NSString *const kTaskNotifierDidSpin = @"kTaskNotifierDidSpin";
                 }
                 int statLoc;
                 PtyTaskDebugLog(@"wait on %d", [pid intValue]);
-                if (waitpid([pid intValue], &statLoc, WNOHANG) < 0) {
+                int waitresult = waitpid([pid intValue], &statLoc, WNOHANG);
+                if (waitresult == 0) {
+                    // the process is not yet dead, so put it back in the pool
+                    [newDeadpool addObject:pid];
+                } else if (waitresult < 0) {
                     if (errno != ECHILD) {
                         PtyTaskDebugLog(@"  wait failed with %d (%s), adding back to deadpool", errno, strerror(errno));
                         [newDeadpool addObject:pid];


### PR DESCRIPTION
Pids are added to a "deadpool" in TaskNotifier when we expect them to
die soon. When reaping processes, it's possible that waitpid() will
return 0, meaning that the process is not yet dead. In that case, put
its pid back into the deadpool so that we attempt to reap it again.
Otherwise the process will become a zombie.

Fixes https://code.google.com/p/iterm2/issues/detail?id=3471