### PR TITLE
Fix stack overflow in indicatorRectForTabCell: on startup

### DIFF
--- a/ThirdParty/PSMTabBarControl/source/PSMYosemiteTabStyle.m
+++ b/ThirdParty/PSMTabBarControl/source/PSMYosemiteTabStyle.m
@@ -160,7 +160,7 @@
         NSRect objectCounterRect = [self objectCounterRectForTabCell:cell];
         minX = NSMinX(objectCounterRect);
     } else if (![[cell indicator] isHidden]) {
-        minX = NSMinX([self indicatorRectForTabCell:cell]) - kSPMTabBarCellInternalXMargin;
+        minX = NSMinX([[cell indicator] frame]) - kSPMTabBarCellInternalXMargin;
     } else {
         minX = NSMaxX(cellFrame) - kSPMTabBarCellInternalXMargin;
     }


### PR DESCRIPTION
- On startup, a tab won't have a count, but it may have an indicator