### PR TITLE
Configureable badge size, font, & margins

### DIFF
--- a/badge_evolution.md
+++ b/badge_evolution.md
@@ -1,0 +1,36 @@
+# Badge Feature Evolution Proposal
+
+---
+
+## 1. Configure Current Mechanism
+This step involves keeping the current algorithm for drawing the badge as it is, but exposing all the _magic numbers_ in the **Advanced Preferences**
+
+- [x] Font Name (with a check that it exists, falling back to Helvetica)
+- [x] Bold on/off
+- [x] Max Size Width (% of current view)
+- [x] Max Size Height (% of current view)
+- [x] Add VerticalMargin
+- [x] Add HorizontalMargin
+- [ ] Add setting controlling whether badge label wraps
+
+## 2. Positioning Refinements to Current Algorithm
+- [ ] Add static Max Width
+- [ ] Add static Max Height
+- [ ] Add static Min Width
+- [ ] Add static Min Height
+- [ ] Choose pin location from (TopLeft, TopRight, TopCenter, MidLeft, BottomRight, BottomCenter, BottomLeft)
+	- [ ] **Optional:** enhance iTermAdvancedPreferences to allow settings that select from an enum
+	- make margins work as expected with all pin locations
+
+## 3. Style Enhancements
+- [ ] consider converting implementation from NSLabel to a virtual terminal pane, that can optionally have a separate profile, then would get all the below for free
+- [ ] Add setting for badge background color
+- [ ] Add setting for badge outline
+	- [ ] width
+	- [ ] color
+- [ ] Add color parsing
+	- [ ] parse terminal escape codes
+	- [ ] use badge color as foreground color
+	- [ ] use underlying terminal theme for base colors
+	- [ ] always understand xterm-256color codes, regardless of underlying terminal
+- [ ] Add inline images a la shell integration

--- a/sources/iTermAdvancedSettingsModel.h
+++ b/sources/iTermAdvancedSettingsModel.h
@@ -109,9 +109,9 @@
 
 + (NSString *)badgeFont;
 + (BOOL)badgeFontIsBold;
-+ (double)badgeMaxWidthPercent;
-+ (double)badgeMaxHeightPercent;
-+ (int)badgeHorizontalMargin;
-+ (int)badgeVerticalMargin;
++ (double)badgeMaxWidthFraction;
++ (double)badgeMaxHeightFraction;
++ (int)badgeRightMargin;
++ (int)badgeTopMargin;
 
 @end

--- a/sources/iTermAdvancedSettingsModel.h
+++ b/sources/iTermAdvancedSettingsModel.h
@@ -109,5 +109,9 @@
 
 + (NSString *)badgeFont;
 + (BOOL)badgeFontIsBold;
++ (double)badgeMaxWidthPercent;
++ (double)badgeMaxHeightPercent;
++ (int)badgeHorizontalMargin;
++ (int)badgeVerticalMargin;
 
 @end

--- a/sources/iTermAdvancedSettingsModel.h
+++ b/sources/iTermAdvancedSettingsModel.h
@@ -107,4 +107,7 @@
 + (BOOL)disallowCopyEmptyString;
 + (BOOL)profilesWindowJoinsActiveSpace;
 
++ (NSString *)badgeFont;
++ (BOOL)badgeFontIsBold;
+
 @end

--- a/sources/iTermAdvancedSettingsModel.m
+++ b/sources/iTermAdvancedSettingsModel.m
@@ -151,4 +151,8 @@ DEFINE_BOOL(disallowCopyEmptyString, NO, @"Pasteboard: Disallow copying empty st
 
 DEFINE_BOOL(noSyncTipsDisabled, NO, @"Tip of the Day: Disable the Tip of the Day?");
 
+#pragma mark - Badge
+DEFINE_STRING(badgeFont, @"Helvetica", @"Badge: Font to use for the badge.");
+DEFINE_BOOL(badgeFontIsBold, YES, @"Badge: Make the badge font bold.");
+
 @end

--- a/sources/iTermAdvancedSettingsModel.m
+++ b/sources/iTermAdvancedSettingsModel.m
@@ -156,6 +156,6 @@ DEFINE_STRING(badgeFont, @"Helvetica", @"Badge: Font to use for the badge.");
 DEFINE_BOOL(badgeFontIsBold, YES, @"Badge: Should the badge render in bold type?");
 DEFINE_FLOAT(badgeMaxWidthFraction, 0.5, @"Badge: Maximum width of the badge\nAs a fraction of the width of the terminal, between 0 and 1.0.");
 DEFINE_FLOAT(badgeMaxHeightFraction, 0.2, @"Badge: Maximum height of the badge\nAs a fraction of the height of the terminal, between 0 and 1.0.");
-DEFINE_INT(badgeRightMargin, 10, @"Badge: Margin: Right\nHow much space to leave between the right edge of the badge and the right edge of the terminal.");
-DEFINE_INT(badgeTopMargin, 10, @"Badge: Margin: Top\nHow much space to leave between the top edge of the badge and the top edge of the terminal.");
+DEFINE_INT(badgeRightMargin, 10, @"Badge: Right Margin\nHow much space to leave between the right edge of the badge and the right edge of the terminal.");
+DEFINE_INT(badgeTopMargin, 10, @"Badge: Top Margin\nHow much space to leave between the top edge of the badge and the top edge of the terminal.");
 @end

--- a/sources/iTermAdvancedSettingsModel.m
+++ b/sources/iTermAdvancedSettingsModel.m
@@ -153,9 +153,9 @@ DEFINE_BOOL(noSyncTipsDisabled, NO, @"Tip of the Day: Disable the Tip of the Day
 
 #pragma mark - Badge
 DEFINE_STRING(badgeFont, @"Helvetica", @"Badge: Font to use for the badge.");
-DEFINE_BOOL(badgeFontIsBold, YES, @"Badge: Make the badge font bold.");
-DEFINE_FLOAT(badgeMaxWidthPercent, 0.5, @"Badge: Maximum width of the badge\nAs a percentage of the width of the terminal, between 1% and 100%.");
-DEFINE_FLOAT(badgeMaxHeightPercent, 0.2, @"Badge: Maximum height of the badge\nThis is a percentage of the height of the terminal, between 1% and 100%.");
-DEFINE_INT(badgeHorizontalMargin, 10, @"Badge: Margin: Horizontal\nHow much space to leave between the right edge of the badge and the right edge of the terminal.");
-DEFINE_INT(badgeVerticalMargin, 10, @"Badge: Margin: Vertical\nHow much space to leave between the top edge of the badge and the top edge of the terminal.");
+DEFINE_BOOL(badgeFontIsBold, YES, @"Badge: Should the badge render in bold type?");
+DEFINE_FLOAT(badgeMaxWidthFraction, 0.5, @"Badge: Maximum width of the badge\nAs a fraction of the width of the terminal, between 0 and 1.0.");
+DEFINE_FLOAT(badgeMaxHeightFraction, 0.2, @"Badge: Maximum height of the badge\nAs a fraction of the height of the terminal, between 0 and 1.0.");
+DEFINE_INT(badgeRightMargin, 10, @"Badge: Margin: Right\nHow much space to leave between the right edge of the badge and the right edge of the terminal.");
+DEFINE_INT(badgeTopMargin, 10, @"Badge: Margin: Top\nHow much space to leave between the top edge of the badge and the top edge of the terminal.");
 @end

--- a/sources/iTermAdvancedSettingsModel.m
+++ b/sources/iTermAdvancedSettingsModel.m
@@ -154,5 +154,8 @@ DEFINE_BOOL(noSyncTipsDisabled, NO, @"Tip of the Day: Disable the Tip of the Day
 #pragma mark - Badge
 DEFINE_STRING(badgeFont, @"Helvetica", @"Badge: Font to use for the badge.");
 DEFINE_BOOL(badgeFontIsBold, YES, @"Badge: Make the badge font bold.");
-
+DEFINE_FLOAT(badgeMaxWidthPercent, 0.5, @"Badge: Maximum width of the badge\nAs a percentage of the width of the terminal, between 1% and 100%.");
+DEFINE_FLOAT(badgeMaxHeightPercent, 0.2, @"Badge: Maximum height of the badge\nThis is a percentage of the height of the terminal, between 1% and 100%.");
+DEFINE_INT(badgeHorizontalMargin, 10, @"Badge: Margin: Horizontal\nHow much space to leave between the right edge of the badge and the right edge of the terminal.");
+DEFINE_INT(badgeVerticalMargin, 10, @"Badge: Margin: Vertical\nHow much space to leave between the top edge of the badge and the top edge of the terminal.");
 @end

--- a/sources/iTermBadgeLabel.m
+++ b/sources/iTermBadgeLabel.m
@@ -161,9 +161,11 @@
 
 // Max size of image in points within the containing view.
 - (NSSize)maxSize {
+    double maxWidth = MIN(1.0, MAX(0.01, [iTermAdvancedSettingsModel badgeMaxWidthPercent]));
+    double maxHeight = MIN(1.0, MAX(0.01, [iTermAdvancedSettingsModel badgeMaxHeightPercent]));
     NSSize maxSize = _viewSize;
-    maxSize.width *= 0.5;
-    maxSize.height *= 0.2;
+    maxSize.width *= maxWidth;
+    maxSize.height *= maxHeight;
     return maxSize;
 }
 

--- a/sources/iTermBadgeLabel.m
+++ b/sources/iTermBadgeLabel.m
@@ -135,8 +135,8 @@
     NSFontManager *fontManager = [NSFontManager sharedFontManager];
     NSArray *fonts = [[NSFontManager sharedFontManager] availableFontFamilies];
     NSString *fontName = [iTermAdvancedSettingsModel badgeFont];
-    NSFont * font;
-    if( ! [fonts containsObject:fontName]) {
+    NSFont *font;
+    if(![fonts containsObject:fontName]) {
       fontName = @"Helvetica";
     }
     font = [NSFont fontWithName:fontName size:pointSize];
@@ -161,8 +161,8 @@
 
 // Max size of image in points within the containing view.
 - (NSSize)maxSize {
-    double maxWidth = MIN(1.0, MAX(0.01, [iTermAdvancedSettingsModel badgeMaxWidthPercent]));
-    double maxHeight = MIN(1.0, MAX(0.01, [iTermAdvancedSettingsModel badgeMaxHeightPercent]));
+    double maxWidth = MIN(1.0, MAX(0.01, [iTermAdvancedSettingsModel badgeMaxWidthFraction]));
+    double maxHeight = MIN(1.0, MAX(0.0, [iTermAdvancedSettingsModel badgeMaxHeightFraction]));
     NSSize maxSize = _viewSize;
     maxSize.width *= maxWidth;
     maxSize.height *= maxHeight;

--- a/sources/iTermBadgeLabel.m
+++ b/sources/iTermBadgeLabel.m
@@ -136,11 +136,11 @@
     NSArray *fonts = [[NSFontManager sharedFontManager] availableFontFamilies];
     NSString *fontName = [iTermAdvancedSettingsModel badgeFont];
     NSFont *font;
-    if(![fonts containsObject:fontName]) {
+    if (![fonts containsObject:fontName]) {
       fontName = @"Helvetica";
     }
     font = [NSFont fontWithName:fontName size:pointSize];
-    if( [iTermAdvancedSettingsModel badgeFontIsBold] ) {
+    if ([iTermAdvancedSettingsModel badgeFontIsBold]) {
       font = [fontManager convertFont:font
                           toHaveTrait:NSBoldFontMask];
     }

--- a/sources/iTermBadgeLabel.m
+++ b/sources/iTermBadgeLabel.m
@@ -8,6 +8,7 @@
 
 #import "iTermBadgeLabel.h"
 #import "DebugLogging.h"
+#import "iTermAdvancedSettingsModel.h"
 
 @interface iTermBadgeLabel()
 @property(nonatomic, retain) NSImage *image;
@@ -132,8 +133,18 @@
 // Attributed string attributes for a given font point size.
 - (NSDictionary *)attributesWithPointSize:(CGFloat)pointSize {
     NSFontManager *fontManager = [NSFontManager sharedFontManager];
-    NSFont *font = [fontManager convertFont:[NSFont fontWithName:@"Helvetica" size:pointSize]
-                                toHaveTrait:NSBoldFontMask];
+    NSArray *fonts = [[NSFontManager sharedFontManager] availableFontFamilies];
+    NSString *fontName = [iTermAdvancedSettingsModel badgeFont];
+    NSFont * font;
+    if( ! [fonts containsObject:fontName]) {
+      fontName = @"Helvetica";
+    }
+    font = [NSFont fontWithName:fontName size:pointSize];
+    if( [iTermAdvancedSettingsModel badgeFontIsBold] ) {
+      font = [fontManager convertFont:font
+                          toHaveTrait:NSBoldFontMask];
+    }
+
     NSDictionary *attributes = @{ NSFontAttributeName: font,
                                   NSForegroundColorAttributeName: _fillColor,
                                   NSParagraphStyleAttributeName: _paragraphStyle };

--- a/sources/iTermTextDrawingHelper.m
+++ b/sources/iTermTextDrawingHelper.m
@@ -27,7 +27,6 @@
 #import "VT100Terminal.h"  // TODO: Remove this dependency
 
 static const int kBadgeMargin = 4;
-static const int kBadgeRightMargin = 10;
 
 @interface iTermTextDrawingHelper() <iTermCursorDelegate>
 @end
@@ -583,8 +582,8 @@ static const int kBadgeRightMargin = 10;
     NSSize textViewSize = _frame.size;
     NSSize visibleSize = _scrollViewDocumentVisibleRect.size;
     NSSize imageSize = image.size;
-    NSRect destination = NSMakeRect(textViewSize.width - imageSize.width - kBadgeRightMargin,
-                                    textViewSize.height - visibleSize.height + kiTermIndicatorStandardHeight,
+    NSRect destination = NSMakeRect(textViewSize.width - imageSize.width - [iTermAdvancedSettingsModel badgeHorizontalMargin],
+                                    textViewSize.height - visibleSize.height + kiTermIndicatorStandardHeight + [iTermAdvancedSettingsModel badgeVerticalMargin],
                                     imageSize.width,
                                     imageSize.height);
     NSRect intersection = NSIntersectionRect(rect, destination);
@@ -602,7 +601,8 @@ static const int kBadgeRightMargin = 10;
              fraction:1
        respectFlipped:YES
                 hints:nil];
-    imageSize.width += kBadgeMargin + kBadgeRightMargin;
+    imageSize.width += kBadgeMargin + [iTermAdvancedSettingsModel badgeHorizontalMargin];
+
     return imageSize;
 }
 

--- a/sources/iTermTextDrawingHelper.m
+++ b/sources/iTermTextDrawingHelper.m
@@ -582,8 +582,8 @@ static const int kBadgeMargin = 4;
     NSSize textViewSize = _frame.size;
     NSSize visibleSize = _scrollViewDocumentVisibleRect.size;
     NSSize imageSize = image.size;
-    NSRect destination = NSMakeRect(textViewSize.width - imageSize.width - [iTermAdvancedSettingsModel badgeHorizontalMargin],
-                                    textViewSize.height - visibleSize.height + kiTermIndicatorStandardHeight + [iTermAdvancedSettingsModel badgeVerticalMargin],
+    NSRect destination = NSMakeRect(textViewSize.width - imageSize.width - [iTermAdvancedSettingsModel badgeRightMargin],
+                                    textViewSize.height - visibleSize.height + kiTermIndicatorStandardHeight + [iTermAdvancedSettingsModel badgeTopMargin],
                                     imageSize.width,
                                     imageSize.height);
     NSRect intersection = NSIntersectionRect(rect, destination);
@@ -601,7 +601,7 @@ static const int kBadgeMargin = 4;
              fraction:1
        respectFlipped:YES
                 hints:nil];
-    imageSize.width += kBadgeMargin + [iTermAdvancedSettingsModel badgeHorizontalMargin];
+    imageSize.width += kBadgeMargin + [iTermAdvancedSettingsModel badgeRightMargin];
 
     return imageSize;
 }


### PR DESCRIPTION
This leaves the current method of creating and drawing a badge untouched, but simply exposes all the numbers (and the font) in the Advanced Preferences. So it is still pinned to the top right corner.

See the file `badge_evolution.md` for my ideas on a roadmap for further enhancing badges.

relevant:
[New configuration settings: badge location, font and size. (#3508)](https://gitlab.com/gnachman/iterm2/issues/3508)
[Add tmux-like status line (#2941)](https://gitlab.com/gnachman/iterm2/issues/2941)
