### PR TITLE
Fix pattern matching for user@host and user@host:path

### DIFF
--- a/sources/iTermRule.m
+++ b/sources/iTermRule.m
@@ -40,7 +40,10 @@
       colon = NSNotFound;
     } else if (colon != NSNotFound) {
       // user@host:path
-      hostname = [string substringWithRange:NSMakeRange(atSign + 1, colon - atSign)];
+      hostname = [string substringWithRange:NSMakeRange(atSign + 1, colon - atSign - 1)];
+    } else if (colon == NSNotFound) {
+      // user@host
+      hostname = [string substringFromIndex:atSign + 1];
     }
   }
   if (colon != NSNotFound) {


### PR DESCRIPTION
- the colon from user@host:path has been included in the hostname
- user@host has not been recognized