### PR TITLE
Increase MARGIN and VMARGIN by 10

### DIFF
--- a/sources/iTermTextDrawingHelper.h
+++ b/sources/iTermTextDrawingHelper.h
@@ -13,10 +13,10 @@
 #import "VT100GridTypes.h"
 
 // Number of pixels margin on left and right edge.
-#define MARGIN 5
+#define MARGIN 15
 
 // Number of pixels margin on the top.
-#define VMARGIN 2
+#define VMARGIN 12
 
 @class iTermColorMap;
 @class iTermFindOnPageHelper;


### PR DESCRIPTION
This change increases the margins around the text to remove the visual tension that is currently present.

Adequate whitespace is a common design best practice:
- https://medium.com/@erikdkennedy/7-rules-for-creating-gorgeous-ui-part-1-559d4e805cda#b7c4
- https://designschool.canva.com/blog/white-space-design/
- http://blog.teamtreehouse.com/white-space-in-web-design-what-it-is-and-why-you-should-use-it

This is a common change request that is often completed by compiling your own version of iTerm2:
- http://superuser.com/questions/810582/iterm-osx-terminal-change-text-margin-from-edge-of-window
- https://www.reddit.com/r/unixporn/comments/43e9ch/iterm2_with_adjustable_margins/
- https://www.reddit.com/r/unixporn/comments/37csyp/osx_heres_my_custom_iterm2_without_borders_and/
- https://github.com/jaredculp/iterm2-borderless-padding
- https://gist.github.com/unrolled/c5e04dd7138377fed18e
- https://gitlab.com/gnachman/iterm2/issues/950

Having to modify the source and build a custom version of iTerm2 is a pain. It also makes taking new updates difficult.
