### PR TITLE
Fill in x/ypixel in struct winsize for the TIOCGWINSZ ioctl.

### DIFF
--- a/sources/PTYSession.m
+++ b/sources/PTYSession.m
@@ -1169,7 +1169,7 @@ static NSTimeInterval kMinimumPartialLineTriggerCheckInterval = 0.5;
 {
     DLog(@"Set session %@ to %dx%d", self, width, height);
     [_screen resizeWidth:width height:height];
-    [_shell setWidth:width height:height pixelWidth:width*_textview.charWidth pixelHeight:height*_textview.lineHeight];
+    [_shell setWidth:width height:height pixelWidth:width * _textview.charWidth pixelHeight:height * _textview.lineHeight];
     [_textview clearHighlights];
     [[_tab realParentWindow] invalidateRestorableState];
 }
@@ -3586,6 +3586,7 @@ static NSTimeInterval kMinimumPartialLineTriggerCheckInterval = 0.5;
             [[[self tab] parentWindow] fitWindowToTab:[self tab]];
         }
     }
+
     // If the window isn't able to adjust, or adjust enough, make the session
     // work with whatever size we ended up having.
     if ([self isTmuxClient]) {

--- a/sources/PTYSession.m
+++ b/sources/PTYSession.m
@@ -3587,6 +3587,9 @@ static NSTimeInterval kMinimumPartialLineTriggerCheckInterval = 0.5;
         }
     }
 
+    // Update the TTY's winsize since lineHeight may have changed
+    [_shell setWidth:_screen.width height:_screen.height pixelWidth:_screen.width * _textview.charWidth pixelHeight:_screen.height * _textview.lineHeight];
+
     // If the window isn't able to adjust, or adjust enough, make the session
     // work with whatever size we ended up having.
     if ([self isTmuxClient]) {

--- a/sources/PTYSession.m
+++ b/sources/PTYSession.m
@@ -1169,7 +1169,7 @@ static NSTimeInterval kMinimumPartialLineTriggerCheckInterval = 0.5;
 {
     DLog(@"Set session %@ to %dx%d", self, width, height);
     [_screen resizeWidth:width height:height];
-    [_shell setWidth:width height:height];
+    [_shell setWidth:width height:height pixelWidth:width*_textview.charWidth pixelHeight:height*_textview.lineHeight];
     [_textview clearHighlights];
     [[_tab realParentWindow] invalidateRestorableState];
 }
@@ -1346,8 +1346,10 @@ static NSTimeInterval kMinimumPartialLineTriggerCheckInterval = 0.5;
     [_shell launchWithPath:program
                  arguments:arguments
                environment:env
-                     width:[_screen width]
-                    height:[_screen height]
+                     width:_screen.width
+                    height:_screen.height
+                pixelWidth:_screen.width * _textview.charWidth
+               pixelHeight:_screen.height * _textview.lineHeight
                     isUTF8:isUTF8];
     NSString *initialText = _profile[KEY_INITIAL_TEXT];
     if ([initialText length]) {
@@ -1994,7 +1996,9 @@ static NSTimeInterval kMinimumPartialLineTriggerCheckInterval = 0.5;
     _shell = [[PTYTask alloc] init];
     [_shell setDelegate:self];
     [_shell setWidth:_screen.width
-              height:_screen.height];
+              height:_screen.height
+          pixelWidth:_screen.width * _textview.charWidth
+         pixelHeight:_screen.height * _textview.lineHeight];
     [self startProgram:_program
            environment:_environment
                 isUTF8:_isUTF8

--- a/sources/PTYTask.h
+++ b/sources/PTYTask.h
@@ -56,10 +56,10 @@ extern NSString *kCoprocessStatusChangeNotification;
 - (void)launchWithPath:(NSString*)progpath
              arguments:(NSArray*)args
            environment:(NSDictionary*)env
-                 width:(int)width
-                height:(int)height
-            pixelWidth:(int)pixelWidth
-           pixelHeight:(int)pixelHeight
+                 width:(unsigned short)width
+                height:(unsigned short)height
+            pixelWidth:(unsigned short)pixelWidth
+           pixelHeight:(unsigned short)pixelHeight
                 isUTF8:(BOOL)isUTF8;
 
 - (NSString*)currentJob:(BOOL)forceRefresh;
@@ -67,7 +67,7 @@ extern NSString *kCoprocessStatusChangeNotification;
 - (void)writeTask:(NSData*)data;
 
 - (void)sendSignal:(int)signo;
-- (void)setWidth:(int)width height:(int)height pixelWidth:(int)pixelWidth pixelHeight:(int)pixelHeight;
+- (void)setWidth:(unsigned short)width height:(unsigned short)height pixelWidth:(unsigned short)pixelWidth pixelHeight:(unsigned short)pixelHeight;
 - (void)stop;
 
 

--- a/sources/PTYTask.h
+++ b/sources/PTYTask.h
@@ -58,6 +58,8 @@ extern NSString *kCoprocessStatusChangeNotification;
            environment:(NSDictionary*)env
                  width:(int)width
                 height:(int)height
+            pixelWidth:(int)pixelWidth
+           pixelHeight:(int)pixelHeight
                 isUTF8:(BOOL)isUTF8;
 
 - (NSString*)currentJob:(BOOL)forceRefresh;
@@ -65,7 +67,7 @@ extern NSString *kCoprocessStatusChangeNotification;
 - (void)writeTask:(NSData*)data;
 
 - (void)sendSignal:(int)signo;
-- (void)setWidth:(int)width height:(int)height;
+- (void)setWidth:(int)width height:(int)height pixelWidth:(int)pixelWidth pixelHeight:(int)pixelHeight;
 - (void)stop;
 
 

--- a/sources/PTYTask.m
+++ b/sources/PTYTask.m
@@ -41,10 +41,10 @@ NSString *kCoprocessStatusChangeNotification = @"kCoprocessStatusChangeNotificat
 static void
 setup_tty_param(struct termios* term,
                 struct winsize* win,
-                int width,
-                int height,
-                int pixelWidth,
-                int pixelHeight,
+                unsigned short width,
+                unsigned short height,
+                unsigned short pixelWidth,
+                unsigned short pixelHeight,
                 BOOL isUTF8)
 {
     memset(term, 0, sizeof(struct termios));
@@ -415,10 +415,10 @@ static int MyForkPty(int *amaster,
 - (void)launchWithPath:(NSString *)progpath
              arguments:(NSArray *)args
            environment:(NSDictionary *)env
-                 width:(int)width
-                height:(int)height
-            pixelWidth:(int)pixelWidth
-           pixelHeight:(int)pixelHeight
+                 width:(unsigned short)width
+                height:(unsigned short)height
+            pixelWidth:(unsigned short)pixelWidth
+           pixelHeight:(unsigned short)pixelHeight
                 isUTF8:(BOOL)isUTF8 {
     struct termios term;
     struct winsize win;
@@ -803,7 +803,7 @@ static int MyForkPty(int *amaster,
     }
 }
 
-- (void)setWidth:(int)width height:(int)height pixelWidth:(int)pixelWidth pixelHeight:(int)pixelHeight
+- (void)setWidth:(unsigned short)width height:(unsigned short)height pixelWidth:(unsigned short)pixelWidth pixelHeight:(unsigned short)pixelHeight
 {
     PtyTaskDebugLog(@"Set terminal size to %dx%d", width, height);
     struct winsize winsize;


### PR DESCRIPTION
https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man4/tty.4.html

iTerm currently fills in the row/column fields, but not the pixel density. This commit brings it in line with Terminal's behavior.

I was actually using this in combination with terminfo commands to play gifs before gif support was added.
