### PR TITLE
Fix a bookmarks bug caused by a nil value

### DIFF
--- a/sources/ITAddressBookMgr.m
+++ b/sources/ITAddressBookMgr.m
@@ -80,6 +80,12 @@ static NSString *const kLegacyDynamicTag = @"dynamic";
             [[ProfileModel sharedInstance] removeAllBookmarks];
         }
 
+        if (![prefs objectForKey:KEY_NEW_BOOKMARKS]) {
+            // Even if we don't need to migrate from old-style bookmarks,
+            // make sure that the new-style bookmarks are non-nil.
+            [prefs setObject:[[ProfileModel sharedInstance] rawData] forKey:KEY_NEW_BOOKMARKS];
+        }
+
         // Load new-style bookmarks.
         id newBookmarks = [prefs objectForKey:KEY_NEW_BOOKMARKS];
         NSString *originalDefaultGuid = nil;


### PR DESCRIPTION
In the case where no migration was needed from old-style bookmarks to new-style bookmarks, no value would be set for `KEY_NEW_BOOKMARKS`. This resulted in the bookmarks for `KEY_DEFAULT_GUID` never getting loaded.

This fixes [Issue 3491](https://code.google.com/p/iterm2/issues/detail?id=3491).