### PR TITLE
Allow substring hostname matching.

### DIFF
--- a/iTerm2XCTests/iTermRuleTest.m
+++ b/iTerm2XCTests/iTermRuleTest.m
@@ -20,6 +20,12 @@
     iTermRule *_usernameHostname;  // username@hostname
     iTermRule *_usernameHostnamePath;  // username@hostname:path
     iTermRule *_usernameWildcardPath;  // username@*:path
+    iTermRule *_usernameWildcardStartPath;  // username@*hostname:path
+    iTermRule *_usernameWildcardEndPath;  // username@hostname*:path
+    iTermRule *_usernameWildcardStartEndPath;  // username@*hostname*:path
+    iTermRule *_usernameWildcardMiddlePath;  // username@host*name:path
+    iTermRule *_usernameWildcardAllPath;  // username@*host*name*:path
+    iTermRule *_usernameWildcardActualPath; // username@service*.*.hostname.com:path
     iTermRule *_hostnamePath;  // hostname:path
     iTermRule *_path;  // /path
     iTermRule *_malformed1;  // foo:bar@baz
@@ -34,6 +40,14 @@
     _usernameHostname = [iTermRule ruleWithString:@"username@hostname"];
     _usernameHostnamePath = [iTermRule ruleWithString:@"username@hostname:/path"];
     _usernameWildcardPath = [iTermRule ruleWithString:@"username@*:/path"];
+  
+    _usernameWildcardStartPath = [iTermRule ruleWithString:@"username@*hostname:/path"];
+    _usernameWildcardEndPath = [iTermRule ruleWithString:@"username@hostname*:/path"];
+    _usernameWildcardStartEndPath = [iTermRule ruleWithString:@"username@*hostname*:/path"];
+    _usernameWildcardMiddlePath = [iTermRule ruleWithString:@"username@host*name:/path"];
+    _usernameWildcardAllPath = [iTermRule ruleWithString:@"username@*host*name*:/path"];
+    _usernameWildcardActualPath = [iTermRule ruleWithString:@"username@service*.*.hostname.com:/path"];
+  
     _hostnamePath = [iTermRule ruleWithString:@"hostname:/path"];
     _path = [iTermRule ruleWithString:@"/path"];
     _malformed1 = [iTermRule ruleWithString:@"/foo:bar@baz"];
@@ -43,6 +57,12 @@
                 _usernameHostname,
                 _usernameHostnamePath,
                 _usernameWildcardPath,
+                _usernameWildcardStartPath,
+                _usernameWildcardEndPath,
+                _usernameWildcardStartEndPath,
+                _usernameWildcardMiddlePath,
+                _usernameWildcardAllPath,
+                _usernameWildcardActualPath,
                 _hostnamePath,
                 _path,
                 _malformed1 ];
@@ -90,8 +110,10 @@
                                                          username:@"username"
                                                              path:@"/path"];
     NSArray *expected = @[ _usernameHostnamePath, _usernameHostname, _hostnamePath, _hostname,
-                           _usernameWildcardPath, _username,
-                           _path ];
+                           _usernameWildcardStartPath, _usernameWildcardEndPath,
+                           _usernameWildcardStartEndPath, _usernameWildcardMiddlePath, _usernameWildcardAllPath,
+                           _usernameWildcardPath, _username, _path ];
+
     XCTAssertEqualObjects(rules, expected);
 }
 
@@ -103,6 +125,43 @@
                            _path ];
     XCTAssertEqualObjects(rules, expected);
 }
+
+- (void)testUsernameWildcardStartPath {
+  NSArray *rules = [self matchingRulesSortedByScoreWithHostname:@"service01.hostname"
+                                                       username:@"username"
+                                                           path:@"/path"];
+  NSArray *expected = @[ _usernameWildcardStartPath, _usernameWildcardStartEndPath, _usernameWildcardAllPath,
+                         _usernameWildcardPath, _username, _path ];
+  XCTAssertEqualObjects(rules, expected);
+}
+
+- (void)testUsernameWildcardEndPath {
+  NSArray *rules = [self matchingRulesSortedByScoreWithHostname:@"hostname.com"
+                                                       username:@"username"
+                                                           path:@"/path"];
+  NSArray *expected = @[ _usernameWildcardEndPath, _usernameWildcardStartEndPath, _usernameWildcardAllPath,
+                         _usernameWildcardPath, _username, _path ];
+  XCTAssertEqualObjects(rules, expected);
+}
+
+- (void)testUsernameWildcardStartEndPath {
+  NSArray *rules = [self matchingRulesSortedByScoreWithHostname:@"service01.hostname.com"
+                                                       username:@"username"
+                                                           path:@"/path"];
+  NSArray *expected = @[ _usernameWildcardStartEndPath, _usernameWildcardAllPath,
+                         _usernameWildcardPath, _username, _path ];
+  XCTAssertEqualObjects(rules, expected);
+}
+
+- (void)testUsernameWildcardActualPath {
+  NSArray *rules = [self matchingRulesSortedByScoreWithHostname:@"service01.prod.hostname.com"
+                                                       username:@"username"
+                                                           path:@"/path"];
+  NSArray *expected = @[ _usernameWildcardStartEndPath, _usernameWildcardAllPath, _usernameWildcardActualPath,
+                         _usernameWildcardPath, _username, _path ];
+  XCTAssertEqualObjects(rules, expected);
+}
+
 
 - (void)testHostnamePath {
     NSArray *rules = [self matchingRulesSortedByScoreWithHostname:@"hostname"

--- a/sources/PTYSession.m
+++ b/sources/PTYSession.m
@@ -6416,13 +6416,15 @@ static NSTimeInterval kMinimumPartialLineTriggerCheckInterval = 0.5;
 
     // Find the best-matching rule.
     int bestScore = 0;
+    int longestHost = 0;
     Profile *bestProfile = nil;
 
     for (NSString *ruleString in stringToProfile) {
         iTermRule *rule = [iTermRule ruleWithString:ruleString];
         int score = [rule scoreForHostname:hostname username:username path:path];
-        if (score > bestScore) {
+        if ((score > bestScore) || (score > 0 && score == bestScore && [rule.hostname length] > longestHost)) {
             bestScore = score;
+            longestHost = [rule.hostname length];
             bestProfile = stringToProfile[ruleString];
         }
     }

--- a/sources/iTermRule.m
+++ b/sources/iTermRule.m
@@ -86,9 +86,9 @@
                username:(NSString *)username
                    path:(NSString *)path {
   const int kHostExactMatchScore = 8;
-  const int kHostMatchScore      = 4;
-  const int kUserMatchScore      = 2;
-  const int kPathMatchScore      = 1;
+  const int kHostMatchScore = 4;
+  const int kUserMatchScore = 2;
+  const int kPathMatchScore = 1;
 
   int score = 0;
 

--- a/sources/iTermRule.m
+++ b/sources/iTermRule.m
@@ -74,14 +74,20 @@
 - (int)scoreForHostname:(NSString *)hostname
                username:(NSString *)username
                    path:(NSString *)path {
-  const int kHostMatchScore = 4;
-  const int kUserMatchScore = 2;
-  const int kPathMatchScore = 1;
+  const int kHostExactMatchScore = 8;
+  const int kHostMatchScore      = 4;
+  const int kUserMatchScore      = 2;
+  const int kPathMatchScore      = 1;
 
   int score = 0;
 
   if ([hostname isEqualToString:self.hostname]) {
-    score |= kHostMatchScore;
+    score |= kHostExactMatchScore;
+  } else {
+    NSRange containsHost = [hostname rangeOfString:self.hostname options:NSCaseInsensitiveSearch];
+    if (containsHost.location != NSNotFound) {
+      score |= kHostMatchScore;
+    }
   }
   if ([username isEqualToString:self.username]) {
     score |= kUserMatchScore;

--- a/sources/iTermRule.m
+++ b/sources/iTermRule.m
@@ -81,14 +81,17 @@
 
   int score = 0;
 
-  if ([hostname isEqualToString:self.hostname]) {
-    score |= kHostExactMatchScore;
-  } else {
+  if (self.hostname != nil) {
     NSRange containsHost = [hostname rangeOfString:self.hostname options:NSCaseInsensitiveSearch];
     if (containsHost.location != NSNotFound) {
-      score |= kHostMatchScore;
+      if (containsHost.location == 0 && containsHost.length == hostname.length) {
+        score |= kHostExactMatchScore;
+      } else {
+        score |= kHostMatchScore;
+      }
     }
   }
+
   if ([username isEqualToString:self.username]) {
     score |= kUserMatchScore;
   }


### PR DESCRIPTION
This adds in the ability to only specify part of the full hostname for APS. For example instead of having to add:
someservice01.stage.company.com
someservice02.stage.company.com
someservice03.stage.company.com
otherservice01.stage.company.com
otherservice02.stage.company.com

you can just add:
.stage.company.com

and for prod:
.prod.company.com

In my use case I wanted two ssh profiles, one for stage servers and one for production and didn't want to have to type in over 50 server names into each.

I left exact match in place to take precedence over a partial match.