### PR TITLE
scroll wheel sends escape sequences in alternate screen mode

### DIFF
--- a/sources/PTYTextView.m
+++ b/sources/PTYTextView.m
@@ -1560,8 +1560,8 @@ static const int kDragThreshold = 3;
         return NO;
     }
     BOOL alternateMouseScroll = [iTermAdvancedSettingsModel alternateMouseScroll];
-    NSString* alternateMouseScrollEscapeUp = [iTermAdvancedSettingsModel alternateMouseScrollEscapeUp];
-    NSString* alternateMouseScrollEscapeDown = [iTermAdvancedSettingsModel alternateMouseScrollEscapeDown];
+    NSString *alternateMouseScrollEscapeUp = [iTermAdvancedSettingsModel alternateMouseScrollEscapeUp];
+    NSString *alternateMouseScrollEscapeDown = [iTermAdvancedSettingsModel alternateMouseScrollEscapeDown];
     BOOL showingAlternateScreen = [self.dataSource showingAlternateScreen];
     if (!showingAlternateScreen) {
         return NO;

--- a/sources/iTermAdvancedSettingsModel.h
+++ b/sources/iTermAdvancedSettingsModel.h
@@ -15,6 +15,8 @@
 + (int)minCompactTabWidth;
 + (int)optimumTabWidth;
 + (BOOL)alternateMouseScroll;
++ (NSString *)alternateMouseScrollEscapeUp;
++ (NSString *)alternateMouseScrollEscapeDown;
 + (BOOL)traditionalVisualBell;
 + (double)hotkeyTermAnimationDuration;
 + (BOOL)hotkeyWindowFloatsAboveOtherWindows;

--- a/sources/iTermAdvancedSettingsModel.m
+++ b/sources/iTermAdvancedSettingsModel.m
@@ -64,6 +64,8 @@ DEFINE_FLOAT(tabAutoShowHoldTime, 1.0, @"Tabs: How long in seconds to show tabs 
 DEFINE_BOOL(allowDragOfTabIntoNewWindow, YES, @"Tabs: Allow a tab to be dragged and dropped outside any existing tab bar to create a new window.");
 
 #pragma mark Mouse
+DEFINE_STRING(alternateMouseScrollEscapeUp, @"", @"Mouse: Scroll wheel sends the specified escape sequence in alternate screen mode (up)");
+DEFINE_STRING(alternateMouseScrollEscapeDown, @"", @"Mouse: Scroll wheel sends the specified escape sequence in alternate screen mode (down)");
 DEFINE_BOOL(alternateMouseScroll, NO, @"Mouse: Scroll wheel sends arrow keys when in alternate screen mode.");
 DEFINE_BOOL(pinchToChangeFontSizeDisabled, NO, @"Mouse: Disable changing font size in response to a pinch gesture.");
 DEFINE_BOOL(useSystemCursorWhenPossible, NO, @"Mouse: Use system cursor icons when possible.");

--- a/sources/iTermAdvancedSettingsModel.m
+++ b/sources/iTermAdvancedSettingsModel.m
@@ -64,8 +64,12 @@ DEFINE_FLOAT(tabAutoShowHoldTime, 1.0, @"Tabs: How long in seconds to show tabs 
 DEFINE_BOOL(allowDragOfTabIntoNewWindow, YES, @"Tabs: Allow a tab to be dragged and dropped outside any existing tab bar to create a new window.");
 
 #pragma mark Mouse
-DEFINE_STRING(alternateMouseScrollEscapeUp, @"", @"Mouse: Scroll wheel sends the specified escape sequence in alternate screen mode (up)");
-DEFINE_STRING(alternateMouseScrollEscapeDown, @"", @"Mouse: Scroll wheel sends the specified escape sequence in alternate screen mode (down)");
+DEFINE_STRING(alternateMouseScrollEscapeUp, @"",
+              @"Mouse: Scroll wheel sends the specified escape sequence in alternate screen mode (up)\n"
+              @"The sequence should use Vim syntax for the input format, such as \\e for escape.");
+DEFINE_STRING(alternateMouseScrollEscapeDown, @"",
+              @"Mouse: Scroll wheel sends the specified escape sequence in alternate screen mode (down)\n"
+              @"The sequence should use Vim syntax for the input format, such as \\e for escape.");
 DEFINE_BOOL(alternateMouseScroll, NO, @"Mouse: Scroll wheel sends arrow keys when in alternate screen mode.");
 DEFINE_BOOL(pinchToChangeFontSizeDisabled, NO, @"Mouse: Disable changing font size in response to a pinch gesture.");
 DEFINE_BOOL(useSystemCursorWhenPossible, NO, @"Mouse: Use system cursor icons when possible.");


### PR DESCRIPTION
The point of this patch is to add an option to make the mouse scroll wheel configurable to send escape sequences in alternate screen mode. This adds onto the similar arrow key option that is already present by creating two more configuration options in the Advanced pane. 

The motivation for this change is to be able to implement the technique described here:
https://www.staldal.nu/tech/2009/01/11/how-to-use-mousewheel-in-gnu-screen/

Note: I'm not an Objective-C expert by any means, so I won't be surprised if I did something here that isn't best practice.