### PR TITLE
Fix search direction for Find Next and Find Previous actions

### DIFF
--- a/sources/PseudoTerminal.m
+++ b/sources/PseudoTerminal.m
@@ -7209,15 +7209,12 @@ static const CGFloat kHorizontalTabBarHeight = 22;
     [[self currentSession] showFindPanel];
 }
 
-// findNext and findPrevious are reversed here because in the search UI next
-// goes backwards and previous goes forwards.
-// Internally, next=forward and prev=backwards.
 - (IBAction)findPrevious:(id)sender {
-    [[self currentSession] searchNext];
+    [[self currentSession] searchPrevious];
 }
 
 - (IBAction)findNext:(id)sender {
-    [[self currentSession] searchPrevious];
+    [[self currentSession] searchNext];
 }
 
 - (IBAction)findWithSelection:(id)sender {


### PR DESCRIPTION
⌘G and ⌘⇧G were going the wrong directions when searching within iTerm2.

The comment in the code mentioned something about the search UI being reversed, but I couldn't reproduce this. I tested the left / right buttons in the Find View and they work as expected.