### PR TITLE
configurable tab label truncation style

### DIFF
--- a/ThirdParty/PSMTabBarControl/source/PSMYosemiteTabStyle.m
+++ b/ThirdParty/PSMTabBarControl/source/PSMYosemiteTabStyle.m
@@ -9,6 +9,7 @@
 #import "PSMYosemiteTabStyle.h"
 #import "PSMTabBarCell.h"
 #import "PSMTabBarControl.h"
+#import "iTermAdvancedSettingsModel.h"
 
 #define kPSMMetalObjectCounterRadius 7.0
 #define kPSMMetalCounterMinWidth 20
@@ -296,7 +297,16 @@
     if (!truncatingTailParagraphStyle) {
         truncatingTailParagraphStyle =
             [[[NSParagraphStyle defaultParagraphStyle] mutableCopy] retain];
-        [truncatingTailParagraphStyle setLineBreakMode:NSLineBreakByTruncatingTail];
+        switch ([iTermAdvancedSettingsModel tabLabelTruncationStyle]) {
+            case kAdvancedSettingsTruncationStyleLeft:
+                [truncatingTailParagraphStyle setLineBreakMode:NSLineBreakByTruncatingHead];
+                break;
+            case kAdvancedSettingsTruncationStyleMiddle:
+                [truncatingTailParagraphStyle setLineBreakMode:NSLineBreakByTruncatingMiddle];
+                break;
+            default:
+                [truncatingTailParagraphStyle setLineBreakMode:NSLineBreakByTruncatingTail];
+        }
         [truncatingTailParagraphStyle setAlignment:NSCenterTextAlignment];
     }
     [attrStr addAttribute:NSParagraphStyleAttributeName

--- a/sources/iTermAdvancedSettingsModel.h
+++ b/sources/iTermAdvancedSettingsModel.h
@@ -8,8 +8,15 @@
 
 #import <Foundation/Foundation.h>
 
+enum {
+    kAdvancedSettingsTruncationStyleRight = 0,
+    kAdvancedSettingsTruncationStyleMiddle = 1,
+    kAdvancedSettingsTruncationStyleLeft = 2
+};
+
 @interface iTermAdvancedSettingsModel : NSObject
 
++ (int)tabLabelTruncationStyle;
 + (BOOL)useUnevenTabs;
 + (int)minTabWidth;
 + (int)minCompactTabWidth;

--- a/sources/iTermAdvancedSettingsModel.m
+++ b/sources/iTermAdvancedSettingsModel.m
@@ -45,6 +45,7 @@
 }
 
 #pragma mark Tabs
+DEFINE_INT(tabLabelTruncationStyle, kAdvancedSettingsTruncationStyleRight, @"Tabs: Tab label truncation style.\n0=Right, 1=Middle, 2=Left.");
 DEFINE_BOOL(useUnevenTabs, NO, @"Tabs: Uneven tab widths allowed.");
 DEFINE_INT(minTabWidth, 75, @"Tabs: Minimum tab width when using uneven tab widths.");
 DEFINE_INT(minCompactTabWidth, 60, @"Tabs: Minimum tab width when using uneven tab widths for compact tabs.");


### PR DESCRIPTION
Choice of Right, Middle, or Left elision to make label text fit on tab GUI element.

Setting only visible in Preferences / Advanced.

Exposing a bare `int` for the setting is crude.  I'm hazily assuming you may add an `NSDictionary` type to the advanced settings in the future (mapping to a dropdown in the GUI), which could be made backward-compatible to the `int` value.
