### PR TITLE
Fixed titlebar separator

### DIFF
--- a/sources/PseudoTerminal.m
+++ b/sources/PseudoTerminal.m
@@ -2321,6 +2321,8 @@ static NSString* TERMINAL_ARRANGEMENT_HIDING_TOOLBELT_SHOULD_RESIZE_WINDOW = @"H
         [self editSession:self.currentSession makeKey:NO];
     }
     [self notifyTmuxOfTabChange];
+
+    [_contentView updateDivisionView];
 }
 
 - (void)makeCurrentSessionFirstResponder
@@ -2583,6 +2585,8 @@ static NSString* TERMINAL_ARRANGEMENT_HIDING_TOOLBELT_SHOULD_RESIZE_WINDOW = @"H
     for (PTYSession* aSession in [self allSessions]) {
         [aSession setFocused:NO];
     }
+
+    [_contentView updateDivisionView];
 }
 
 // Returns the hotkey window that should be hidden or nil if the hotkey window

--- a/sources/SolidColorView.m
+++ b/sources/SolidColorView.m
@@ -33,6 +33,7 @@
 {
     [color_ autorelease];
     color_ = [color retain];
+    [self setNeedsDisplay:YES];
 }
 
 - (NSColor*)color
@@ -50,4 +51,9 @@
     isFlipped_ = value;
 }
 
+- (void)dealloc
+{
+    [color_ release];
+    [super dealloc];
+}
 @end

--- a/sources/iTermRootTerminalView.h
+++ b/sources/iTermRootTerminalView.h
@@ -48,7 +48,7 @@ extern const CGFloat kLeftTabsWidth;
 // Gray line dividing tab/title bar from content. Will be nil if a division
 // view isn't needed such as for fullscreen windows or windows without a
 // title bar (e.g., top-of-screen).
-@property(nonatomic, readonly) NSView *divisionView;
+@property(nonatomic, readonly) SolidColorView *divisionView;
 
 // Toolbelt view. Goes on the right side of the terminal window, if visible.
 @property(nonatomic, readonly) iTermToolbeltView *toolbelt;

--- a/sources/iTermRootTerminalView.m
+++ b/sources/iTermRootTerminalView.m
@@ -28,9 +28,8 @@ static const CGFloat kMaximumToolbeltSizeAsFractionOfWindow = 0.5;
 
 @property(nonatomic, retain) PTYTabView *tabView;
 @property(nonatomic, retain) iTermTabBarControlView *tabBarControl;
-@property(nonatomic, retain) NSView *divisionView;
+@property(nonatomic, retain) SolidColorView *divisionView;
 @property(nonatomic, retain) iTermToolbeltView *toolbelt;
-
 @end
 
 
@@ -126,11 +125,13 @@ static const CGFloat kMaximumToolbeltSizeAsFractionOfWindow = 0.5;
                                               self.bounds.size.width,
                                               kDivisionViewHeight);
         if (!_divisionView) {
-            _divisionView = [[SolidColorView alloc] initWithFrame:divisionViewFrame
-                                                            color:[NSColor darkGrayColor]];
+            _divisionView = [[SolidColorView alloc] initWithFrame:divisionViewFrame];
             _divisionView.autoresizingMask = (NSViewWidthSizable | NSViewMinYMargin);
             [self addSubview:_divisionView];
         }
+        _divisionView.color = self.window.isKeyWindow
+                ? [NSColor colorWithCalibratedHue:1 saturation:0 brightness:0.49 alpha:1]
+                : [NSColor colorWithCalibratedHue:1 saturation:0 brightness:0.65 alpha:1];
         _divisionView.frame = divisionViewFrame;
     } else if (_divisionView) {
         // Remove existing division


### PR DESCRIPTION
Titlebar separator is now slightly lighter in color, and adjusts itself when the window is in the background.

It's a small change, but it's a lot nicer this way.

### Before (View at full size)
<img width="1383" alt="before" src="https://cloud.githubusercontent.com/assets/6299/8741791/f0915dce-2c98-11e5-9c13-fd301a8d60b0.png">

### After (View at full size)
<img width="1410" alt="after" src="https://cloud.githubusercontent.com/assets/6299/8741792/f25ef454-2c98-11e5-963e-1583a12cf62e.png">