### PR TITLE
Setup for custom title delay settings.

### DIFF
--- a/sources/iTermDelayedTitleSetter.m
+++ b/sources/iTermDelayedTitleSetter.m
@@ -7,11 +7,18 @@
 //
 
 #import "iTermDelayedTitleSetter.h"
+#import "DebugLogging.h"
 
 NSString *const kDelayedTitleSetterSetTitle = @"kDelayedTitleSetterSetTitle";
 NSString *const kDelayedTitleSetterTitleKey = @"title";
 
+static NSString * const kDelayedTitleSetterCustomDelayKey = @"DelayedTitleCustomDelayTimeInterval";
+
 static const NSTimeInterval kDelay = 0.1;
+
+static const char * kDelayedTitleSetterNSTimeIntervalObjCType = @encode(NSTimeInterval);
+
+static const char * kDelayedTitleSetterFloatObjCType = @encode(float);
 
 @interface iTermDelayedTitleSetter()
 @property(nonatomic, assign) NSTimer *timer;
@@ -20,19 +27,69 @@ static const NSTimeInterval kDelay = 0.1;
 
 @implementation iTermDelayedTitleSetter
 
++ (void) initialize {
+    [super initialize];
+    [[NSUserDefaults standardUserDefaults] registerDefaults:@{ kDelayedTitleSetterCustomDelayKey : @(kDelay) }];
+}
+
 - (void)dealloc {
     [_pendingTitle release];
     [super dealloc];
 }
 
+- (NSTimeInterval) titleDelayDuration {
+    NSNumber *titleDelayDurationNumber = [[NSUserDefaults standardUserDefaults] objectForKey:kDelayedTitleSetterCustomDelayKey];
+
+    if (![titleDelayDurationNumber isKindOfClass:[NSNumber class]]) {
+        // Validate the duration, if it's not a number remove it.
+
+        DLog(@"duration isn't a number! (%@) %@", NSStringFromClass([titleDelayDurationNumber class]), titleDelayDurationNumber);
+
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:kDelayedTitleSetterCustomDelayKey];
+
+        [[NSUserDefaults standardUserDefaults] synchronize];
+
+        titleDelayDurationNumber = @(kDelay);
+    } else {
+        const char *titleDelayDurationObjCType = [titleDelayDurationNumber objCType];
+
+        if (strcmp(titleDelayDurationObjCType, kDelayedTitleSetterNSTimeIntervalObjCType) != 0) {
+            if (strcmp(titleDelayDurationObjCType, kDelayedTitleSetterFloatObjCType) != 0) {
+                DLog(@"types not equal: ori: %s saved: %s", kDelayedTitleSetterNSTimeIntervalObjCType, titleDelayDurationObjCType);
+
+                titleDelayDurationNumber = @(kDelay);
+            }
+        }
+    }
+
+    NSTimeInterval titleDelayDuration = [titleDelayDurationNumber doubleValue];
+
+    if (titleDelayDuration < 0) {
+        titleDelayDuration = kDelay;
+
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:kDelayedTitleSetterCustomDelayKey];
+
+        [[NSUserDefaults standardUserDefaults] synchronize];
+    }
+
+    return titleDelayDuration;
+}
+
 - (void)setTitle:(NSString *)title {
     self.pendingTitle = title;
-    if (!self.timer) {
-        self.timer = [NSTimer scheduledTimerWithTimeInterval:kDelay
-                                                      target:self
-                                                    selector:@selector(timerDidFire:)
-                                                    userInfo:nil
-                                                     repeats:NO];
+
+    NSTimeInterval timerDelay = [self titleDelayDuration];
+
+    if (timerDelay > 0) {
+        if (!self.timer) {
+            self.timer = [NSTimer scheduledTimerWithTimeInterval:[self titleDelayDuration]
+                                                          target:self
+                                                        selector:@selector(timerDidFire:)
+                                                        userInfo:nil
+                                                         repeats:NO];
+        }
+    } else {
+        [self timerDidFire:nil];
     }
 }
 


### PR DESCRIPTION
Added the possibility to change the delay for the app to set a tab’s title.

This can be achieved by running the following command:

``` bash
defaults write com.googlecode.iterm2 DelayedTitleCustomDelayTimeInterval -float 0.5
```

If no value is set in the defaults then the default value of `0.1` is used.
