### PR TITLE
Add "with/without newline" argument to Applescript write verb

### DIFF
--- a/iTerm2.sdef
+++ b/iTerm2.sdef
@@ -288,6 +288,10 @@
       <parameter name="text" code="Text" type="text"
           description="Text to send" optional="yes">
         <cocoa key="text"/>
+	<parameter name="newline" code="wrtxtnl" type="boolean"
+            description="If newline should be added to end of text (default: yes)" optional="yes">
+          <cocoa key="newline"/>
+        </parameter>
       </parameter>
     </command>
 

--- a/sources/PTYSession+Scripting.m
+++ b/sources/PTYSession+Scripting.m
@@ -61,6 +61,8 @@
     NSString *contentsOfFile = [args objectForKey:@"contentsOfFile"];
     // optional argument follows (might be nil):
     NSString *text = [args objectForKey:@"text"];
+    // optional argument follows (might be nil; if so, defaults to true):
+    BOOL newline = ( [args objectForKey:@"newline"] ? [[args objectForKey:@"newline"] boolValue] : YES );
     NSData *data = nil;
     NSString *aString = nil;
 
@@ -79,11 +81,11 @@
         text = [text description];
     }
     if (text != nil) {
-        if ([text characterAtIndex:[text length]-1]==' ') {
-            data = [text dataUsingEncoding:[self.terminal encoding]];
-        } else {
+        if (newline) {
             aString = [NSString stringWithFormat:@"%@\n", text];
             data = [aString dataUsingEncoding:[self.terminal encoding]];
+        } else {
+            data = [text dataUsingEncoding:[self.terminal encoding]];
         }
     }
 


### PR DESCRIPTION
I've completely replaced the old notion of not sending a newline if the text ends in a space.

I think this works, but I'm currently unable to see how to use Applescript with iTerm2 v3.

With iTerm2 v2, I could do something like:

	set term to (make new terminal)
	tell term
		set sess to (launch session "default")
	end tell
	tell sess to write text "echo"

With iTerm2 v3, I simply don't see how to get a handle on a session, new or old, to use `write` with.

As such, I cannot test my changes. If you let me know how to get a session handle, I'll be happy to test and fix, if needed.