### PR TITLE
Fixed compiler warnings. Use correct kTmuxWindowOpener* constants.

### DIFF
--- a/sources/PTYTab.m
+++ b/sources/PTYTab.m
@@ -2325,7 +2325,7 @@ static NSString* FormatRect(NSRect r) {
 }
 
 + (PTYTab *)tabWithArrangement:(NSDictionary*)arrangement
-                    inTerminal:(NSWindowController<iTermWindowController> *)term
+                    inTerminal:(NSWindowController<iTermWindowController, PTYTabDelegate> *)term
                hasFlexibleView:(BOOL)hasFlexible
                        viewMap:(NSDictionary *)viewMap
 {

--- a/sources/TmuxController.m
+++ b/sources/TmuxController.m
@@ -915,7 +915,7 @@ static NSString *kListWindowsFormat = @"\"#{session_name}\t#{window_id}\t"
 - (NSString *)windowFlagsForTerminal:(PseudoTerminal *)term {
     if (term.anyFullScreen) {
         return [NSString stringWithFormat:@"%@=%@",
-                kTmuxControllerWindowFlagStyle, kTmuxControllerWindowFlagStyleValueFullScreen];
+                kTmuxWindowOpenerWindowFlagStyle, kTmuxWindowOpenerWindowFlagStyleValueFullScreen];
     } else {
         return @"";
     }

--- a/sources/TmuxWindowOpener.m
+++ b/sources/TmuxWindowOpener.m
@@ -356,11 +356,11 @@ NSString *const kTmuxWindowOpenerWindowFlagStyleValueFullScreen = @"FullScreen";
                 // Check the window flags
                 NSString *windowId = [NSString stringWithFormat:@"%d", windowIndex_];
                 NSDictionary *flags = _windowFlags[windowId];
-                NSString *style = flags[kTmuxControllerWindowFlagStyle];
-                BOOL wantFullScreen = [style isEqual:kTmuxControllerWindowFlagStyleValueFullScreen];
+                NSString *style = flags[kTmuxWindowOpenerWindowFlagStyle];
+                BOOL wantFullScreen = [style isEqual:kTmuxWindowOpenerWindowFlagStyleValueFullScreen];
                 BOOL isFullScreen = [term anyFullScreen];
-                if (wantFullScreen && !isFullScreen) {
-                    [term toggleFullScreenMode:nil];
+                if (wantFullScreen && !isFullScreen && [term isKindOfClass:[PseudoTerminal class]]) {
+                    [(PseudoTerminal *)term toggleFullScreenMode:nil];
                 }
             } else {
                 DLog(@"Not calling loadTmuxLayout");


### PR DESCRIPTION
- Fixed compiler warnings for Xcode v6.3.2.
- Use 'correct' kTmuxWindowOpenerWindowFlagStyle* constants.

I'm not sure I replaced with the correct constants. Let me know.