### PR TITLE
we could be leaking PTYTasks when calling "continue;" if we have dupl…

### DIFF
--- a/sources/TaskNotifier.m
+++ b/sources/TaskNotifier.m
@@ -385,7 +385,7 @@ NSString *const kTaskNotifierDidSpin = @"kTaskNotifierDidSpin";
                     PtyTaskDebugLog(@"Duplicate fd %d", fd);
                     continue;
                 }
-                [task retain];
+                [[task retain] autorelease];
                 [handledFds addObject:@(fd)];
 
                 if ([self handleReadOnFileDescriptor:fd task:task fdSet:&rfds]) {
@@ -430,7 +430,6 @@ NSString *const kTaskNotifierDidSpin = @"kTaskNotifierDidSpin";
                         }
                     }
                 }
-                [task release];
             }
         }
 


### PR DESCRIPTION
…icate fds,

in which case "[task release]" would not be called