### PR TITLE
Fixed yet another cornercase with the "¥".

### DIFF
--- a/sources/NSEvent+iTerm.m
+++ b/sources/NSEvent+iTerm.m
@@ -58,7 +58,7 @@
 - (NSEvent *)eventByChangingYenToBackslash {
     // NSEvent: type=KeyDown loc=(0,477) time=103943.2 flags=0x80120 win=0x7fd5786432b0 winNum=3667 ctxt=0x0 chars="\" unmodchars="¥" repeat=0 keyCode=93
     
-    if ([self.charactersIgnoringModifiers isEqualToString:@"¥"]) {
+    if ([self.charactersIgnoringModifiers isEqualToString:@"¥"] && [self.characters isEqualToString:@"¥"]) {
         return [NSEvent keyEventWithType:self.type
                                 location:self.locationInWindow
                            modifierFlags:self.modifierFlags


### PR DESCRIPTION
I came up with another corner case. Thanks, #showerthoughts.

It now checks that the production that would be emitted originally by the keypress would be "¥" also – this for the (rare) case that alt + ¥ would produce something special that the user intended to produce.

In the normal case (the standard Japanese keyboard on Mac) alt + ¥ is mapped to emit "\", so in the majority of cases "\" will be emitted either way.