### PR TITLE
Use handleEvent instead of interpretKeyEvents(again).

### DIFF
--- a/sources/PTYTextView.m
+++ b/sources/PTYTextView.m
@@ -4833,7 +4833,6 @@ static double EuclideanDistance(NSPoint p1, NSPoint p2) {
         // See comment in -keyDown:
         DLog(@"Rerouting doCommandBySelector from %@ to %@", self, gCurrentKeyEventTextView);
         [gCurrentKeyEventTextView doCommandBySelector:aSelector];
-        [self.delegate keyDown:_keydownEvent];
         return;
     }
     [self.delegate keyDown:_keydownEvent];

--- a/sources/PTYTextView.m
+++ b/sources/PTYTextView.m
@@ -142,6 +142,7 @@ static const int kDragThreshold = 3;
     double _charHeightWithoutSpacing;
 
     // NSTextInputClient support
+    NSEvent* _keydownEvent;
     BOOL _inputMethodIsInserting;
     NSDictionary *_markedTextAttributes;
 
@@ -1434,7 +1435,8 @@ static const int kDragThreshold = 3;
         // track the instance of PTYTextView that is currently handling a key event and rerouting
         // calls as needed in -insertText and -doCommandBySelector.
         gCurrentKeyEventTextView = [[self retain] autorelease];
-        [self interpretKeyEvents:[NSArray arrayWithObject:event]];
+        _keydownEvent = event;
+        _inputMethodIsInserting = !event.isARepeat && [self.inputContext handleEvent:event];
         gCurrentKeyEventTextView = nil;
 
         // If the IME didn't want it, pass it on to the delegate
@@ -4831,8 +4833,10 @@ static double EuclideanDistance(NSPoint p1, NSPoint p2) {
         // See comment in -keyDown:
         DLog(@"Rerouting doCommandBySelector from %@ to %@", self, gCurrentKeyEventTextView);
         [gCurrentKeyEventTextView doCommandBySelector:aSelector];
+        [self.delegate keyDown:_keydownEvent];
         return;
     }
+    [self.delegate keyDown:_keydownEvent];
     DLog(@"doCommandBySelector:%@", NSStringFromSelector(aSelector));
 }
 


### PR DESCRIPTION
Hi, I'm an AquaSKK IM user and encountered the same problem @mzp reported on issue #202 .
This patch is based on @mzp 's work and rebased to the current master.

In the issue, you pointed out the problem that patch breaks key repeating, as I met too, so I added additional condition check wether the event represents key repeating or not using `event.isARepeat`.

Honestly, I don't understand the iTerm2 codebase any little, but, at least, this patch didn't cause any problem while a week I was using this version.