### PR TITLE
Setting to allow hot key window to float above windows even in background

### DIFF
--- a/sources/HotkeyWindowController.m
+++ b/sources/HotkeyWindowController.m
@@ -288,6 +288,12 @@ static void RollOutHotkeyTerm(PseudoTerminal* term, BOOL itermWasActiveWhenHotke
             rollingIn_ = YES;
         }
     }
+    if([iTermAdvancedSettingsModel hotkeyWindowFloatsAboveOtherWindows]) {
+        hotkeyTerm.window.level = NSFloatingWindowLevel;
+    }
+    else {
+        hotkeyTerm.window.level = NSNormalWindowLevel;
+    }
 }
 
 - (void)createHiddenHotkeyWindow {

--- a/sources/iTermAdvancedSettingsModel.h
+++ b/sources/iTermAdvancedSettingsModel.h
@@ -17,6 +17,7 @@
 + (BOOL)alternateMouseScroll;
 + (BOOL)traditionalVisualBell;
 + (double)hotkeyTermAnimationDuration;
++ (BOOL)hotkeyWindowFloatsAboveOtherWindows;
 + (NSString *)searchCommand;
 + (double)antiIdleTimerPeriod;
 + (BOOL)dockIconTogglesWindow;

--- a/sources/iTermAdvancedSettingsModel.m
+++ b/sources/iTermAdvancedSettingsModel.m
@@ -82,6 +82,7 @@ DEFINE_BOOL(requireCmdForDraggingText, NO, @"Terminal: To drag images or selecte
 #pragma mark Hotkey
 DEFINE_FLOAT(hotkeyTermAnimationDuration, 0.25, @"Hotkey: Duration in seconds of the hotkey window animation.");
 DEFINE_BOOL(dockIconTogglesWindow, NO, @"Hotkey: If the only window is a hotkey window, then clicking the dock icon shows or hides it.");
+DEFINE_BOOL(hotkeyWindowFloatsAboveOtherWindows, NO, @"Hotkey: The hotkey window floats above other windows even when iTerm is in the background.");
 
 #pragma mark General
 DEFINE_STRING(searchCommand, @"http://google.com/search?q=%@", @"General: Template for URL of search engine.\niTerm2 replaces the string “%@” with the text to search for. Query parameter percent escaping is used.");


### PR DESCRIPTION
This is useful for watching the status of a terminal even when you're
doing other things.