### PR TITLE
Feature - Toggle: Only apply transparency to default bg

### DIFF
--- a/Interfaces/PreferencePanel.xib
+++ b/Interfaces/PreferencePanel.xib
@@ -2615,11 +2615,11 @@ DQ
             <point key="canvasLocation" x="-62.5" y="288.5"/>
         </customView>
         <customView id="77f-eM-Dma" userLabel="Prefs - Profiles - Window" customClass="iTermSizeRememberingView">
-            <rect key="frame" x="0.0" y="0.0" width="559" height="424"/>
+            <rect key="frame" x="0.0" y="0.0" width="559" height="437"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <textField verticalHuggingPriority="750" id="4911">
-                    <rect key="frame" x="94" y="174" width="130" height="22"/>
+                    <rect key="frame" x="94" y="187" width="130" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" continuous="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" usesSingleLineMode="YES" id="4951">
                         <font key="font" metaFont="system"/>
@@ -2632,7 +2632,7 @@ DQ
                     </connections>
                 </textField>
                 <textField verticalHuggingPriority="750" id="4912">
-                    <rect key="frame" x="28" y="174" width="67" height="19"/>
+                    <rect key="frame" x="28" y="187" width="67" height="19"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Columns:" id="4950">
                         <font key="font" metaFont="system"/>
@@ -2641,7 +2641,7 @@ DQ
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" id="4913">
-                    <rect key="frame" x="51" y="144" width="44" height="19"/>
+                    <rect key="frame" x="51" y="157" width="44" height="19"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Rows:" id="4949">
                         <font key="font" metaFont="system"/>
@@ -2650,7 +2650,7 @@ DQ
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" id="4914">
-                    <rect key="frame" x="94" y="144" width="130" height="22"/>
+                    <rect key="frame" x="94" y="157" width="130" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="4947">
                         <font key="font" metaFont="system"/>
@@ -2663,7 +2663,7 @@ DQ
                     </connections>
                 </textField>
                 <textField verticalHuggingPriority="750" id="4992">
-                    <rect key="frame" x="15" y="204" width="190" height="20"/>
+                    <rect key="frame" x="15" y="217" width="190" height="20"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Settings for New Windows" id="4993">
                         <font key="font" metaFont="systemBold"/>
@@ -2672,7 +2672,7 @@ DQ
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" id="4916">
-                    <rect key="frame" x="324" y="172" width="221" height="26"/>
+                    <rect key="frame" x="324" y="185" width="221" height="26"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <popUpButtonCell key="cell" type="push" title="Fullscreen" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="1" imageScaling="proportionallyDown" inset="2" selectedItem="4944" id="4941">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -2701,7 +2701,7 @@ DQ
                     </connections>
                 </popUpButton>
                 <popUpButton verticalHuggingPriority="750" id="4917">
-                    <rect key="frame" x="324" y="146" width="221" height="26"/>
+                    <rect key="frame" x="324" y="159" width="221" height="26"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <popUpButtonCell key="cell" type="push" alternateTitle="Current Screen" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" id="4939">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -2714,7 +2714,7 @@ DQ
                     </connections>
                 </popUpButton>
                 <textField verticalHuggingPriority="750" id="4918">
-                    <rect key="frame" x="284" y="178" width="41" height="17"/>
+                    <rect key="frame" x="284" y="191" width="41" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Style:" id="4938">
                         <font key="font" metaFont="system"/>
@@ -2723,7 +2723,7 @@ DQ
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" id="4919">
-                    <rect key="frame" x="272" y="152" width="53" height="17"/>
+                    <rect key="frame" x="272" y="165" width="53" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Screen:" id="4937">
                         <font key="font" metaFont="system"/>
@@ -2732,7 +2732,7 @@ DQ
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" id="4920">
-                    <rect key="frame" x="272" y="126" width="53" height="17"/>
+                    <rect key="frame" x="272" y="139" width="53" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Space:" id="4936">
                         <font key="font" metaFont="system"/>
@@ -2741,7 +2741,7 @@ DQ
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" id="4921">
-                    <rect key="frame" x="323" y="119" width="222" height="26"/>
+                    <rect key="frame" x="323" y="132" width="222" height="26"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <popUpButtonCell key="cell" type="push" title="Current Space" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="4935" id="4922">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -2769,7 +2769,7 @@ DQ
                     </connections>
                 </popUpButton>
                 <button id="4973">
-                    <rect key="frame" x="275" y="375" width="144" height="18"/>
+                    <rect key="frame" x="275" y="388" width="144" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Background Image:" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="4988">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -2781,7 +2781,7 @@ DQ
                     </connections>
                 </button>
                 <button toolTip="Tessellates the image instead of stretching it." id="6395">
-                    <rect key="frame" x="297" y="255" width="88" height="18"/>
+                    <rect key="frame" x="297" y="268" width="88" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Tile image" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="6396">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -2793,7 +2793,7 @@ DQ
                     </connections>
                 </button>
                 <imageView id="4974" customClass="iTermImageWell">
-                    <rect key="frame" x="296" y="276" width="249" height="96"/>
+                    <rect key="frame" x="296" y="289" width="249" height="96"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <imageCell key="cell" selectable="YES" editable="YES" alignment="left" imageScaling="proportionallyDown" imageFrameStyle="grayBezel" id="4987"/>
                     <connections>
@@ -2801,7 +2801,7 @@ DQ
                     </connections>
                 </imageView>
                 <textField verticalHuggingPriority="750" id="4975">
-                    <rect key="frame" x="15" y="359" width="97" height="34"/>
+                    <rect key="frame" x="15" y="372" width="97" height="34"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Transparency:" id="4986">
                         <font key="font" metaFont="system"/>
@@ -2810,7 +2810,7 @@ DQ
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" id="6324">
-                    <rect key="frame" x="296" y="232" width="68" height="17"/>
+                    <rect key="frame" x="296" y="245" width="68" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Blending:" id="6325">
                         <font key="font" metaFont="system"/>
@@ -2819,7 +2819,7 @@ DQ
                     </textFieldCell>
                 </textField>
                 <button id="4976">
-                    <rect key="frame" x="15" y="316" width="63" height="18"/>
+                    <rect key="frame" x="15" y="329" width="63" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Blur:" bezelStyle="regularSquare" imagePosition="left" alignment="left" continuous="YES" inset="2" id="4985">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -2830,7 +2830,7 @@ DQ
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" id="4977">
-                    <rect key="frame" x="15" y="401" width="146" height="20"/>
+                    <rect key="frame" x="15" y="414" width="146" height="20"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Window Appearance" id="4984">
                         <font key="font" metaFont="systemBold"/>
@@ -2839,7 +2839,7 @@ DQ
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" id="6327">
-                    <rect key="frame" x="275" y="401" width="146" height="20"/>
+                    <rect key="frame" x="275" y="414" width="146" height="20"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Background Image" id="6328">
                         <font key="font" metaFont="systemBold"/>
@@ -2848,7 +2848,7 @@ DQ
                     </textFieldCell>
                 </textField>
                 <slider verticalHuggingPriority="750" id="4978">
-                    <rect key="frame" x="36" y="355" width="190" height="21"/>
+                    <rect key="frame" x="36" y="368" width="190" height="21"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <sliderCell key="cell" continuous="YES" alignment="left" maxValue="0.90000000000000002" tickMarkPosition="below" sliderType="linear" id="4983"/>
                     <connections>
@@ -2857,7 +2857,7 @@ DQ
                     </connections>
                 </slider>
                 <textField verticalHuggingPriority="750" id="4979">
-                    <rect key="frame" x="35" y="340" width="53" height="11"/>
+                    <rect key="frame" x="35" y="353" width="53" height="11"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Opaque" id="4982">
                         <font key="font" metaFont="miniSystem"/>
@@ -2866,7 +2866,7 @@ DQ
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" id="4980">
-                    <rect key="frame" x="168" y="340" width="58" height="11"/>
+                    <rect key="frame" x="168" y="353" width="58" height="11"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Transparent" id="4981">
                         <font key="font" metaFont="miniSystem"/>
@@ -2875,7 +2875,7 @@ DQ
                     </textFieldCell>
                 </textField>
                 <slider verticalHuggingPriority="750" id="5363">
-                    <rect key="frame" x="36" y="291" width="190" height="21"/>
+                    <rect key="frame" x="36" y="304" width="190" height="21"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <sliderCell key="cell" continuous="YES" alignment="left" minValue="0.10000000000000001" maxValue="30" doubleValue="0.10000000000000001" tickMarkPosition="below" sliderType="linear" id="5368"/>
                     <connections>
@@ -2884,7 +2884,7 @@ DQ
                     </connections>
                 </slider>
                 <textField verticalHuggingPriority="750" id="5364">
-                    <rect key="frame" x="35" y="276" width="61" height="11"/>
+                    <rect key="frame" x="35" y="289" width="61" height="11"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Small Radius" id="5367">
                         <font key="font" metaFont="miniSystem"/>
@@ -2893,7 +2893,7 @@ DQ
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" id="5365">
-                    <rect key="frame" x="164" y="276" width="62" height="11"/>
+                    <rect key="frame" x="164" y="289" width="62" height="11"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Large Radius" id="5366">
                         <font key="font" metaFont="miniSystem"/>
@@ -2902,7 +2902,7 @@ DQ
                     </textFieldCell>
                 </textField>
                 <button id="6416">
-                    <rect key="frame" x="15" y="18" width="389" height="18"/>
+                    <rect key="frame" x="15" y="31" width="389" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Force this profile to open in a new window, never in a tab." bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="6417">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -2914,7 +2914,7 @@ DQ
                     </connections>
                 </button>
                 <button toolTip="Enable this to prevent title changes originated by an escape code from removing the profile name from the tab title." id="5008">
-                    <rect key="frame" x="15" y="40" width="458" height="18"/>
+                    <rect key="frame" x="15" y="53" width="458" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="If showing profile name in tab title, keep it when the title is changed" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="5009">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -2925,7 +2925,7 @@ DQ
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" id="5012">
-                    <rect key="frame" x="15" y="64" width="105" height="20"/>
+                    <rect key="frame" x="15" y="77" width="105" height="20"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Miscellaneous" id="5013">
                         <font key="font" metaFont="systemBold"/>
@@ -2934,7 +2934,7 @@ DQ
                     </textFieldCell>
                 </textField>
                 <slider toolTip="How much of the background image is visible through the background color." verticalHuggingPriority="750" id="6320">
-                    <rect key="frame" x="367" y="230" width="177" height="21"/>
+                    <rect key="frame" x="367" y="243" width="177" height="21"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <sliderCell key="cell" continuous="YES" alignment="left" minValue="0.050000000000000003" maxValue="1" doubleValue="0.40000000000000002" tickMarkPosition="below" sliderType="linear" id="6321"/>
                     <connections>
@@ -2943,7 +2943,7 @@ DQ
                     </connections>
                 </slider>
                 <button id="6354">
-                    <rect key="frame" x="86" y="120" width="140" height="18"/>
+                    <rect key="frame" x="86" y="133" width="140" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Hide after opening" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="6355">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -2954,7 +2954,7 @@ DQ
                     </connections>
                 </button>
                 <button id="hmf-ta-TMb">
-                    <rect key="frame" x="86" y="100" width="140" height="18"/>
+                    <rect key="frame" x="86" y="113" width="140" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Open Toolbelt" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="hr1-3l-FQW">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>

--- a/Interfaces/PreferencePanel.xib
+++ b/Interfaces/PreferencePanel.xib
@@ -2917,7 +2917,7 @@ DQ
                 <button toolTip="Enable this to make non-default background colors always opaque. This is useful when using Powerline in a translucent window." id="fwj-4Y-nja">
                     <rect key="frame" x="15" y="9" width="389" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <buttonCell key="cell" type="check" title="Only apply transparency to the main background color." bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="sBm-XA-tIi">
+                    <buttonCell key="cell" type="check" title="Only apply transparency to the default background color." bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="sBm-XA-tIi">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>

--- a/Interfaces/PreferencePanel.xib
+++ b/Interfaces/PreferencePanel.xib
@@ -2911,7 +2911,7 @@ DQ
                     </buttonCell>
                     <connections>
                         <action selector="settingChanged:" target="BMA-OA-Kzc" id="VYD-F1-fDI"/>
-                        <outlet property="nextKeyView" destination="4978" id="6418"/>
+                        <outlet property="nextKeyView" destination="fwj-4Y-nja" id="u8P-d1-x0a"/>
                     </connections>
                 </button>
                 <button toolTip="Enable this to prevent background colors for text from being affected by the transparency setting. Useful for having a transparent terminal background but opaque Powerline segments(background) to match opaque Powerline separators(foreground)." id="fwj-4Y-nja">
@@ -2935,6 +2935,7 @@ DQ
                     </buttonCell>
                     <connections>
                         <action selector="settingChanged:" target="BMA-OA-Kzc" id="5jm-v3-jaw"/>
+                        <outlet property="nextKeyView" destination="6416" id="5hh-n9-L6w"/>
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" id="5012">

--- a/Interfaces/PreferencePanel.xib
+++ b/Interfaces/PreferencePanel.xib
@@ -2914,7 +2914,7 @@ DQ
                         <outlet property="nextKeyView" destination="fwj-4Y-nja" id="u8P-d1-x0a"/>
                     </connections>
                 </button>
-                <button toolTip="Enable this to prevent background colors for text from being affected by the transparency setting. Useful for having a transparent terminal background but opaque Powerline segments(background) to match opaque Powerline separators(foreground)." id="fwj-4Y-nja">
+                <button toolTip="Enable this to make non-default background colors always opaque. This is useful when using Powerline in a translucent window." id="fwj-4Y-nja">
                     <rect key="frame" x="15" y="9" width="389" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Only apply transparency to the main background color." bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="sBm-XA-tIi">

--- a/Interfaces/PreferencePanel.xib
+++ b/Interfaces/PreferencePanel.xib
@@ -1486,7 +1486,7 @@ DQ
                 <outlet property="_blurRadius" destination="5363" id="iUQ-8z-lyV"/>
                 <outlet property="_columnsField" destination="4911" id="X3h-Pu-qzV"/>
                 <outlet property="_columnsLabel" destination="4912" id="veJ-9B-Jrh"/>
-                <outlet property="_defaultBGAlphaOnly" destination="fwj-4Y-nja" id="caf-eb-abe"/>
+                <outlet property="_transparencyAffectsOnlyDefaultBackgroundColor" destination="fwj-4Y-nja" id="caf-eb-abe"/>
                 <outlet property="_hideAfterOpening" destination="6354" id="ivO-Qa-O3r"/>
                 <outlet property="_openToolbelt" destination="hmf-ta-TMb" id="nOK-vG-n8c"/>
                 <outlet property="_preventTab" destination="6416" id="eRg-47-Fqf"/>

--- a/Interfaces/PreferencePanel.xib
+++ b/Interfaces/PreferencePanel.xib
@@ -1486,6 +1486,7 @@ DQ
                 <outlet property="_blurRadius" destination="5363" id="iUQ-8z-lyV"/>
                 <outlet property="_columnsField" destination="4911" id="X3h-Pu-qzV"/>
                 <outlet property="_columnsLabel" destination="4912" id="veJ-9B-Jrh"/>
+                <outlet property="_defaultBGAlphaOnly" destination="fwj-4Y-nja" id="caf-eb-abe"/>
                 <outlet property="_hideAfterOpening" destination="6354" id="ivO-Qa-O3r"/>
                 <outlet property="_openToolbelt" destination="hmf-ta-TMb" id="nOK-vG-n8c"/>
                 <outlet property="_preventTab" destination="6416" id="eRg-47-Fqf"/>
@@ -2911,6 +2912,18 @@ DQ
                     <connections>
                         <action selector="settingChanged:" target="BMA-OA-Kzc" id="VYD-F1-fDI"/>
                         <outlet property="nextKeyView" destination="4978" id="6418"/>
+                    </connections>
+                </button>
+                <button toolTip="Enable this to prevent background colors for text from being affected by the transparency setting. Useful for having a transparent terminal background but opaque Powerline segments(background) to match opaque Powerline separators(foreground)." id="fwj-4Y-nja">
+                    <rect key="frame" x="15" y="9" width="389" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="check" title="Only apply transparency to the main background color." bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="sBm-XA-tIi">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="settingChanged:" target="BMA-OA-Kzc" id="sGR-E1-876"/>
+                        <outlet property="nextKeyView" destination="4978" id="Tpo-gX-6bI"/>
                     </connections>
                 </button>
                 <button toolTip="Enable this to prevent title changes originated by an escape code from removing the profile name from the tab title." id="5008">

--- a/sources/ITAddressBookMgr.h
+++ b/sources/ITAddressBookMgr.h
@@ -139,7 +139,7 @@
 // Terminal
 #define KEY_DISABLE_WINDOW_RESIZING           @"Disable Window Resizing"
 #define KEY_PREVENT_TAB                       @"Prevent Opening in a Tab"
-#define KEY_DEFAULT_BG_ALPHA_ONLY             @"Only The Default BG Color Uses Transparency"
+#define KEY_TRANSPARENCY_AFFECTS_ONLY_DEFAULT_BACKGROUND_COLOR @"Only The Default BG Color Uses Transparency"
 #define KEY_OPEN_TOOLBELT                     @"Open Toolbelt"
 #define KEY_HIDE_AFTER_OPENING                @"Hide After Opening"
 #define KEY_SYNC_TITLE                        @"Sync Title"

--- a/sources/ITAddressBookMgr.h
+++ b/sources/ITAddressBookMgr.h
@@ -139,7 +139,7 @@
 // Terminal
 #define KEY_DISABLE_WINDOW_RESIZING           @"Disable Window Resizing"
 #define KEY_PREVENT_TAB                       @"Prevent Opening in a Tab"
-#define KEY_DEFAULT_BG_ALPHA_ONLY             @"Only The Main BG Color Uses Transparency"
+#define KEY_DEFAULT_BG_ALPHA_ONLY             @"Only The Default BG Color Uses Transparency"
 #define KEY_OPEN_TOOLBELT                     @"Open Toolbelt"
 #define KEY_HIDE_AFTER_OPENING                @"Hide After Opening"
 #define KEY_SYNC_TITLE                        @"Sync Title"

--- a/sources/ITAddressBookMgr.h
+++ b/sources/ITAddressBookMgr.h
@@ -139,6 +139,7 @@
 // Terminal
 #define KEY_DISABLE_WINDOW_RESIZING           @"Disable Window Resizing"
 #define KEY_PREVENT_TAB                       @"Prevent Opening in a Tab"
+#define KEY_DEFAULT_BG_ALPHA_ONLY             @"Only The Main BG Color Uses Transparency"
 #define KEY_OPEN_TOOLBELT                     @"Open Toolbelt"
 #define KEY_HIDE_AFTER_OPENING                @"Hide After Opening"
 #define KEY_SYNC_TITLE                        @"Sync Title"

--- a/sources/PTYSession.m
+++ b/sources/PTYSession.m
@@ -1033,6 +1033,7 @@ ITERM_WEAKLY_REFERENCEABLE
     const float theBlend =
         [_profile objectForKey:KEY_BLEND] ? [[_profile objectForKey:KEY_BLEND] floatValue] : 0.5;
     [self setBlend:theBlend];
+    [self setDefaultBGAlphaOnly:[[_profile objectForKey:KEY_DEFAULT_BG_ALPHA_ONLY] boolValue]];
 
     [_wrapper addSubview:_textview];
     [_textview setFrame:NSMakeRect(0, VMARGIN, aSize.width, aSize.height - VMARGIN)];
@@ -2646,6 +2647,7 @@ ITERM_WEAKLY_REFERENCEABLE
     // transparency
     [self setTransparency:[iTermProfilePreferences floatForKey:KEY_TRANSPARENCY inProfile:aDict]];
     [self setBlend:[iTermProfilePreferences floatForKey:KEY_BLEND inProfile:aDict]];
+    [self setDefaultBGAlphaOnly:[iTermProfilePreferences floatForKey:KEY_DEFAULT_BG_ALPHA_ONLY inProfile:aDict]];
 
     // bold 
     [self setUseBoldFont:[iTermProfilePreferences boolForKey:KEY_USE_BOLD_FONT
@@ -3050,6 +3052,11 @@ ITERM_WEAKLY_REFERENCEABLE
 
 - (void)setBlend:(float)blendVal {
     [_textview setBlend:blendVal];
+}
+
+- (void)setDefaultBGAlphaOnly:(BOOL)value
+{
+    [_textview setDefaultBGAlphaOnly:value];
 }
 
 - (BOOL)antiIdle {

--- a/sources/PTYSession.m
+++ b/sources/PTYSession.m
@@ -1033,7 +1033,7 @@ ITERM_WEAKLY_REFERENCEABLE
     const float theBlend =
         [_profile objectForKey:KEY_BLEND] ? [[_profile objectForKey:KEY_BLEND] floatValue] : 0.5;
     [self setBlend:theBlend];
-    [self setTransparencyAffectsOnlyDefaultBackgroundColor:[[_profile objectForKey:KEY_DEFAULT_BG_ALPHA_ONLY] boolValue]];
+    [self setTransparencyAffectsOnlyDefaultBackgroundColor:[[_profile objectForKey:KEY_TRANSPARENCY_AFFECTS_ONLY_DEFAULT_BACKGROUND_COLOR] boolValue]];
 
     [_wrapper addSubview:_textview];
     [_textview setFrame:NSMakeRect(0, VMARGIN, aSize.width, aSize.height - VMARGIN)];
@@ -2647,7 +2647,7 @@ ITERM_WEAKLY_REFERENCEABLE
     // transparency
     [self setTransparency:[iTermProfilePreferences floatForKey:KEY_TRANSPARENCY inProfile:aDict]];
     [self setBlend:[iTermProfilePreferences floatForKey:KEY_BLEND inProfile:aDict]];
-    [self setTransparencyAffectsOnlyDefaultBackgroundColor:[iTermProfilePreferences floatForKey:KEY_DEFAULT_BG_ALPHA_ONLY inProfile:aDict]];
+    [self setTransparencyAffectsOnlyDefaultBackgroundColor:[iTermProfilePreferences floatForKey:KEY_TRANSPARENCY_AFFECTS_ONLY_DEFAULT_BACKGROUND_COLOR inProfile:aDict]];
 
     // bold 
     [self setUseBoldFont:[iTermProfilePreferences boolForKey:KEY_USE_BOLD_FONT

--- a/sources/PTYSession.m
+++ b/sources/PTYSession.m
@@ -1033,7 +1033,7 @@ ITERM_WEAKLY_REFERENCEABLE
     const float theBlend =
         [_profile objectForKey:KEY_BLEND] ? [[_profile objectForKey:KEY_BLEND] floatValue] : 0.5;
     [self setBlend:theBlend];
-    [self setDefaultBGAlphaOnly:[[_profile objectForKey:KEY_DEFAULT_BG_ALPHA_ONLY] boolValue]];
+    [self setTransparencyAffectsOnlyDefaultBackgroundColor:[[_profile objectForKey:KEY_DEFAULT_BG_ALPHA_ONLY] boolValue]];
 
     [_wrapper addSubview:_textview];
     [_textview setFrame:NSMakeRect(0, VMARGIN, aSize.width, aSize.height - VMARGIN)];
@@ -2647,7 +2647,7 @@ ITERM_WEAKLY_REFERENCEABLE
     // transparency
     [self setTransparency:[iTermProfilePreferences floatForKey:KEY_TRANSPARENCY inProfile:aDict]];
     [self setBlend:[iTermProfilePreferences floatForKey:KEY_BLEND inProfile:aDict]];
-    [self setDefaultBGAlphaOnly:[iTermProfilePreferences floatForKey:KEY_DEFAULT_BG_ALPHA_ONLY inProfile:aDict]];
+    [self setTransparencyAffectsOnlyDefaultBackgroundColor:[iTermProfilePreferences floatForKey:KEY_DEFAULT_BG_ALPHA_ONLY inProfile:aDict]];
 
     // bold 
     [self setUseBoldFont:[iTermProfilePreferences boolForKey:KEY_USE_BOLD_FONT
@@ -3054,9 +3054,9 @@ ITERM_WEAKLY_REFERENCEABLE
     [_textview setBlend:blendVal];
 }
 
-- (void)setDefaultBGAlphaOnly:(BOOL)value
+- (void)setTransparencyAffectsOnlyDefaultBackgroundColor:(BOOL)value
 {
-    [_textview setDefaultBGAlphaOnly:value];
+    [_textview setTransparencyAffectsOnlyDefaultBackgroundColor:value];
 }
 
 - (BOOL)antiIdle {

--- a/sources/PTYTextView.m
+++ b/sources/PTYTextView.m
@@ -5179,6 +5179,11 @@ static double EuclideanDistance(NSPoint p1, NSPoint p2) {
     [self setNeedsDisplay:YES];
 }
 
+- (void)setDefaultBGAlphaOnly:(BOOL)value {
+    _drawingHelper.defaultBGAlphaOnly = value;
+    [self setNeedsDisplay:YES];
+}
+
 - (float)blend {
     return _drawingHelper.blend;
 }

--- a/sources/PTYTextView.m
+++ b/sources/PTYTextView.m
@@ -5179,8 +5179,8 @@ static double EuclideanDistance(NSPoint p1, NSPoint p2) {
     [self setNeedsDisplay:YES];
 }
 
-- (void)setDefaultBGAlphaOnly:(BOOL)value {
-    _drawingHelper.defaultBGAlphaOnly = value;
+- (void)setTransparencyAffectsOnlyDefaultBackgroundColor:(BOOL)value {
+    _drawingHelper.transparencyAffectsOnlyDefaultBackgroundColor = value;
     [self setNeedsDisplay:YES];
 }
 

--- a/sources/ProfilesWindowPreferencesViewController.m
+++ b/sources/ProfilesWindowPreferencesViewController.m
@@ -41,7 +41,7 @@
     IBOutlet NSTextField *_spaceLabel;
     IBOutlet NSButton *_syncTitle;
     IBOutlet NSButton *_preventTab;
-    IBOutlet NSButton *_defaultBGAlphaOnly;
+    IBOutlet NSButton *_transparencyAffectsOnlyDefaultBackgroundColor;
     IBOutlet NSButton *_openToolbelt;
 }
 
@@ -120,7 +120,7 @@
                     key:KEY_PREVENT_TAB
                    type:kPreferenceInfoTypeCheckbox];
 
-   [self defineControl:_defaultBGAlphaOnly
+   [self defineControl:_transparencyAffectsOnlyDefaultBackgroundColor
                    key:KEY_DEFAULT_BG_ALPHA_ONLY
                   type:kPreferenceInfoTypeCheckbox];
 

--- a/sources/ProfilesWindowPreferencesViewController.m
+++ b/sources/ProfilesWindowPreferencesViewController.m
@@ -41,6 +41,7 @@
     IBOutlet NSTextField *_spaceLabel;
     IBOutlet NSButton *_syncTitle;
     IBOutlet NSButton *_preventTab;
+    IBOutlet NSButton *_defaultBGAlphaOnly;
     IBOutlet NSButton *_openToolbelt;
 }
 
@@ -118,6 +119,10 @@
     [self defineControl:_preventTab
                     key:KEY_PREVENT_TAB
                    type:kPreferenceInfoTypeCheckbox];
+
+   [self defineControl:_defaultBGAlphaOnly
+                   key:KEY_DEFAULT_BG_ALPHA_ONLY
+                  type:kPreferenceInfoTypeCheckbox];
 
     [self defineControl:_openToolbelt
                     key:KEY_OPEN_TOOLBELT

--- a/sources/ProfilesWindowPreferencesViewController.m
+++ b/sources/ProfilesWindowPreferencesViewController.m
@@ -120,9 +120,10 @@
                     key:KEY_PREVENT_TAB
                    type:kPreferenceInfoTypeCheckbox];
 
-   [self defineControl:_transparencyAffectsOnlyDefaultBackgroundColor
-                   key:KEY_DEFAULT_BG_ALPHA_ONLY
-                  type:kPreferenceInfoTypeCheckbox];
+   info = [self defineControl:_transparencyAffectsOnlyDefaultBackgroundColor
+                          key:KEY_DEFAULT_BG_ALPHA_ONLY
+                         type:kPreferenceInfoTypeCheckbox];
+   info.observer = ^() { _transparencyAffectsOnlyDefaultBackgroundColor.enabled = (_transparency.doubleValue > 0); };
 
     [self defineControl:_openToolbelt
                     key:KEY_OPEN_TOOLBELT

--- a/sources/ProfilesWindowPreferencesViewController.m
+++ b/sources/ProfilesWindowPreferencesViewController.m
@@ -121,7 +121,7 @@
                    type:kPreferenceInfoTypeCheckbox];
 
    info = [self defineControl:_transparencyAffectsOnlyDefaultBackgroundColor
-                          key:KEY_DEFAULT_BG_ALPHA_ONLY
+                          key:KEY_TRANSPARENCY_AFFECTS_ONLY_DEFAULT_BACKGROUND_COLOR
                          type:kPreferenceInfoTypeCheckbox];
    info.observer = ^() { _transparencyAffectsOnlyDefaultBackgroundColor.enabled = (_transparency.doubleValue > 0); };
 

--- a/sources/iTermProfilePreferences.m
+++ b/sources/iTermProfilePreferences.m
@@ -203,7 +203,7 @@ NSString *const kProfilePreferenceInitialDirectoryAdvancedValue = @"Advanced";
                   KEY_SYNC_TITLE: @NO,
                   KEY_DISABLE_WINDOW_RESIZING: @NO,
                   KEY_PREVENT_TAB: @NO,
-                  KEY_DEFAULT_BG_ALPHA_ONLY: @NO,
+                  KEY_TRANSPARENCY_AFFECTS_ONLY_DEFAULT_BACKGROUND_COLOR: @NO,
                   KEY_OPEN_TOOLBELT: @NO,
                   KEY_ASCII_ANTI_ALIASED: @NO,
                   KEY_NONASCII_ANTI_ALIASED: @NO,

--- a/sources/iTermProfilePreferences.m
+++ b/sources/iTermProfilePreferences.m
@@ -203,6 +203,7 @@ NSString *const kProfilePreferenceInitialDirectoryAdvancedValue = @"Advanced";
                   KEY_SYNC_TITLE: @NO,
                   KEY_DISABLE_WINDOW_RESIZING: @NO,
                   KEY_PREVENT_TAB: @NO,
+                  KEY_DEFAULT_BG_ALPHA_ONLY: @NO,
                   KEY_OPEN_TOOLBELT: @NO,
                   KEY_ASCII_ANTI_ALIASED: @NO,
                   KEY_NONASCII_ANTI_ALIASED: @NO,

--- a/sources/iTermTextDrawingHelper.h
+++ b/sources/iTermTextDrawingHelper.h
@@ -177,7 +177,7 @@
 @property(nonatomic, assign) float blend;
 
 // Should transparency not affect background colors other than the default?
-@property(nonatomic, assign) BOOL defaultBGAlphaOnly;
+@property(nonatomic, assign) BOOL transparencyAffectsOnlyDefaultBackgroundColor;
 
 // Should the cursor guide be shown?
 @property(nonatomic, assign) BOOL highlightCursorLine;

--- a/sources/iTermTextDrawingHelper.h
+++ b/sources/iTermTextDrawingHelper.h
@@ -176,6 +176,9 @@
 // Amount to blend background color over background image, 0-1.
 @property(nonatomic, assign) float blend;
 
+// Should transparency not affect background colors other than the default?
+@property(nonatomic, assign) BOOL defaultBGAlphaOnly;
+
 // Should the cursor guide be shown?
 @property(nonatomic, assign) BOOL highlightCursorLine;
 

--- a/sources/iTermTextDrawingHelper.m
+++ b/sources/iTermTextDrawingHelper.m
@@ -315,7 +315,7 @@ extern int CGContextGetFontSmoothingStyle(CGContextRef);
         // When set in preferences, applies alpha only to the defaultBackground
         // colour, useful for keeping Powerline segments opacity(background)
         // consistent with their seperator glyphs opacity(foreground).
-        if (_defaultBGAlphaOnly && !defaultBackground) {
+        if (_transparencyAffectsOnlyDefaultBackgroundColor && !defaultBackground) {
             alpha = 1;
         }
         if (_reverseVideo && defaultBackground) {

--- a/sources/iTermTextDrawingHelper.m
+++ b/sources/iTermTextDrawingHelper.m
@@ -312,6 +312,12 @@ extern int CGContextGetFontSmoothingStyle(CGContextRef);
     } else {
         const BOOL defaultBackground = (run->bgColor == ALTSEM_DEFAULT &&
                                         run->bgColorMode == ColorModeAlternate);
+        // When set in preferences, applies alpha only to the defaultBackground
+        // colour, useful for keeping Powerline segments opacity(background)
+        // consistent with their seperator glyphs opacity(foreground).
+        if (_defaultBGAlphaOnly && !defaultBackground) {
+            alpha = 1;
+        }
         if (_reverseVideo && defaultBackground) {
             // Reverse video is only applied to default background-
             // color chars.

--- a/sources/iTermTextDrawingHelper.m
+++ b/sources/iTermTextDrawingHelper.m
@@ -313,7 +313,7 @@ extern int CGContextGetFontSmoothingStyle(CGContextRef);
         const BOOL defaultBackground = (run->bgColor == ALTSEM_DEFAULT &&
                                         run->bgColorMode == ColorModeAlternate);
         // When set in preferences, applies alpha only to the defaultBackground
-        // colour, useful for keeping Powerline segments opacity(background)
+        // color, useful for keeping Powerline segments opacity(background)
         // consistent with their seperator glyphs opacity(foreground).
         if (_transparencyAffectsOnlyDefaultBackgroundColor && !defaultBackground) {
             alpha = 1;


### PR DESCRIPTION
This fixes a recent issue I raised [here](https://gitlab.com/gnachman/iterm2/issues/4523) and it's related [June 2013 issue](https://gitlab.com/gnachman/iterm2/issues/2478). The problem is also brought up in other repo's and communities. The main advantage being Powerline themes that don't break from having transparent backgrounds.

I've added a UI element to opt-in to the feature, it should not cause any  problems for those not interested(Although it's great for other cases such as messages like session restore text being more readable on a solid grey instead of transparent ;) ). See each commit message for more information :)

Here's a comparison with and without:
![defaultAlphaBGOnly feature](http://i.imgur.com/3UrhYCp.gif)