### PR TITLE
Adding an advanced terminal setting that lets underlining always use a static color

### DIFF
--- a/sources/ITAddressBookMgr.h
+++ b/sources/ITAddressBookMgr.h
@@ -105,6 +105,7 @@
 #define KEY_USE_CURSOR_GUIDE       @"Use Cursor Guide"
 #define KEY_CURSOR_GUIDE_COLOR     @"Cursor Guide Color"
 #define KEY_BADGE_COLOR            @"Badge Color"
+#define KEY_UNDERLINE_COLOR        @"Underline Color"
 
 // Display
 #define KEY_ROWS                   @"Rows"

--- a/sources/iTermAdvancedSettingsModel.h
+++ b/sources/iTermAdvancedSettingsModel.h
@@ -123,6 +123,7 @@
 + (BOOL)allowDragOfTabIntoNewWindow;
 + (BOOL)typingClearsSelection;
 + (BOOL)focusReportingEnabled;
++ (BOOL)staticUnderlineColor;
 
 + (BOOL)hideFromDockAndAppSwitcher;
 + (BOOL)hotkeyWindowIgnoresSpotlight;

--- a/sources/iTermAdvancedSettingsModel.m
+++ b/sources/iTermAdvancedSettingsModel.m
@@ -97,6 +97,7 @@ DEFINE_INT(numberOfLinesForAccessibility, 1000, @"Terminal: Maximum number of li
 DEFINE_INT(triggerRadius, 3, @"Terminal: Number of screen lines to match against trigger regular expressions.\nTrigger regular expressions are matched against the last logical line of text when a newline is received. A search is performed to find the start of the line. Since very long lines would cause performance problems, the search (and consequently the regular expression match, highlighting, and so on) is limited to this many screen lines.");
 DEFINE_BOOL(requireCmdForDraggingText, NO, @"Terminal: To drag images or selected text, you must hold ⌘. This prevents accidental drags.");
 DEFINE_BOOL(focusReportingEnabled, YES, @"Terminal: Apps may turn on Focus Reporting.\nFocus reporting causes iTerm2 to send an escape sequence when a session gains or loses focus. It can cause problems when an ssh session dies unexpectedly because it gets left on, so some users prefer to disable it.");
+DEFINE_BOOL(staticUnderlineColor, NO, @"Terminal: Use a fixed color for underlining characters (currently hardcoded to red).");
 
 #pragma mark Hotkey
 DEFINE_FLOAT(hotkeyTermAnimationDuration, 0.25, @"Hotkey: Duration in seconds of the hotkey window animation.\nWarning: reducing this value may cause problems if you have multiple displays.");

--- a/sources/iTermColorMap.h
+++ b/sources/iTermColorMap.h
@@ -26,6 +26,7 @@ extern const int kColorMapSelectedText;
 extern const int kColorMapCursor;
 extern const int kColorMapCursorText;
 extern const int kColorMapInvalid;
+extern const int kColorMapUnderline;
 
 // This value plus 0...255 are accepted. The ANSI colors below followed by their bright
 // variants make the first 16 entries of the 256-color space.

--- a/sources/iTermColorMap.m
+++ b/sources/iTermColorMap.m
@@ -19,8 +19,9 @@ const int kColorMapCursor = 5;
 const int kColorMapCursorText = 6;
 const int kColorMapInvalid = 7;
 const int kColorMapLink = 8;
+const int kColorMapUnderline = 9;
 // This value plus 0...255 are accepted.
-const int kColorMap8bitBase = 9;
+const int kColorMap8bitBase = 10;
 // This value plus 0...2^24-1 are accepted as read-only keys. These must be the highest-valued keys.
 const int kColorMap24bitBase = kColorMap8bitBase + 256;
 
@@ -325,6 +326,8 @@ const int kColorMapAnsiBrightModifier = 8;
             return KEY_CURSOR_COLOR;
         case kColorMapCursorText:
             return KEY_CURSOR_TEXT_COLOR;
+        case kColorMapUnderline:
+            return KEY_UNDERLINE_COLOR;
 
         case kColorMapAnsiBlack:
             return KEY_ANSI_0_COLOR;

--- a/sources/iTermProfilePreferences.m
+++ b/sources/iTermProfilePreferences.m
@@ -171,6 +171,7 @@ NSString *const kProfilePreferenceInitialDirectoryAdvancedValue = @"Advanced";
                   KEY_ANSI_15_COLOR:       [[NSColor colorWithCalibratedRed:1.000 green:1.000 blue:1.000 alpha:1] dictionaryValue],
                   KEY_CURSOR_GUIDE_COLOR:  [[NSColor colorWithCalibratedRed:0.650 green:0.910 blue:1.000 alpha:0.25] dictionaryValue],
                   KEY_BADGE_COLOR:         [[NSColor colorWithCalibratedRed:1.0 green:0.000 blue:0.000 alpha:0.5] dictionaryValue],
+                  KEY_UNDERLINE_COLOR:     [[NSColor colorWithCalibratedRed:1.0 green:0.000 blue:0.000 alpha:0.0] dictionaryValue],
                   KEY_USE_CURSOR_GUIDE: @NO,
                   KEY_TAB_COLOR: [NSNull null],
                   KEY_USE_TAB_COLOR: @NO,

--- a/sources/iTermTextDrawingHelper.m
+++ b/sources/iTermTextDrawingHelper.m
@@ -870,7 +870,15 @@ extern int CGContextGetFontSmoothingStyle(CGContextRef);
 
     // Draw underline
     if (currentRun->attrs.underline) {
-        [self drawUnderlineOfColor:currentRun->attrs.color
+
+        NSColor *color = nil;
+
+        if ([iTermAdvancedSettingsModel staticUnderlineColor])
+            color = [_colorMap colorForKey:kColorMapUnderline];
+        else
+            color = currentRun->attrs.color;
+
+        [self drawUnderlineOfColor:color
                       atCellOrigin:startPoint
                               font:currentRun->attrs.fontInfo.font
                              width:runWidth];


### PR DESCRIPTION
Adding an advanced terminal setting that lets underlining always use a static color, independent of the color that the character itself is using. The underline color is currently hardcoded to red.