### PR TITLE
Rony/memory usage

### DIFF
--- a/iTerm2.xcodeproj/project.pbxproj
+++ b/iTerm2.xcodeproj/project.pbxproj
@@ -730,6 +730,8 @@
 		1DFA9D6418F37160008ADC98 /* iTermEditKeyActionWindowController.h in Headers */ = {isa = PBXBuildFile; fileRef = 1DFA9D6118F37160008ADC98 /* iTermEditKeyActionWindowController.h */; };
 		1DFA9D7018F3A30F008ADC98 /* PointerPreferencesViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 1DFA9D6E18F3A30F008ADC98 /* PointerPreferencesViewController.h */; };
 		49A6E4091211CC6000D9AD6F /* Compatability.h in Headers */ = {isa = PBXBuildFile; fileRef = 49A6E4081211CC6000D9AD6F /* Compatability.h */; };
+		5370F2EA1C7895F800874C0F /* QLPreviewPanel+iTerm.m in Sources */ = {isa = PBXBuildFile; fileRef = 5370F2E71C78958900874C0F /* QLPreviewPanel+iTerm.m */; };
+		5370F2EB1C7895FD00874C0F /* QLPreviewPanel+iTerm.h in Headers */ = {isa = PBXBuildFile; fileRef = 5370F2E61C78958900874C0F /* QLPreviewPanel+iTerm.h */; };
 		5ECE005F1454E59B004861E9 /* PseudoTerminalRestorer.h in Headers */ = {isa = PBXBuildFile; fileRef = 5ECE005D1454E59B004861E9 /* PseudoTerminalRestorer.h */; };
 		5ECE4AE814513F05002A9CC2 /* Growl.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5ECE4AC41451343E002A9CC2 /* Growl.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		5ECE4AEA14514058002A9CC2 /* Growl Registration Ticket.growlRegDict in Resources */ = {isa = PBXBuildFile; fileRef = 5ECE4AE914514058002A9CC2 /* Growl Registration Ticket.growlRegDict */; };
@@ -2156,6 +2158,8 @@
 		20E74F4804E9089700000106 /* ITAddressBookMgr.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.h; path = ITAddressBookMgr.h; sourceTree = "<group>"; tabWidth = 4; };
 		20E74F4904E9089700000106 /* ITAddressBookMgr.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.objc; path = ITAddressBookMgr.m; sourceTree = "<group>"; tabWidth = 4; };
 		49A6E4081211CC6000D9AD6F /* Compatability.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Compatability.h; sourceTree = "<group>"; };
+		5370F2E61C78958900874C0F /* QLPreviewPanel+iTerm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "QLPreviewPanel+iTerm.h"; sourceTree = "<group>"; };
+		5370F2E71C78958900874C0F /* QLPreviewPanel+iTerm.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "QLPreviewPanel+iTerm.m"; sourceTree = "<group>"; };
 		5BC84AA2F3A178CCEF36EB64 /* Pods-iTerm2XCTests.nightly.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iTerm2XCTests.nightly.xcconfig"; path = "Pods/Target Support Files/Pods-iTerm2XCTests/Pods-iTerm2XCTests.nightly.xcconfig"; sourceTree = "<group>"; };
 		5ECE005D1454E59B004861E9 /* PseudoTerminalRestorer.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.h; path = PseudoTerminalRestorer.h; sourceTree = "<group>"; tabWidth = 4; };
 		5ECE005E1454E59B004861E9 /* PseudoTerminalRestorer.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.objc; path = PseudoTerminalRestorer.m; sourceTree = "<group>"; tabWidth = 4; };
@@ -3777,6 +3781,8 @@
 				A667F38A1B48AEF200705186 /* NSApplication+iTerm.m */,
 				1D300BA81BD9A8BB002043F7 /* NSDate+iTerm.h */,
 				1D300BA91BD9A8BB002043F7 /* NSDate+iTerm.m */,
+				5370F2E61C78958900874C0F /* QLPreviewPanel+iTerm.h */,
+				5370F2E71C78958900874C0F /* QLPreviewPanel+iTerm.m */,
 			);
 			name = Categories;
 			sourceTree = "<group>";
@@ -5121,6 +5127,7 @@
 				1DF121091C344DF100E39F1F /* iTermDynamicProfileManager.h in Headers */,
 				A6F981CC1C13783C00EE0B80 /* iTermCPS.h in Headers */,
 				A62C3B421BD40E7C00B5629D /* iTermImageMark.h in Headers */,
+				5370F2EB1C7895FD00874C0F /* QLPreviewPanel+iTerm.h in Headers */,
 				A62C3B2B1BCC24AB00B5629D /* iTermCommandHistoryCommandUseMO+CoreDataProperties.h in Headers */,
 				A62C3B251BCC24AB00B5629D /* iTermCommandHistoryEntryMO.h in Headers */,
 				1DE0C8451BF17397008ACBA9 /* SetHostnameTrigger.h in Headers */,
@@ -6029,6 +6036,7 @@
 				A6C763DB1B45C6DD00E3C992 /* PSMDarkTabStyle.m in Sources */,
 				A6C763B01B45C52B00E3C992 /* GrowlTrigger.m in Sources */,
 				A6C762D11B45C52B00E3C992 /* iTermSemanticHistoryController.m in Sources */,
+				5370F2EA1C7895F800874C0F /* QLPreviewPanel+iTerm.m in Sources */,
 				A6C762D61B45C52B00E3C992 /* LineBufferPosition.m in Sources */,
 				A6C762BA1B45C52B00E3C992 /* NSMutableData+iTerm.m in Sources */,
 				A6C763941B45C52B00E3C992 /* iTermFileDescriptorSocketPath.c in Sources */,

--- a/sources/PTYSession.m
+++ b/sources/PTYSession.m
@@ -3735,8 +3735,8 @@ static const NSTimeInterval kAntiIdleGracePeriod = 0.1;
         [[ProfileModel sessionsInstance] setBookmark:[self profile] withGuid:guid];
 
         // Update an existing one-bookmark prefs dialog, if open.
-        if (PreferencePanel.sessionsInstance.windowIfLoaded.isVisible) {
-            [PreferencePanel.sessionsInstance underlyingBookmarkDidChange];
+        if ([PreferencePanel sessionsInstance].windowIfLoaded.isVisible) {
+            [[PreferencePanel sessionsInstance] underlyingBookmarkDidChange];
         }
     }
 }

--- a/sources/PTYSession.m
+++ b/sources/PTYSession.m
@@ -3735,8 +3735,8 @@ static const NSTimeInterval kAntiIdleGracePeriod = 0.1;
         [[ProfileModel sessionsInstance] setBookmark:[self profile] withGuid:guid];
 
         // Update an existing one-bookmark prefs dialog, if open.
-        if ([[[PreferencePanel sessionsInstance] window] isVisible]) {
-            [[PreferencePanel sessionsInstance] underlyingBookmarkDidChange];
+        if (PreferencePanel.sessionsInstance.windowIfLoaded.isVisible) {
+            [PreferencePanel.sessionsInstance underlyingBookmarkDidChange];
         }
     }
 }

--- a/sources/PTYTextView.m
+++ b/sources/PTYTextView.m
@@ -710,10 +710,10 @@ static const int kDragThreshold = 3;
 
 - (void)changeFont:(id)fontManager
 {
-    if (PreferencePanel.sharedInstance.windowIfLoaded.isVisible) {
-        [PreferencePanel.sharedInstance changeFont:fontManager];
-    } else if (PreferencePanel.sessionsInstance.windowIfLoaded.isVisible) {
-        [PreferencePanel.sessionsInstance changeFont:fontManager];
+    if ([PreferencePanel sharedInstance].windowIfLoaded.isVisible) {
+        [[PreferencePanel sharedInstance] changeFont:fontManager];
+    } else if ([PreferencePanel sessionsInstance].windowIfLoaded.isVisible) {
+        [[PreferencePanel sessionsInstance] changeFont:fontManager];
     }
 }
 

--- a/sources/PTYTextView.m
+++ b/sources/PTYTextView.m
@@ -710,10 +710,10 @@ static const int kDragThreshold = 3;
 
 - (void)changeFont:(id)fontManager
 {
-    if ([[[PreferencePanel sharedInstance] window] isVisible]) {
-        [[PreferencePanel sharedInstance] changeFont:fontManager];
-    } else if ([[[PreferencePanel sessionsInstance] window] isVisible]) {
-        [[PreferencePanel sessionsInstance] changeFont:fontManager];
+    if (PreferencePanel.sharedInstance.windowIfLoaded.isVisible) {
+        [PreferencePanel.sharedInstance changeFont:fontManager];
+    } else if (PreferencePanel.sessionsInstance.windowIfLoaded.isVisible) {
+        [PreferencePanel.sessionsInstance changeFont:fontManager];
     }
 }
 

--- a/sources/PreferenceInfo.m
+++ b/sources/PreferenceInfo.m
@@ -34,6 +34,8 @@
     [_shouldBeEnabled release];
     [_onChange release];
     [_customSettingChangedHandler release];
+    [_onUpdate release];
+    [_observer release];
     [super dealloc];
 }
 
@@ -42,10 +44,10 @@
     _observer = [observer copy];
     // Call the observer after a delayed perform so that the current profile can be set and then the
     // control's value gets initialized.
-    [self performSelector:@selector(callObserver) withObject:nil afterDelay:0];
+    [self _callObserver];
 }
 
-- (void)callObserver {
+- (void)_callObserver {
     if (self.observer) {
         self.observer();
     }

--- a/sources/PreferenceInfo.m
+++ b/sources/PreferenceInfo.m
@@ -8,6 +8,8 @@
 
 #import "PreferenceInfo.h"
 
+extern NSString *const kPreferencePanelDidLoadNotification;
+
 @implementation PreferenceInfo
 
 + (instancetype)infoForPreferenceWithKey:(NSString *)key
@@ -42,12 +44,16 @@
 - (void)setObserver:(void (^)())observer {
     [_observer autorelease];
     _observer = [observer copy];
-    // Call the observer after a delayed perform so that the current profile can be set and then the
-    // control's value gets initialized.
-    [self _callObserver];
+    // wait until the control is properly set up and then update its value
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(_preferencePanelDidLoad:)
+                                                 name:kPreferencePanelDidLoadNotification
+                                               object:nil];
 }
 
-- (void)_callObserver {
+- (void)_preferencePanelDidLoad:(NSNotification *)notification
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:kPreferencePanelDidLoadNotification object:nil];
     if (self.observer) {
         self.observer();
     }

--- a/sources/PreferencePanel.h
+++ b/sources/PreferencePanel.h
@@ -38,6 +38,7 @@ extern NSString *const kUpdateLabelsNotification;
 extern NSString *const kKeyBindingsChangedNotification;
 extern NSString *const kPreferencePanelDidUpdateProfileFields;
 extern NSString *const kSessionProfileDidChange;  // Posted by a session when it changes to update the Get Info window.
+extern NSString *const kPreferencePanelWillCloseNotification;
 
 // All profiles should be reloaded.
 extern NSString *const kReloadAllProfiles;
@@ -82,6 +83,8 @@ void LoadPrefsFromCustomFolder(void);
 - (IBAction)showMouseTabView:(id)sender;
 
 - (void)underlyingBookmarkDidChange;
+
+- (NSWindow *)windowIfLoaded;
 
 - (WindowArrangements *)arrangements;
 - (void)run;

--- a/sources/PreferencePanel.h
+++ b/sources/PreferencePanel.h
@@ -38,6 +38,7 @@ extern NSString *const kUpdateLabelsNotification;
 extern NSString *const kKeyBindingsChangedNotification;
 extern NSString *const kPreferencePanelDidUpdateProfileFields;
 extern NSString *const kSessionProfileDidChange;  // Posted by a session when it changes to update the Get Info window.
+extern NSString *const kPreferencePanelDidLoadNotification;
 extern NSString *const kPreferencePanelWillCloseNotification;
 
 // All profiles should be reloaded.
@@ -72,6 +73,8 @@ void LoadPrefsFromCustomFolder(void);
 
 + (instancetype)sharedInstance;
 + (instancetype)sessionsInstance;
+
+- (instancetype)initWithProfileModel:(ProfileModel*)model editCurrentSessionMode:(BOOL)editCurrentSessionMode;
 
 - (void)openToProfileWithGuid:(NSString*)guid selectGeneralTab:(BOOL)selectGeneralTab;
 

--- a/sources/PseudoTerminal.m
+++ b/sources/PseudoTerminal.m
@@ -2360,7 +2360,8 @@ static NSString* TERMINAL_ARRANGEMENT_HIDING_TOOLBELT_SHOULD_RESIZE_WINDOW = @"H
                withObject:nil
                afterDelay:0];
     [[NSNotificationCenter defaultCenter] postNotificationName:kCurrentSessionDidChange object:nil];
-    if ([[[PreferencePanel sessionsInstance] window] isVisible]) {
+    NSWindow *window = [PreferencePanel sessionsInstance].windowIfLoaded;
+    if (window && window.isVisible) {
         [self editSession:self.currentSession makeKey:NO];
     }
     [self notifyTmuxOfTabChange];
@@ -3669,7 +3670,7 @@ static NSString* TERMINAL_ARRANGEMENT_HIDING_TOOLBELT_SHOULD_RESIZE_WINDOW = @"H
     NSString *newGuid = [session divorceAddressBookEntryFromPreferences];
     [[PreferencePanel sessionsInstance] openToProfileWithGuid:newGuid selectGeneralTab:makeKey];
     if (makeKey) {
-        [[[PreferencePanel sessionsInstance] window] makeKeyAndOrderFront:nil];
+        [PreferencePanel.sessionsInstance.windowIfLoaded makeKeyAndOrderFront:nil];
     }
 }
 
@@ -3837,7 +3838,8 @@ static NSString* TERMINAL_ARRANGEMENT_HIDING_TOOLBELT_SHOULD_RESIZE_WINDOW = @"H
     [self updateTabColors];
     [[NSNotificationCenter defaultCenter] postNotificationName:kCurrentSessionDidChange object:nil];
     [self notifyTmuxOfTabChange];
-    if ([[[PreferencePanel sessionsInstance] window] isVisible]) {
+    NSWindow *window = [PreferencePanel sessionsInstance].windowIfLoaded;
+    if (window && window.isVisible) {
         [self editSession:self.currentSession makeKey:NO];
     }
 }
@@ -5202,7 +5204,8 @@ static NSString* TERMINAL_ARRANGEMENT_HIDING_TOOLBELT_SHOULD_RESIZE_WINDOW = @"H
     }
     [[_contentView.toolbelt commandHistoryView] updateCommands];
     [[NSNotificationCenter defaultCenter] postNotificationName:kCurrentSessionDidChange object:nil];
-    if ([[[PreferencePanel sessionsInstance] window] isVisible]) {
+    NSWindow *window = [PreferencePanel sessionsInstance].windowIfLoaded;
+    if (window && window.isVisible) {
         [self editSession:self.currentSession makeKey:NO];
     }
 }
@@ -6882,9 +6885,9 @@ static NSString* TERMINAL_ARRANGEMENT_HIDING_TOOLBELT_SHOULD_RESIZE_WINDOW = @"H
                 [session setDefaultName:[profile objectForKey:KEY_NAME]];
             }
             if ([session isDivorced] &&
-                [[[PreferencePanel sessionsInstance] currentProfileGuid] isEqualToString:guid] &&
-                [[[PreferencePanel sessionsInstance] window] isVisible]) {
-                [[PreferencePanel sessionsInstance] underlyingBookmarkDidChange];
+                [PreferencePanel.sessionsInstance.currentProfileGuid isEqualToString:guid] &&
+                 PreferencePanel.sessionsInstance.windowIfLoaded.isVisible) {
+                [PreferencePanel.sessionsInstance underlyingBookmarkDidChange];
             }
         }
         [oldName release];
@@ -7269,11 +7272,11 @@ static NSString* TERMINAL_ARRANGEMENT_HIDING_TOOLBELT_SHOULD_RESIZE_WINDOW = @"H
         _directoriesPopupWindowController.delegate = nil;
     }
     [[NSNotificationCenter defaultCenter] postNotificationName:kCurrentSessionDidChange object:nil];
-    if ([[[PreferencePanel sessionsInstance] window] isVisible]) {
+    if (PreferencePanel.sessionsInstance.windowIfLoaded.isVisible) {
         if (self.currentSession) {
             [self editSession:self.currentSession makeKey:NO];
         } else {
-            [[[PreferencePanel sessionsInstance] window] close];
+            [PreferencePanel.sessionsInstance.windowIfLoaded close];
         }
     }
 }

--- a/sources/PseudoTerminal.m
+++ b/sources/PseudoTerminal.m
@@ -3670,7 +3670,7 @@ static NSString* TERMINAL_ARRANGEMENT_HIDING_TOOLBELT_SHOULD_RESIZE_WINDOW = @"H
     NSString *newGuid = [session divorceAddressBookEntryFromPreferences];
     [[PreferencePanel sessionsInstance] openToProfileWithGuid:newGuid selectGeneralTab:makeKey];
     if (makeKey) {
-        [PreferencePanel.sessionsInstance.windowIfLoaded makeKeyAndOrderFront:nil];
+        [[PreferencePanel sessionsInstance].windowIfLoaded makeKeyAndOrderFront:nil];
     }
 }
 
@@ -6885,9 +6885,9 @@ static NSString* TERMINAL_ARRANGEMENT_HIDING_TOOLBELT_SHOULD_RESIZE_WINDOW = @"H
                 [session setDefaultName:[profile objectForKey:KEY_NAME]];
             }
             if ([session isDivorced] &&
-                [PreferencePanel.sessionsInstance.currentProfileGuid isEqualToString:guid] &&
-                 PreferencePanel.sessionsInstance.windowIfLoaded.isVisible) {
-                [PreferencePanel.sessionsInstance underlyingBookmarkDidChange];
+                [[PreferencePanel sessionsInstance].currentProfileGuid isEqualToString:guid] &&
+                 [PreferencePanel sessionsInstance].windowIfLoaded.isVisible) {
+                [[PreferencePanel sessionsInstance] underlyingBookmarkDidChange];
             }
         }
         [oldName release];
@@ -7272,11 +7272,11 @@ static NSString* TERMINAL_ARRANGEMENT_HIDING_TOOLBELT_SHOULD_RESIZE_WINDOW = @"H
         _directoriesPopupWindowController.delegate = nil;
     }
     [[NSNotificationCenter defaultCenter] postNotificationName:kCurrentSessionDidChange object:nil];
-    if (PreferencePanel.sessionsInstance.windowIfLoaded.isVisible) {
+    if ([PreferencePanel sessionsInstance].windowIfLoaded.isVisible) {
         if (self.currentSession) {
             [self editSession:self.currentSession makeKey:NO];
         } else {
-            [PreferencePanel.sessionsInstance.windowIfLoaded close];
+            [[PreferencePanel sessionsInstance].windowIfLoaded close];
         }
     }
 }

--- a/sources/QLPreviewPanel+iTerm.h
+++ b/sources/QLPreviewPanel+iTerm.h
@@ -1,0 +1,15 @@
+//
+//  QLPreviewPanel+iTerm.h
+//  iTerm2
+//
+//  Created by Rony Fadel on 2/20/16.
+//
+//
+
+#import <Quartz/Quartz.h>
+
+@interface QLPreviewPanel (iTerm)
+
++ (instancetype)sharedPreviewPanelIfExists;
+
+@end

--- a/sources/QLPreviewPanel+iTerm.m
+++ b/sources/QLPreviewPanel+iTerm.m
@@ -1,0 +1,22 @@
+//
+//  QLPreviewPanel+iTerm.m
+//  iTerm2
+//
+//  Created by Rony Fadel on 2/20/16.
+//
+//
+
+#import "QLPreviewPanel+iTerm.h"
+
+@implementation QLPreviewPanel (iTerm)
+
++ (instancetype)sharedPreviewPanelIfExists
+{
+    if ([QLPreviewPanel sharedPreviewPanelExists]) {
+        return [QLPreviewPanel sharedPreviewPanel];
+    } else {
+        return nil;
+    }
+}
+
+@end

--- a/sources/iTermApplication.h
+++ b/sources/iTermApplication.h
@@ -30,6 +30,7 @@
 
 #import <Cocoa/Cocoa.h>
 
+@class PreferencePanel;
 @class iTermApplicationDelegate;
 
 @interface iTermApplication : NSApplication

--- a/sources/iTermApplication.m
+++ b/sources/iTermApplication.m
@@ -39,6 +39,7 @@
 #import "PTYTab.h"
 #import "PTYTextView.h"
 #import "PTYWindow.h"
+#import "PreferencePanel.h"
 
 @implementation iTermApplication
 
@@ -222,4 +223,3 @@
 }
 
 @end
-

--- a/sources/iTermApplicationDelegate.h
+++ b/sources/iTermApplicationDelegate.h
@@ -136,4 +136,8 @@ int DebugLogImpl(const char *file, int line, const char *function, NSString* val
 - (PseudoTerminal *)currentTerminal;
 - (NSArray*)terminals;
 
+// Preference panels
+- (PreferencePanel *)sharedPreferencePanel;
+- (PreferencePanel *)sessionsPreferencePanel;
+
 @end

--- a/sources/iTermApplicationDelegate.m
+++ b/sources/iTermApplicationDelegate.m
@@ -150,6 +150,9 @@ static BOOL hasBecomeActive = NO;
     id<NSObject> _appNapStoppingActivity;
 
     BOOL _sparkleRestarting;  // Is Sparkle about to restart the app?
+
+    PreferencePanel *_sharedPreferencePanel;
+    PreferencePanel *_sessionsPreferencePanel;
 }
 
 // NSApplication delegate methods
@@ -659,6 +662,10 @@ static BOOL hasBecomeActive = NO;
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(currentSessionDidChange)
                                                      name:kCurrentSessionDidChange
+                                                   object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(preferencePanelWillClose:)
+                                                     name:kPreferencePanelWillCloseNotification
                                                    object:nil];
         [[NSAppleEventManager sharedAppleEventManager] setEventHandler:self
                                                            andSelector:@selector(getUrl:withReplyEvent:)
@@ -1701,6 +1708,35 @@ static BOOL hasBecomeActive = NO;
 
 - (NSArray*)terminals {
     return [[iTermController sharedInstance] terminals];
+}
+
+- (void)preferencePanelWillClose:(NSNotification *)notification
+{
+    if (notification.object == _sharedPreferencePanel) {
+        [_sharedPreferencePanel release];
+        _sharedPreferencePanel = nil;
+    } else if (notification.object == _sessionsPreferencePanel) {
+        [_sessionsPreferencePanel release];
+        _sessionsPreferencePanel = nil;
+    }
+}
+
+- (PreferencePanel *)sharedPreferencePanel
+{
+    if (!_sharedPreferencePanel) {
+        _sharedPreferencePanel = [[PreferencePanel alloc] initWithProfileModel:[ProfileModel sharedInstance]
+                                                        editCurrentSessionMode:NO];
+    }
+    return _sharedPreferencePanel;
+}
+
+- (PreferencePanel *)sessionsPreferencePanel
+{
+    if (!_sessionsPreferencePanel) {
+        _sessionsPreferencePanel = [[PreferencePanel alloc] initWithProfileModel:[ProfileModel sessionsInstance]
+                                                          editCurrentSessionMode:YES];
+    }
+    return _sessionsPreferencePanel;
 }
 
 @end

--- a/sources/iTermApplicationDelegate.m
+++ b/sources/iTermApplicationDelegate.m
@@ -64,6 +64,7 @@
 #import "Sparkle/SUUpdater.h"
 #import "ToastWindowController.h"
 #import "VT100Terminal.h"
+#import "QLPreviewPanel+iTerm.h"
 
 #import <Quartz/Quartz.h>
 #import <objc/runtime.h>
@@ -1684,10 +1685,13 @@ static BOOL hasBecomeActive = NO;
 
 - (void)currentSessionDidChange {
     [_passwordManagerWindowController update];
-    QLPreviewPanel *panel = [QLPreviewPanel sharedPreviewPanel];
     PseudoTerminal *currentWindow = [[iTermController sharedInstance] currentTerminal];
-    if (panel.currentController == currentWindow) {
-        [currentWindow.currentSession.quickLookController takeControl];
+    iTermQuickLookController *quickLookController = currentWindow.currentSession.quickLookController;
+    if (quickLookController) {
+        QLPreviewPanel *panel = [QLPreviewPanel sharedPreviewPanelIfExists];
+        if (panel.currentController == currentWindow) {
+            [quickLookController takeControl];
+        }
     }
 }
 

--- a/sources/iTermPreferencesBaseViewController.m
+++ b/sources/iTermPreferencesBaseViewController.m
@@ -45,6 +45,11 @@ static NSString *const kKey = @"key";
                                                  selector:@selector(preferenceDidChangeFromOtherPanel:)
                                                      name:kPreferenceDidChangeFromOtherPanel
                                                    object:nil];
+
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(preferencePanelWillClose:)
+                                                     name:kPreferencePanelWillCloseNotification
+                                                   object:nil];
     }
     return self;
 }
@@ -512,6 +517,12 @@ static NSString *const kKey = @"key";
     PreferenceInfo *info = [self infoForKey:key];
     assert(info);
     [self updateValueForInfo:info];
+}
+
+- (void)preferencePanelWillClose:(NSNotification *)notification {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+    // breaks reference cycles in settingChanged and update blocks
+    [_keyMap removeAllObjects];
 }
 
 @end

--- a/sources/iTermQuickLookController.m
+++ b/sources/iTermQuickLookController.m
@@ -7,7 +7,7 @@
 //
 
 #import "iTermQuickLookController.h"
-#import <Quartz/Quartz.h>
+#import "QLPreviewPanel+iTerm.h"
 
 @interface iTermQuickLookController() <QLPreviewPanelDataSource, QLPreviewPanelDelegate>
 @property(nonatomic, retain) NSMutableArray<NSURL *> *files;
@@ -22,9 +22,10 @@
 @implementation iTermQuickLookController
 
 + (void)dismissSharedPanel {
-  if ([[QLPreviewPanel sharedPreviewPanel] isVisible]) {
-    [[QLPreviewPanel sharedPreviewPanel] orderOut:nil];
-  }
+    QLPreviewPanel *panel = [QLPreviewPanel sharedPreviewPanelIfExists];
+    if ([panel isVisible]) {
+        [panel orderOut:nil];
+    }
 }
 
 - (void)dealloc {
@@ -60,11 +61,11 @@
 }
 
 - (void)close {
-  QLPreviewPanel *panel = [QLPreviewPanel sharedPreviewPanel];
-  if ([panel isVisible] &&
-      [panel delegate] == self) {
-    [panel orderOut:nil];
-  }
+    QLPreviewPanel *panel = [QLPreviewPanel sharedPreviewPanelIfExists];
+    if ([panel isVisible] &&
+        [panel delegate] == self) {
+        [panel orderOut:nil];
+    }
 }
 
 - (void)takeControl {


### PR DESCRIPTION
One thing I'm not too happy about is the following:

-    [self performSelector:@selector(callObserver) withObject:nil afterDelay:0];

Can we find a cleaner pattern for this, instead of performing after delay?

Thanks!