### PR TITLE
Make small scroll events move the terminal by one line.

### DIFF
--- a/sources/PTYScrollView.m
+++ b/sources/PTYScrollView.m
@@ -116,7 +116,21 @@
     NSRect scrollRect;
 
     scrollRect = [self documentVisibleRect];
-    scrollRect.origin.y -= [theEvent deltaY] * [self verticalLineScroll];
+
+    CGFloat delta = [theEvent deltaY];
+    // Make sure that a very small scroll event moves by at least one line.
+    if (fabs(delta) < 1) {
+        if (delta > 0) {
+            delta = 1;
+        } else if (delta < 0) {
+            delta = -1;
+        } else {
+            // The delta could be 0 in case of touchpad scrolling.
+            delta = 0;
+        }
+    }
+
+    scrollRect.origin.y -= delta * [self verticalLineScroll];
     [[self documentView] scrollRectToVisible:scrollRect];
 
     [self detectUserScroll];


### PR DESCRIPTION
This makes the scrolling behavior a bit nicer so it doesn't effectively ignore small scroll events. It matches the behavior of Terminal.app a bit better in this regard.