### PR TITLE
Fixed the yen button error that happened if the current keyboard layout doesn't produce "¥".

### DIFF
--- a/sources/NSEvent+iTerm.m
+++ b/sources/NSEvent+iTerm.m
@@ -58,26 +58,20 @@
 - (NSEvent *)eventByChangingYenToBackslash {
     // NSEvent: type=KeyDown loc=(0,477) time=103943.2 flags=0x80120 win=0x7fd5786432b0 winNum=3667 ctxt=0x0 chars="\" unmodchars="¥" repeat=0 keyCode=93
     
-    if (self.keyCode == kVK_JIS_Yen) {
-        NSString *characters = @"\\";
-        if (self.modifierFlags & NSShiftKeyMask) {
-            characters = @"|";
-        } else {
-            characters = @"\\";
-        }
+    if ([self.charactersIgnoringModifiers isEqualToString:@"¥"]) {
         return [NSEvent keyEventWithType:self.type
                                 location:self.locationInWindow
                            modifierFlags:self.modifierFlags
                                timestamp:self.timestamp
                             windowNumber:self.windowNumber
                                  context:self.context
-                              characters:characters
+                              characters:@"\\"
              charactersIgnoringModifiers:@"\\"
                                isARepeat:self.isARepeat
                                  keyCode:self.keyCode];
     } else {
         return self;
     }
-
+    
 }
 @end


### PR DESCRIPTION
iTerm2 mimics MacOS's Terminal and produces "\" instead "¥", when the yen button of a Japanese keyboard is pressed. This is because of a legacy quirk of Japanese keyboard layouts, that use ¥ instead of \\.

However, the current implementation naively checks only if the pressed key is the yen key (the key code). However, as the user can change and edit keyboard layouts, the yen keys doesn't necessarily produce "¥".

With this commit, it checks whether the character production of the key is "¥". It still needs to check the keycode in order to prevent any other mappings that produce "¥" from turning "\". (Another solution would be to check if the `charactersIgnoringModifiers` equals to "¥" and leave out the key code check... I'm not aware which one has less corner cases.)