### PR TITLE
Revert "Fix for setting BBEdit as default for semantic history"

### DIFF
--- a/sources/iTermSemanticHistoryController.m
+++ b/sources/iTermSemanticHistoryController.m
@@ -295,7 +295,7 @@ NSString *const kSemanticHistoryWorkingDirectorySubstitutionKey = @"semanticHist
     }
 
     if ([prefs_[kSemanticHistoryActionKey] isEqualToString:kSemanticHistoryCoprocessAction]) {
-        DLog(@"Launch coprocess with script %@", script);
+        DLog(@"Launch coproress with script %@", script);
         assert(delegate_);
         [delegate_ semanticHistoryLaunchCoprocessWithCommand:script];
         return YES;

--- a/sources/iTermSemanticHistoryPrefsController.m
+++ b/sources/iTermSemanticHistoryPrefsController.m
@@ -91,7 +91,7 @@ enum {
                                kSublimeText3Identifier: @"subl",
                                kMacVimIdentifier: @"mvim",
                                kTextmateIdentifier: @"txmt",
-                               kBBEditIdentifier: @"x-bbedit",
+                               kBBEditIdentifier: @"txmt",
                                kAtomIdentifier: @"atom" };
     return schemes[editor];
 }


### PR DESCRIPTION
Reverts gnachman/iTerm2#206 - x-bbedit doesn't actually open files (documented here: https://groups.google.com/forum/#!topic/bbedit/9sjczMsPO1g)