### PR TITLE
set the min & max font size for badge

### DIFF
--- a/sources/iTermAdvancedSettingsModel.h
+++ b/sources/iTermAdvancedSettingsModel.h
@@ -115,6 +115,8 @@
 + (double)badgeMaxHeightFraction;
 + (int)badgeRightMargin;
 + (int)badgeTopMargin;
++ (double)badgeMinFontSize;
++ (double)badgeMaxFontSize;
 + (BOOL)noSyncReplaceProfileWarning;
 + (BOOL)requireCmdForDraggingText;
 + (double)tabAutoShowHoldTime;

--- a/sources/iTermAdvancedSettingsModel.m
+++ b/sources/iTermAdvancedSettingsModel.m
@@ -188,6 +188,8 @@ DEFINE_FLOAT(badgeMaxWidthFraction, 0.5, @"Badge: Maximum width of the badge\nAs
 DEFINE_FLOAT(badgeMaxHeightFraction, 0.2, @"Badge: Maximum height of the badge\nAs a fraction of the height of the terminal, between 0 and 1.0.");
 DEFINE_INT(badgeRightMargin, 10, @"Badge: Right Margin\nHow much space to leave between the right edge of the badge and the right edge of the terminal.");
 DEFINE_INT(badgeTopMargin, 10, @"Badge: Top Margin\nHow much space to leave between the top edge of the badge and the top edge of the terminal.");
+DEFINE_FLOAT(badgeMinFontSize,10.0, @"Badge: Minimum font size that's going to be used in a badge");
+DEFINE_FLOAT(badgeMaxFontSize,100.0, @"Badge: Maximum font size that's going to be used in a badge");
 
 #pragma mark - Experimental Features
 DEFINE_BOOL(includePasteHistoryInAdvancedPaste, NO, @"Experimental Features: Include paste history in the advanced paste menu.");

--- a/sources/iTermBadgeLabel.m
+++ b/sources/iTermBadgeLabel.m
@@ -99,9 +99,17 @@
          _fillColor,
          NSStringFromSize(_viewSize),
          [NSThread callStackSymbols]);
+    float maxFont = [iTermAdvancedSettingsModel badgeMaxFontSize];
+    float minFont = [iTermAdvancedSettingsModel badgeMinFontSize];
 
     if ([_stringValue length]) {
-        return [self imageWithPointSize:self.idealPointSize];
+        if (self.idealPointSize < minFont) {
+            return [self imageWithPointSize:minFont];
+        } else if (self.idealPointSize > maxFont) {
+            return [self imageWithPointSize:maxFont];
+        } else {
+            return [self imageWithPointSize:self.idealPointSize];
+        }
     }
 
     return nil;


### PR DESCRIPTION
This patch allow user to set a min & a max font size for badge font. I manly done this for users with retina display & external monitor where the current badge options are making the feature almost unusable.
