### PR TITLE
Focus ring drawing fix, and some code refactoring

### DIFF
--- a/sources/FindViewController.m
+++ b/sources/FindViewController.m
@@ -98,12 +98,14 @@ const CGFloat kEdgeWidth = 3;
 }
 
 - (void)drawFocusRingMaskWithFrame:(NSRect)cellFrame inView:(NSView *)controlView {
-    if (IsYosemiteOrLater()) {
-        [super drawFocusRingMaskWithFrame:NSInsetRect(cellFrame, kFocusRingInset.width, kFocusRingInset.height)
-                                   inView:controlView];
-    } else {
-        [super drawFocusRingMaskWithFrame:cellFrame inView:controlView];
-    }
+    if (controlView.frame.origin.y >= 0) {
+        if (IsYosemiteOrLater()) {
+            [super drawFocusRingMaskWithFrame:NSInsetRect(cellFrame, kFocusRingInset.width, kFocusRingInset.height)
+                                       inView:controlView];
+        } else {
+            [super drawFocusRingMaskWithFrame:cellFrame inView:controlView];
+        }
+    }    
 }
 
 - (void)drawWithFrame:(NSRect)cellFrame inView:(NSView *)controlView

--- a/sources/HotkeyWindowController.m
+++ b/sources/HotkeyWindowController.m
@@ -712,18 +712,16 @@ static CGEventRef OnTappedEvent(CGEventTapProxy proxy, CGEventType type, CGEvent
 }
 
 - (void)requestAccessibilityPermissionMavericks {
-    static BOOL alreadyAsked;
-    if (alreadyAsked) {
-        return;
-    }
-    alreadyAsked = YES;
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= 1090
-    NSDictionary *options = [NSDictionary dictionaryWithObject:[NSNumber numberWithBool:YES]
-                                                        forKey:(NSString *)kAXTrustedCheckOptionPrompt];
-    // Show a dialog prompting the user to open system prefs.
-    if (!AXIsProcessTrustedWithOptions((CFDictionaryRef)options)) {
-        return;
-    }
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSDictionary *options = [NSDictionary dictionaryWithObject:[NSNumber numberWithBool:YES]
+                                                            forKey:(NSString *)kAXTrustedCheckOptionPrompt];
+        // Show a dialog prompting the user to open system prefs.
+        if (!AXIsProcessTrustedWithOptions((CFDictionaryRef)options)) {
+            return;
+        }
+    });
 #endif
 }
 

--- a/sources/HotkeyWindowController.m
+++ b/sources/HotkeyWindowController.m
@@ -712,17 +712,14 @@ static CGEventRef OnTappedEvent(CGEventTapProxy proxy, CGEventType type, CGEvent
 }
 
 - (void)requestAccessibilityPermissionMavericks {
-#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1090
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        NSDictionary *options = [NSDictionary dictionaryWithObject:[NSNumber numberWithBool:YES]
-                                                            forKey:(NSString *)kAXTrustedCheckOptionPrompt];
+        NSDictionary *options = @{ (NSString *)kAXTrustedCheckOptionPrompt: @YES };
         // Show a dialog prompting the user to open system prefs.
         if (!AXIsProcessTrustedWithOptions((CFDictionaryRef)options)) {
             return;
         }
     });
-#endif
 }
 
 - (void)beginRemappingModifiers

--- a/sources/PTYTextView.m
+++ b/sources/PTYTextView.m
@@ -1331,12 +1331,11 @@ static const int kDragThreshold = 3;
     // key then it starts searching from the bottom again.
     [_findOnPageHelper resetFindCursor];
 
-    static BOOL isFirstInteraction = YES;
-    if (isFirstInteraction) {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
         iTermApplicationDelegate *appDelegate = iTermApplication.sharedApplication.delegate;
         [appDelegate userDidInteractWithASession];
-        isFirstInteraction = NO;
-    }
+    });
 
     DLog(@"PTYTextView keyDown BEGIN %@", event);
     id delegate = [self delegate];

--- a/sources/iTermController.m
+++ b/sources/iTermController.m
@@ -60,9 +60,9 @@
 @end
 
 // Constants for saved window arrangement key names.
-static NSString* APPLICATION_SUPPORT_DIRECTORY = @"~/Library/Application Support";
-static NSString *SUPPORT_DIRECTORY = @"~/Library/Application Support/iTerm";
-static NSString *SCRIPT_DIRECTORY = @"~/Library/Application Support/iTerm/Scripts";
+static NSString *APPLICATION_SUPPORT_DIRECTORY = @"~/Library/Application Support";
+static NSString *SUPPORT_DIRECTORY             = @"~/Library/Application Support/iTerm";
+static NSString *SCRIPT_DIRECTORY              = @"~/Library/Application Support/iTerm/Scripts";
 
 // Pref keys
 static NSString *const kSelectionRespectsSoftBoundariesKey = @"Selection Respects Soft Boundaries";

--- a/sources/iTermController.m
+++ b/sources/iTermController.m
@@ -61,8 +61,8 @@
 
 // Constants for saved window arrangement key names.
 static NSString *APPLICATION_SUPPORT_DIRECTORY = @"~/Library/Application Support";
-static NSString *SUPPORT_DIRECTORY             = @"~/Library/Application Support/iTerm";
-static NSString *SCRIPT_DIRECTORY              = @"~/Library/Application Support/iTerm/Scripts";
+static NSString *SUPPORT_DIRECTORY = @"~/Library/Application Support/iTerm";
+static NSString *SCRIPT_DIRECTORY = @"~/Library/Application Support/iTerm/Scripts";
 
 // Pref keys
 static NSString *const kSelectionRespectsSoftBoundariesKey = @"Selection Respects Soft Boundaries";

--- a/sources/iTermController.m
+++ b/sources/iTermController.m
@@ -124,16 +124,15 @@ BOOL IsYosemiteOrLater(void) {
     id runningApplicationClass_;
 }
 
-static iTermController* shared = nil;
-static BOOL initDone = NO;
+static iTermController* shared;
 
 + (iTermController*)sharedInstance
 {
-    if (!shared && !initDone) {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
         shared = [[iTermController alloc] init];
-        initDone = YES;
-    }
-
+    });
+    
     return shared;
 }
 

--- a/sources/iTermController.m
+++ b/sources/iTermController.m
@@ -67,11 +67,11 @@ static NSString *SCRIPT_DIRECTORY              = @"~/Library/Application Support
 // Pref keys
 static NSString *const kSelectionRespectsSoftBoundariesKey = @"Selection Respects Soft Boundaries";
 
-static BOOL UncachedIsMavericksOrLater(void) {
-    unsigned major;
-    unsigned minor;
-    if ([iTermController getSystemVersionMajor:&major minor:&minor bugFix:nil]) {
-        return (major == 10 && minor >= 9) || (major > 10);
+static BOOL UncachedIsSystemVersionEqualToOrLaterThan(unsigned major, unsigned minor) {
+    unsigned systemMajor;
+    unsigned systemMinor;
+    if ([iTermController getSystemVersionMajor:&systemMajor minor:&systemMinor bugFix:nil]) {
+        return (systemMajor == major && systemMinor >= minor) || (systemMajor > major);
     } else {
         return NO;
     }
@@ -79,34 +79,21 @@ static BOOL UncachedIsMavericksOrLater(void) {
 
 BOOL IsMavericksOrLater(void) {
     static BOOL result;
-    static BOOL initialized;
-    if (!initialized) {
-        initialized = YES;
-        result = UncachedIsMavericksOrLater();
-    }
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        result = UncachedIsSystemVersionEqualToOrLaterThan(10, 9);
+    });
     return result;
-}
-
-static BOOL UncachedIsYosemiteOrLater(void) {
-    unsigned major;
-    unsigned minor;
-    if ([iTermController getSystemVersionMajor:&major minor:&minor bugFix:nil]) {
-        return (major == 10 && minor >= 10) || (major > 10);
-    } else {
-        return NO;
-    }
 }
 
 BOOL IsYosemiteOrLater(void) {
     static BOOL result;
-    static BOOL initialized;
-    if (!initialized) {
-        initialized = YES;
-        result = UncachedIsYosemiteOrLater();
-    }
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        result = UncachedIsSystemVersionEqualToOrLaterThan(10, 10);
+    });
     return result;
 }
-
 
 @implementation iTermController {
     NSMutableArray *_restorableSessions;


### PR DESCRIPTION
#### 4 commits

**Use dispatch_once for one-shot actions**
Unless there's a specific reason not to use this (for perf, if all static variable accesses are guaranteed to
occur on the main thread), dispatch_once is usually a cleaner pattern.

**focus ring drawing**
this is something that has always irked me in AppKit. The focus ring is appearing above the title bar when sliding down, even though the search field is behind that bar.

**Align static path strings**
some variable definition alignment

**Refactor system version check code**
refactored duplicate code