### PR TITLE
Fix wrong keyboard shortcut in tip of the day data

### DIFF
--- a/sources/iTermTipData.m
+++ b/sources/iTermTipData.m
@@ -110,7 +110,7 @@
                         kTipUrlKey: @"https://iterm2.com/shell_integration.html" },
 
             @"0026": @{ kTipTitleKey: @"Shell Integration: Selection",
-                        kTipBodyKey: @"With Shell Integration installed, you can select the output of the last command with ⌥⌘A.",
+                        kTipBodyKey: @"With Shell Integration installed, you can select the output of the last command with ⇧⌘A.",
                         kTipUrlKey: @"https://iterm2.com/shell_integration.html" },
 
             @"0027": @{ kTipTitleKey: @"Bells",


### PR DESCRIPTION
"Select Output of Last Command" is bound to Shift+Command+A.

![](https://i.imgur.com/UUf7Ign.png)