### PR TITLE
Make the find bar first responder immediately upon opening

### DIFF
--- a/sources/FindViewController.m
+++ b/sources/FindViewController.m
@@ -476,12 +476,8 @@ const CGFloat kEdgeWidth = 3;
 
     [NSAnimationContext endGrouping];
 
-    dispatch_async(dispatch_get_main_queue(), ^{
-        DLog(@"Grab focus for find view %@", self.view);
-        [[[self view] window] makeFirstResponder:findBarTextField_];
-    });
-
-    [delegate_ findViewControllerMakeDocumentFirstResponder];
+    DLog(@"Grab focus for find view %@", self.view);
+    [[[self view] window] makeFirstResponder:findBarTextField_];
 }
 
 - (void)makeVisible {


### PR DESCRIPTION
More aggressive fix for issue 3496. The original fix allowed
a possibility for enqueued events to be processed before
the text field gained focus, so that for example typing
cmd-F followed by 'a', the 'a' would go to the iTerm window.
This fix ensures that enqueued events go to the search field.