### PR TITLE
force encoding value to 32bit

### DIFF
--- a/sources/PTYSession.m
+++ b/sources/PTYSession.m
@@ -2962,7 +2962,7 @@ static NSTimeInterval kMinimumPartialLineTriggerCheckInterval = 0.5;
 
 - (void)setEncoding:(NSStringEncoding)encoding
 {
-    [_terminal setEncoding:encoding];
+    [_terminal setEncoding:(encoding & 0xffffffff)];
 }
 
 


### PR DESCRIPTION
NSStringEncoding is defined as NSUInteger, which is defined as unsigned int in 32bit-env & unsigned long in 64bit-env.
However iTerm saves value in internal dictionary as 32bit signed int, so casting 32bit signed int to 64bit unsigned int occurs, making unintended sign expansion (0xffffffff80000422 instead of 0x0000000080000422). So we need to clear high 32bit of encoding value to correctly match encoding values with predefined constants.

Also we can handle encoding option as 64bit value in whole application but that might break 32-bit build environment.

