### PR TITLE
Fixed wording in settings for triple-click setting.

### DIFF
--- a/Interfaces/PreferencePanel.xib
+++ b/Interfaces/PreferencePanel.xib
@@ -5583,7 +5583,7 @@ DQ
                 <button toolTip="If disabled, then triple click selects one line as it appears onscreen." id="6260">
                     <rect key="frame" x="390" y="68" width="258" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <buttonCell key="cell" type="check" title="Triple-click selects full wrapped lines" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="6261">
+                    <buttonCell key="cell" type="check" title="Triple-click selects entire wrapped lines" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="6261">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>


### PR DESCRIPTION
While using iTerm I noticed that the wording was a little odd for the triple click setting.

It originally said "Triple-click selects full wrapped lines" but perhaps something like "Triple-click selects entire wrapped lines" would be clearer. 

Hope this isn't too much of a nitpick!