### PR TITLE
Strip more bracketed delimiters

### DIFF
--- a/iTerm2XCTests/iTermNSStringCategoryTest.m
+++ b/iTerm2XCTests/iTermNSStringCategoryTest.m
@@ -190,6 +190,32 @@
     }
 }
 
+- (void)testStringByRemovingEnclosingBrackets {
+  XCTAssert([@"abc" isEqualToString:[@"abc" stringByRemovingEnclosingBrackets]]);
+
+  XCTAssert([@"abc" isEqualToString:[@"(abc)" stringByRemovingEnclosingBrackets]]);
+  XCTAssert([@"abc" isEqualToString:[@"<abc>" stringByRemovingEnclosingBrackets]]);
+  XCTAssert([@"abc" isEqualToString:[@"[abc]" stringByRemovingEnclosingBrackets]]);
+  XCTAssert([@"abc" isEqualToString:[@"{abc}" stringByRemovingEnclosingBrackets]]);
+  XCTAssert([@"abc" isEqualToString:[@"'abc'" stringByRemovingEnclosingBrackets]]);
+  XCTAssert([@"abc" isEqualToString:[@"\"abc\"" stringByRemovingEnclosingBrackets]]);
+
+  XCTAssert([@"(abc(" isEqualToString:[@"(abc(" stringByRemovingEnclosingBrackets]]);
+  XCTAssert([@"<abc<" isEqualToString:[@"<abc<" stringByRemovingEnclosingBrackets]]);
+  XCTAssert([@"[abc[" isEqualToString:[@"[abc[" stringByRemovingEnclosingBrackets]]);
+  XCTAssert([@"{abc{" isEqualToString:[@"{abc{" stringByRemovingEnclosingBrackets]]);
+
+  XCTAssert([@"a" isEqualToString:[@"a" stringByRemovingEnclosingBrackets]]);
+  XCTAssert([@"a" isEqualToString:[@"(a)" stringByRemovingEnclosingBrackets]]);
+
+  XCTAssert([@"" isEqualToString:[@"" stringByRemovingEnclosingBrackets]]);
+  XCTAssert([@"" isEqualToString:[@"()" stringByRemovingEnclosingBrackets]]);
+  XCTAssert([@"" isEqualToString:[@"([])" stringByRemovingEnclosingBrackets]]);
+
+  XCTAssert([@"abc" isEqualToString:[@"<[abc]>" stringByRemovingEnclosingBrackets]]);
+  XCTAssert([@"<[abc>]" isEqualToString:[@"<[abc>]" stringByRemovingEnclosingBrackets]]);
+}
+
 - (void)testStringMatchesCaseInsensitiveGlobPattern {
   // Empty string tests
   XCTAssertTrue([@"" stringMatchesCaseInsensitiveGlobPattern:@""]);

--- a/iTerm2XCTests/iTermSemanticHistoryTest.m
+++ b/iTerm2XCTests/iTermSemanticHistoryTest.m
@@ -205,18 +205,20 @@
     XCTAssert(lineNumber.length == 0);
 }
 
-- (void)testGetFullPathStripsParens {
-    NSString *lineNumber = nil;
-    static NSString *const kFilename = @"/path/to/file";
-    NSString *kFilenameWithParens = [NSString stringWithFormat:@"(%@)", kFilename];
-    static NSString *const kWorkingDirectory = @"/working/directory";
-    [_semanticHistoryController.fakeFileManager.files addObject:kFilename];
-    NSString *actual = [_semanticHistoryController getFullPath:kFilenameWithParens
-                                              workingDirectory:kWorkingDirectory
-                                                    lineNumber:&lineNumber];
-    NSString *expected = kFilename;
-    XCTAssert([expected isEqualToString:actual]);
-    XCTAssert(lineNumber.length == 0);
+- (void)testGetFullPathStripsDelimiters {
+    for (NSString *delimiters in @[ @"()", @"<>", @"[]", @"{}", @"''", @"\"\"" ]) {
+        NSString *lineNumber = nil;
+        static NSString *const kFilename = @"/path/to/file";
+        NSString *kFilenameWithParens = [NSString stringWithFormat:@"%C%@%C", [delimiters characterAtIndex:0], kFilename, [delimiters characterAtIndex:1]];
+        static NSString *const kWorkingDirectory = @"/working/directory";
+        [_semanticHistoryController.fakeFileManager.files addObject:kFilename];
+        NSString *actual = [_semanticHistoryController getFullPath:kFilenameWithParens
+                                                  workingDirectory:kWorkingDirectory
+                                                        lineNumber:&lineNumber];
+        NSString *expected = kFilename;
+        assert([expected isEqualToString:actual]);
+        assert(lineNumber.length == 0);
+    }
 }
 
 - (void)testGetFullPathStripsTrailingPunctuation {

--- a/sources/NSStringITerm.h
+++ b/sources/NSStringITerm.h
@@ -134,6 +134,8 @@ int decode_utf8_char(const unsigned char * restrict datap,
 //    "*http://example.com" -> "http://example.com"
 - (NSRange)rangeOfURLInString;
 
+- (NSString *)stringByRemovingEnclosingBrackets;
+
 - (NSString *)stringByEscapingForURL;
 - (NSString *)stringByCapitalizingFirstLetter;
 

--- a/sources/NSStringITerm.m
+++ b/sources/NSStringITerm.m
@@ -652,6 +652,23 @@ int decode_utf8_char(const unsigned char *datap,
     return [self rangeOfString:trimmedURLString];
 }
 
+- (NSString *)stringByRemovingEnclosingBrackets {
+    int index;
+    for (index = 0; 2*index < self.length; index++) {
+      unichar start = [self characterAtIndex:index];
+      unichar end = [self characterAtIndex:self.length-index-1];
+      if (!((start == '(' && end == ')') ||
+            (start == '<' && end == '>') ||
+            (start == '[' && end == ']') ||
+            (start == '{' && end == '}') ||
+            (start == '\'' && end == '\'') ||
+            (start == '"' && end == '"'))) {
+          break;
+      }
+    }
+    return [self substringWithRange:NSMakeRange(index, self.length-2*index)];
+}
+
 - (NSString *)stringByRemovingTerminatingPunctuation {
     NSString *s = self;
     NSArray *punctuationMarks = @[ @"!", @"?", @".", @",", @";", @":", @"...", @"…" ];

--- a/sources/iTermSemanticHistoryController.m
+++ b/sources/iTermSemanticHistoryController.m
@@ -40,19 +40,6 @@ NSString *const kSemanticHistoryWorkingDirectorySubstitutionKey = @"semanticHist
 @synthesize prefs = prefs_;
 @synthesize delegate = delegate_;
 
-static unsigned int oppositeDelimiter(unichar start) {
-    switch(start) {
-        case '(': return ')';
-        case '<': return '>';
-        case '[': return ']';
-        case '{': return '}';
-        case '\'':
-        case '"':
-            return start;
-        default:
-            return (unsigned int)-1; // unsigned int to prevent it from matching any unsigned short
-    }
-}
 
 - (NSString *)getFullPath:(NSString *)path
          workingDirectory:(NSString *)workingDirectory
@@ -66,14 +53,7 @@ static unsigned int oppositeDelimiter(unichar start) {
     }
 
     // If it's in any form of bracketed delimiters, strip them
-    int parens = 0;
-    while (oppositeDelimiter([path characterAtIndex:parens]) == [path characterAtIndex:(path.length - parens - 1)]) {
-        parens++;
-    }
-    if (parens > 0) {
-        path = [path substringWithRange:NSMakeRange(parens, path.length - parens - 1)];
-        DLog(@" Strip parens, leaving %@", path);
-    }
+    path = [path stringByRemovingEnclosingBrackets];
 
     // strip various trailing characters that are unlikely to be part of the file name.
     path = [path stringByReplacingOccurrencesOfRegex:@"[.),:]$"


### PR DESCRIPTION
The main motivation for this change is that git when presenting merge conflicts sometimes shows the file paths in single quotes. Instead of just adding single quotes, I thought it was just as well to add some other delimiters that are unlikely to appear in file names