### PR TITLE
Fix for setting BBEdit as default for semantic history

### DIFF
--- a/sources/iTermSemanticHistoryController.m
+++ b/sources/iTermSemanticHistoryController.m
@@ -295,7 +295,7 @@ NSString *const kSemanticHistoryWorkingDirectorySubstitutionKey = @"semanticHist
     }
 
     if ([prefs_[kSemanticHistoryActionKey] isEqualToString:kSemanticHistoryCoprocessAction]) {
-        DLog(@"Launch coproress with script %@", script);
+        DLog(@"Launch coprocess with script %@", script);
         assert(delegate_);
         [delegate_ semanticHistoryLaunchCoprocessWithCommand:script];
         return YES;

--- a/sources/iTermSemanticHistoryPrefsController.m
+++ b/sources/iTermSemanticHistoryPrefsController.m
@@ -91,7 +91,7 @@ enum {
                                kSublimeText3Identifier: @"subl",
                                kMacVimIdentifier: @"mvim",
                                kTextmateIdentifier: @"txmt",
-                               kBBEditIdentifier: @"txmt",
+                               kBBEditIdentifier: @"x-bbedit",
                                kAtomIdentifier: @"atom" };
     return schemes[editor];
 }


### PR DESCRIPTION
Without this, if a user has both BBEdit and TextMate installed and
chooses BBEdit as default for semantic history, iTerm2 would still
launch TextMate. This is because both were configured to use the
same URL scheme.
using that has the problem that when both BBEdit

(Also fix a typo in a debug message :)

Note: Unfortunately, I am unable to build iTerm2, so this has *not* been verified to work -- things, is, on my OS X 10.8.5 machine, ibtoold segfaults (on NumberOfSpacesAccessoryView.xib, I think). Still, this fix should be correct, I hope. I'll be happy to test a nightly build with this, or a custom test binary if somebody is willing to provide one.

Thanks for making iTerm2!