### PR TITLE
Match OS X tab bar styling more closely

### DIFF
--- a/Interfaces/PreferencePanel.xib
+++ b/Interfaces/PreferencePanel.xib
@@ -756,7 +756,7 @@ Gw
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" headerView="5784" id="5783">
-                                    <rect key="frame" x="0.0" y="0.0" width="761" height="19"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="762" height="247"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <size key="intercellSpacing" width="3" height="2"/>
                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -1132,7 +1132,7 @@ DQ
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" headerView="6284" id="6283">
-                                    <rect key="frame" x="0.0" y="0.0" width="533" height="136"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="532" height="19"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <size key="intercellSpacing" width="3" height="2"/>
                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -1312,6 +1312,7 @@ DQ
                 <outlet property="_showPaneTitles" destination="6051" id="n0P-0K-pxx"/>
                 <outlet property="_showTabBarInFullscreen" destination="e4x-7h-mzh" id="21B-SP-LU5"/>
                 <outlet property="_showWindowBorder" destination="5144" id="wpg-cZ-0wM"/>
+                <outlet property="_stretchTabsToFillBar" destination="q7y-hG-x0m" id="HPi-ia-0YJ"/>
                 <outlet property="_tabPosition" destination="4463" id="Rxp-XS-Fkx"/>
                 <outlet property="_tabStyle" destination="uFJ-bZ-kag" id="BZV-Cb-HaF"/>
                 <outlet property="_uiElement" destination="zde-kb-c7t" id="kdn-MM-Kyo"/>
@@ -4552,11 +4553,11 @@ DQ
             <point key="canvasLocation" x="1580" y="289"/>
         </customView>
         <customView id="yCt-fi-XI9" userLabel="Prefs - Appearance" customClass="iTermSizeRememberingView">
-            <rect key="frame" x="0.0" y="0.0" width="744" height="378"/>
+            <rect key="frame" x="0.0" y="0.0" width="744" height="398"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <button id="4446">
-                    <rect key="frame" x="18" y="252" width="263" height="18"/>
+                    <rect key="frame" x="18" y="272" width="263" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Show tab numbers" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="4447">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -4568,7 +4569,7 @@ DQ
                     </connections>
                 </button>
                 <button id="1dE-aB-uR8">
-                    <rect key="frame" x="18" y="232" width="263" height="18"/>
+                    <rect key="frame" x="18" y="252" width="263" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Show tab close buttons" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="GRU-c6-tJK">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -4580,7 +4581,7 @@ DQ
                     </connections>
                 </button>
                 <button id="5374">
-                    <rect key="frame" x="18" y="212" width="160" height="18"/>
+                    <rect key="frame" x="18" y="232" width="160" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Show activity indicator" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="5375">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -4592,7 +4593,7 @@ DQ
                     </connections>
                 </button>
                 <button id="Q0o-aJ-Wec">
-                    <rect key="frame" x="18" y="192" width="186" height="18"/>
+                    <rect key="frame" x="18" y="212" width="186" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Show new-output indicator" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="P1b-LJ-ARG">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -4604,7 +4605,7 @@ DQ
                     </connections>
                 </button>
                 <button id="Esq-U7-Af7">
-                    <rect key="frame" x="18" y="172" width="316" height="18"/>
+                    <rect key="frame" x="18" y="192" width="316" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Flash tab bar when switching tabs in fullscreen" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="2Eu-ti-9Nf">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -4616,7 +4617,7 @@ DQ
                     </connections>
                 </button>
                 <button id="4462">
-                    <rect key="frame" x="18" y="274" width="298" height="18"/>
+                    <rect key="frame" x="18" y="294" width="298" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Show tab bar even when there is only one tab" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="4499">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -4627,7 +4628,7 @@ DQ
                     </connections>
                 </button>
                 <popUpButton verticalHuggingPriority="750" id="4463">
-                    <rect key="frame" x="130" y="330" width="112" height="26"/>
+                    <rect key="frame" x="130" y="350" width="112" height="26"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="clipping" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" id="4495">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -4646,7 +4647,7 @@ DQ
                     </connections>
                 </popUpButton>
                 <textField verticalHuggingPriority="750" id="4556">
-                    <rect key="frame" x="18" y="361" width="140" height="17"/>
+                    <rect key="frame" x="18" y="381" width="140" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Tabs" id="4557">
                         <font key="font" metaFont="systemBold"/>
@@ -4655,7 +4656,7 @@ DQ
                     </textFieldCell>
                 </textField>
                 <button id="4529">
-                    <rect key="frame" x="360" y="337" width="205" height="18"/>
+                    <rect key="frame" x="360" y="357" width="205" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Show window number" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="4536">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -4667,7 +4668,7 @@ DQ
                     </connections>
                 </button>
                 <button id="4530">
-                    <rect key="frame" x="360" y="317" width="213" height="18"/>
+                    <rect key="frame" x="360" y="337" width="213" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Show current job name" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="4535">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -4679,7 +4680,7 @@ DQ
                     </connections>
                 </button>
                 <button id="4531">
-                    <rect key="frame" x="360" y="297" width="264" height="18"/>
+                    <rect key="frame" x="360" y="317" width="264" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Show profile name" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="4534">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -4691,7 +4692,7 @@ DQ
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" id="4532">
-                    <rect key="frame" x="360" y="361" width="153" height="17"/>
+                    <rect key="frame" x="360" y="381" width="153" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Window &amp; Tab Titles" id="4533">
                         <font key="font" metaFont="systemBold"/>
@@ -4700,7 +4701,7 @@ DQ
                     </textFieldCell>
                 </textField>
                 <button id="4560">
-                    <rect key="frame" x="360" y="175" width="178" height="18"/>
+                    <rect key="frame" x="360" y="195" width="178" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Dim inactive split panes" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="4565">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -4712,7 +4713,7 @@ DQ
                     </connections>
                 </button>
                 <button id="5325">
-                    <rect key="frame" x="360" y="155" width="186" height="18"/>
+                    <rect key="frame" x="360" y="175" width="186" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Dim background windows" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="5326">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -4724,7 +4725,7 @@ DQ
                     </connections>
                 </button>
                 <button id="5330">
-                    <rect key="frame" x="360" y="240" width="298" height="18"/>
+                    <rect key="frame" x="360" y="260" width="298" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Dimming affects only text, not background." bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="5331">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -4736,7 +4737,7 @@ DQ
                     </connections>
                 </button>
                 <button id="4561">
-                    <rect key="frame" x="360" y="78" width="228" height="18"/>
+                    <rect key="frame" x="360" y="98" width="228" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Hide scrollbars" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="4564">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -4748,7 +4749,7 @@ DQ
                     </connections>
                 </button>
                 <button toolTip="If this is on then transparency can be toggled window-by-window under View&gt;Use Transparency" id="5753">
-                    <rect key="frame" x="360" y="58" width="366" height="18"/>
+                    <rect key="frame" x="360" y="78" width="366" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Disable transparency for fullscreen windows by default" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="5754">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -4760,7 +4761,7 @@ DQ
                     </connections>
                 </button>
                 <button id="5144">
-                    <rect key="frame" x="360" y="98" width="228" height="18"/>
+                    <rect key="frame" x="360" y="118" width="228" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Show border around window" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="5145">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -4771,7 +4772,7 @@ DQ
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" id="4562">
-                    <rect key="frame" x="360" y="264" width="66" height="17"/>
+                    <rect key="frame" x="360" y="284" width="66" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Dimming" id="4563">
                         <font key="font" metaFont="systemBold"/>
@@ -4780,7 +4781,7 @@ DQ
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" id="5335">
-                    <rect key="frame" x="360" y="122" width="66" height="17"/>
+                    <rect key="frame" x="360" y="142" width="66" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Window" id="5336">
                         <font key="font" metaFont="systemBold"/>
@@ -4798,7 +4799,7 @@ DQ
                     </textFieldCell>
                 </textField>
                 <slider toolTip="Inactive sessions get dimmed to help find the active session." verticalHuggingPriority="750" id="5337">
-                    <rect key="frame" x="481" y="213" width="177" height="21"/>
+                    <rect key="frame" x="481" y="233" width="177" height="21"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <sliderCell key="cell" continuous="YES" state="on" alignment="left" minValue="0.10000000000000001" maxValue="0.59999999999999998" doubleValue="0.40000000000000002" tickMarkPosition="above" sliderType="linear" id="5338"/>
                     <connections>
@@ -4807,7 +4808,7 @@ DQ
                     </connections>
                 </slider>
                 <textField verticalHuggingPriority="750" id="5339">
-                    <rect key="frame" x="360" y="217" width="119" height="17"/>
+                    <rect key="frame" x="360" y="237" width="119" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Dimming amount:" id="5340">
                         <font key="font" metaFont="system"/>
@@ -4816,7 +4817,7 @@ DQ
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" id="5341">
-                    <rect key="frame" x="480" y="201" width="43" height="11"/>
+                    <rect key="frame" x="480" y="221" width="43" height="11"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Minimal" id="5342">
                         <font key="font" metaFont="miniSystem"/>
@@ -4825,7 +4826,7 @@ DQ
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" id="5343">
-                    <rect key="frame" x="615" y="201" width="44" height="11"/>
+                    <rect key="frame" x="615" y="221" width="44" height="11"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Very Dim" id="5344">
                         <font key="font" metaFont="miniSystem"/>
@@ -4878,7 +4879,7 @@ DQ
                     </connections>
                 </button>
                 <popUpButton verticalHuggingPriority="750" id="uFJ-bZ-kag">
-                    <rect key="frame" x="130" y="299" width="187" height="26"/>
+                    <rect key="frame" x="130" y="319" width="187" height="26"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="clipping" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" id="dAw-Fo-tf4" userLabel="Tab Style">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -4899,7 +4900,7 @@ DQ
                     </connections>
                 </popUpButton>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="sxm-tG-syy">
-                    <rect key="frame" x="18" y="336" width="107" height="17"/>
+                    <rect key="frame" x="18" y="356" width="107" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Tab bar location:" id="jnA-10-c4D">
                         <font key="font" metaFont="system"/>
@@ -4908,7 +4909,7 @@ DQ
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="ThU-HR-f8F">
-                    <rect key="frame" x="18" y="304" width="107" height="17"/>
+                    <rect key="frame" x="18" y="324" width="107" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Theme:" id="uhj-9S-l8R">
                         <font key="font" metaFont="system"/>
@@ -4917,7 +4918,7 @@ DQ
                     </textFieldCell>
                 </textField>
                 <button id="e4x-7h-mzh">
-                    <rect key="frame" x="18" y="152" width="316" height="18"/>
+                    <rect key="frame" x="18" y="172" width="316" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Show tab bar in fullscreen" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="UI6-As-YT2">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -4926,6 +4927,18 @@ DQ
                     <connections>
                         <action selector="settingChanged:" target="wvi-ET-SJJ" id="b3q-r3-EVo"/>
                         <outlet property="nextKeyView" destination="5330" id="qXr-pI-cHH"/>
+                    </connections>
+                </button>
+                <button id="q7y-hG-x0m" userLabel="Stretch Tabs to Fill Bar">
+                    <rect key="frame" x="18" y="152" width="316" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="check" title="Stretch tabs to fill bar" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="X12-cb-Cnf">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="settingChanged:" target="wvi-ET-SJJ" id="kT2-YF-Gfu"/>
+                        <outlet property="nextKeyView" destination="5330" id="JWT-Si-m0o"/>
                     </connections>
                 </button>
             </subviews>

--- a/ThirdParty/PSMTabBarControl/source/PSMDarkHighContrastTabStyle.m
+++ b/ThirdParty/PSMTabBarControl/source/PSMDarkHighContrastTabStyle.m
@@ -31,8 +31,4 @@
   return [NSColor colorWithCalibratedWhite:value alpha:1.00];
 }
 
-- (CGFloat)fontSize {
-  return 12.0;
-}
-
 @end

--- a/ThirdParty/PSMTabBarControl/source/PSMDarkHighContrastTabStyle.m
+++ b/ThirdParty/PSMTabBarControl/source/PSMDarkHighContrastTabStyle.m
@@ -31,4 +31,8 @@
   return [NSColor colorWithCalibratedWhite:value alpha:1.00];
 }
 
+- (CGFloat)fontSize {
+    return 12.0;
+}
+
 @end

--- a/ThirdParty/PSMTabBarControl/source/PSMLightHighContrastTabStyle.m
+++ b/ThirdParty/PSMTabBarControl/source/PSMLightHighContrastTabStyle.m
@@ -63,4 +63,8 @@
     return [NSColor colorWithCalibratedWhite:0 alpha:0.3];
 }
 
+- (CGFloat)fontSize {
+    return 12.0;
+}
+
 @end

--- a/ThirdParty/PSMTabBarControl/source/PSMLightHighContrastTabStyle.m
+++ b/ThirdParty/PSMTabBarControl/source/PSMLightHighContrastTabStyle.m
@@ -63,8 +63,4 @@
     return [NSColor colorWithCalibratedWhite:0 alpha:0.3];
 }
 
-- (CGFloat)fontSize {
-  return 12.0;
-}
-
 @end

--- a/ThirdParty/PSMTabBarControl/source/PSMTabBarCell.m
+++ b/ThirdParty/PSMTabBarControl/source/PSMTabBarCell.m
@@ -328,7 +328,7 @@
         // TODO: This image is missing!
         NSImage *piImage = [[NSImage alloc] initByReferencingFile:[[PSMTabBarControl bundle] pathForImageResource:@"pi"]];
         [returnImage lockFocus];
-        NSPoint indicatorPoint = NSMakePoint([self frame].size.width - kSPMTabBarCellInternalXMargin - kPSMTabBarIndicatorWidth, kSPMTabBarCellInternalYMargin);
+        NSPoint indicatorPoint = self.indicator.frame.origin;
         [piImage drawAtPoint:indicatorPoint
                     fromRect:NSZeroRect
                    operation:NSCompositeSourceOver

--- a/ThirdParty/PSMTabBarControl/source/PSMTabBarControl.h
+++ b/ThirdParty/PSMTabBarControl/source/PSMTabBarControl.h
@@ -161,6 +161,7 @@ enum {
 @property(nonatomic, assign) int cellMaxWidth;
 @property(nonatomic, assign) int cellOptimumWidth;
 @property(nonatomic, assign) BOOL sizeCellsToFit;
+@property(nonatomic, assign) BOOL stretchCellsToFit;
 @property(nonatomic, assign) BOOL useOverflowMenu;
 @property(nonatomic, assign) BOOL allowsBackgroundTabClosing;
 @property(nonatomic, assign) BOOL allowsResizing;

--- a/ThirdParty/PSMTabBarControl/source/PSMTabBarControl.h
+++ b/ThirdParty/PSMTabBarControl/source/PSMTabBarControl.h
@@ -19,7 +19,6 @@ extern const CGFloat kPSMTabBarControlHeight;
 
 // internal cell border
 extern const CGFloat kSPMTabBarCellInternalXMargin;
-extern const CGFloat kSPMTabBarCellInternalYMargin;
 
 // padding between objects
 extern const CGFloat kPSMTabBarCellPadding;

--- a/ThirdParty/PSMTabBarControl/source/PSMTabBarControl.m
+++ b/ThirdParty/PSMTabBarControl/source/PSMTabBarControl.m
@@ -20,9 +20,8 @@ NSString *const kPSMModifierChangedNotification = @"kPSMModifierChangedNotificat
 NSString *const kPSMTabModifierKey = @"TabModifier";
 NSString *const PSMTabDragDidEndNotification = @"PSMTabDragDidEndNotification";
 NSString *const PSMTabDragDidBeginNotification = @"PSMTabDragDidBeginNotification";
-const CGFloat kPSMTabBarControlHeight = 22;
+const CGFloat kPSMTabBarControlHeight = 24;
 const CGFloat kSPMTabBarCellInternalXMargin = 6;
-const CGFloat kSPMTabBarCellInternalYMargin = 3.5;
 
 const CGFloat kPSMTabBarCellPadding = 4;
 const CGFloat kPSMTabBarCellIconPadding = 0;
@@ -1021,7 +1020,7 @@ const NSInteger kPSMStartResizeAnimation = 0;
         cellRect.size = [_addTabButton frame].size;
 
         if ([self orientation] == PSMTabBarHorizontalOrientation) {
-            cellRect.origin.y = kSPMTabBarCellInternalYMargin;
+            cellRect.origin.y = 0;
             cellRect.origin.x += [[newWidths valueForKeyPath:@"@sum.floatValue"] floatValue] + 2;
         } else {
             cellRect.origin.x = 0;

--- a/ThirdParty/PSMTabBarControl/source/PSMYosemiteTabStyle.m
+++ b/ThirdParty/PSMTabBarControl/source/PSMYosemiteTabStyle.m
@@ -647,12 +647,12 @@
             labelRect.size.width -= ([self objectCounterRectForTabCell:cell].size.width + kPSMTabBarCellPadding);
         }
 
-        NSSize boundingRect = [attributedString boundingRectWithSize:labelRect.size options:0].size;
-        labelRect.origin.y = floor((cellFrame.size.height - boundingRect.height) / 2.0);
-        labelRect.size.height = boundingRect.height;
+        NSSize boundingSize = [attributedString boundingRectWithSize:labelRect.size options:0].size;
+        labelRect.origin.y = cellFrame.origin.y + floor((cellFrame.size.height - boundingSize.height) / 2.0);
+        labelRect.size.height = boundingSize.height;
 
         if (_orientation == PSMTabBarHorizontalOrientation) {
-            CGFloat effectiveLeftMargin = (labelRect.size.width - boundingRect.width) / 2;
+            CGFloat effectiveLeftMargin = (labelRect.size.width - boundingSize.width) / 2;
             if (effectiveLeftMargin < reservedSpace) {
                 attributedString = [attributedString attributedStringWithTextAlignment:NSLeftTextAlignment];
 

--- a/ThirdParty/PSMTabBarControl/source/PSMYosemiteTabStyle.m
+++ b/ThirdParty/PSMTabBarControl/source/PSMYosemiteTabStyle.m
@@ -409,19 +409,19 @@
 #pragma mark - Drawing
 
 - (NSColor *)topLineColorSelected:(BOOL)selected {
-    return [NSColor colorWithSRGBRed:182/255.0 green:179/255.0 blue:182/255.0 alpha:1];
+    if (selected) {
+        return [NSColor colorWithSRGBRed:189/255.0 green:189/255.0 blue:189/255.0 alpha:1];
+    } else {
+        return [NSColor colorWithSRGBRed:160/255.0 green:160/255.0 blue:160/255.0 alpha:1];
+    }
 }
 
 - (NSColor *)verticalLineColor {
-    return [NSColor colorWithSRGBRed:182/255.0 green:179/255.0 blue:182/255.0 alpha:1];
+    return [NSColor colorWithSRGBRed:160/255.0 green:160/255.0 blue:160/255.0 alpha:1];
 }
 
 - (NSColor *)bottomLineColorSelected:(BOOL)selected {
-    if (selected) {
-        return [NSColor colorWithSRGBRed:182/255.0 green:180/255.0 blue:182/255.0 alpha:1];
-    } else {
-        return [NSColor colorWithSRGBRed:170/255.0 green:167/255.0 blue:170/255.0 alpha:1];
-    }
+    return [NSColor colorWithSRGBRed:160/255.0 green:160/255.0 blue:160/255.0 alpha:1];
 }
 
 - (NSColor *)backgroundColorSelected:(BOOL)selected highlightAmount:(CGFloat)highlightAmount {
@@ -433,12 +433,11 @@
         }
     } else {
         if ([self isYosemiteOrLater]) {
-            CGFloat value = 196/255.0 - highlightAmount * 0.1;
+            CGFloat value = 190/255.0 - highlightAmount * 0.048;
             return [NSColor colorWithSRGBRed:value green:value blue:value alpha:1];
-            return [NSColor redColor];
         } else {
             // 10.9 and earlier needs a darker color to look good
-            CGFloat value = 0.6 - highlightAmount * 0.1;
+            CGFloat value = 0.6 - highlightAmount * 0.048;
             return [NSColor colorWithSRGBRed:value green:value blue:value alpha:1];
         }
     }

--- a/ThirdParty/PSMTabBarControl/source/PSMYosemiteTabStyle.m
+++ b/ThirdParty/PSMTabBarControl/source/PSMYosemiteTabStyle.m
@@ -13,7 +13,6 @@
 
 #define kPSMMetalObjectCounterRadius 7.0
 #define kPSMMetalCounterMinWidth 20
-static const CGFloat kPSMTabBarCellBaselineOffset = 14.5;
 
 @interface NSAttributedString(PSM)
 - (NSAttributedString *)attributedStringWithTextAlignment:(NSTextAlignment)textAlignment;
@@ -191,7 +190,7 @@ static const CGFloat kPSMTabBarCellBaselineOffset = 14.5;
     NSRect result;
     result.size = [_closeButton size];
     result.origin.x = cellFrame.origin.x + kSPMTabBarCellInternalXMargin;
-    result.origin.y = cellFrame.origin.y + kSPMTabBarCellInternalYMargin;
+    result.origin.y = cellFrame.origin.y + floor((cellFrame.size.height - result.size.height) / 2.0);
 
     return result;
 }
@@ -215,7 +214,7 @@ static const CGFloat kPSMTabBarCellBaselineOffset = 14.5;
     NSRect result;
     result.size = NSMakeSize(kPSMTabBarIconWidth, kPSMTabBarIconWidth);
     result.origin.x = minX - kPSMTabBarCellIconPadding - kPSMTabBarIconWidth;
-    result.origin.y = cellFrame.origin.y + kSPMTabBarCellInternalYMargin - 1.0;
+    result.origin.y = cellFrame.origin.y + floor((cellFrame.size.height - result.size.height) / 2.0);
 
     return result;
 }
@@ -235,7 +234,7 @@ static const CGFloat kPSMTabBarCellBaselineOffset = 14.5;
     NSRect result;
     result.size = NSMakeSize(kPSMTabBarIndicatorWidth, kPSMTabBarIndicatorWidth);
     result.origin.x = minX - kPSMTabBarCellIconPadding - kPSMTabBarIndicatorWidth;
-    result.origin.y = cellFrame.origin.y + kSPMTabBarCellInternalYMargin;
+    result.origin.y = cellFrame.origin.y + floor((cellFrame.size.height - result.size.height) / 2.0);
 
     return result;
 }
@@ -256,7 +255,7 @@ static const CGFloat kPSMTabBarCellBaselineOffset = 14.5;
     NSRect result;
     result.size = NSMakeSize(countWidth, 2 * kPSMMetalObjectCounterRadius); // temp
     result.origin.x = cellFrame.origin.x + cellFrame.size.width - kSPMTabBarCellInternalXMargin - result.size.width;
-    result.origin.y = cellFrame.origin.y + kSPMTabBarCellInternalYMargin;
+    result.origin.y = cellFrame.origin.y + floor((cellFrame.size.height - result.size.height) / 2.0);
 
     return result;
 }
@@ -410,11 +409,7 @@ static const CGFloat kPSMTabBarCellBaselineOffset = 14.5;
 #pragma mark - Drawing
 
 - (NSColor *)topLineColorSelected:(BOOL)selected {
-    if (selected) {
-        return [_tabBar.window backgroundColor];
-    } else {
-        return [NSColor colorWithSRGBRed:182/255.0 green:179/255.0 blue:182/255.0 alpha:1];
-    }
+    return [NSColor colorWithSRGBRed:182/255.0 green:179/255.0 blue:182/255.0 alpha:1];
 }
 
 - (NSColor *)verticalLineColor {
@@ -647,16 +642,17 @@ static const CGFloat kPSMTabBarCellBaselineOffset = 14.5;
             labelRect.size.width -= cell.indicator.frame.size.width + kPSMTabBarCellIconPadding;
         }
         labelRect.size.height = cellFrame.size.height;
-        NSFont *font = [[attributedString fontAttributesInRange:NSMakeRange(0, 1)] objectForKey:NSFontAttributeName];
-        labelRect.origin.y = cellFrame.origin.y + kPSMTabBarCellBaselineOffset - font.ascender;
 
         if ([cell count] > 0) {
             labelRect.size.width -= ([self objectCounterRectForTabCell:cell].size.width + kPSMTabBarCellPadding);
         }
 
+        NSSize boundingRect = [attributedString boundingRectWithSize:labelRect.size options:0].size;
+        labelRect.origin.y = floor((cellFrame.size.height - boundingRect.height) / 2.0);
+        labelRect.size.height = boundingRect.height;
+
         if (_orientation == PSMTabBarHorizontalOrientation) {
-            NSSize size = [attributedString boundingRectWithSize:labelRect.size options:0].size;
-            CGFloat effectiveLeftMargin = (labelRect.size.width - size.width) / 2;
+            CGFloat effectiveLeftMargin = (labelRect.size.width - boundingRect.width) / 2;
             if (effectiveLeftMargin < reservedSpace) {
                 attributedString = [attributedString attributedStringWithTextAlignment:NSLeftTextAlignment];
 

--- a/ThirdParty/PSMTabBarControl/source/PSMYosemiteTabStyle.m
+++ b/ThirdParty/PSMTabBarControl/source/PSMYosemiteTabStyle.m
@@ -624,8 +624,8 @@
         NSRect counterStringRect;
         NSAttributedString *counterString = [self attributedObjectCountValueForTabCell:cell];
         counterStringRect.size = [counterString size];
-        counterStringRect.origin.x = myRect.origin.x + ((myRect.size.width - counterStringRect.size.width) / 2.0) + 0.25;
-        counterStringRect.origin.y = myRect.origin.y + ((myRect.size.height - counterStringRect.size.height) / 2.0) + 0.5;
+        counterStringRect.origin.x = myRect.origin.x + floor((myRect.size.width - counterStringRect.size.width) / 2.0);
+        counterStringRect.origin.y = myRect.origin.y + floor((myRect.size.height - counterStringRect.size.height) / 2.0);
         [counterString drawInRect:counterStringRect];
     }
 

--- a/sources/AppearancePreferencesViewController.m
+++ b/sources/AppearancePreferencesViewController.m
@@ -48,6 +48,8 @@ NSString *const iTermProcessTypeDidChangeNotification = @"iTermProcessTypeDidCha
     IBOutlet NSButton *_flashTabBarInFullscreenWhenSwitchingTabs;
     IBOutlet NSButton *_showTabBarInFullscreen;
 
+    IBOutlet NSButton *_stretchTabsToFillBar;
+
     // Show window number in title bar.
     IBOutlet NSButton *_windowNumber;
 
@@ -167,11 +169,17 @@ NSString *const iTermProcessTypeDidChangeNotification = @"iTermProcessTypeDidCha
         [[NSNotificationCenter defaultCenter] postNotificationName:kShowFullscreenTabsSettingDidChange
                                                             object:nil];
     };
+
     // There's a menu item to change this setting. We want the control to reflect it.
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(showFullscreenTabsSettingDidChange:)
                                                  name:kShowFullscreenTabsSettingDidChange
                                                object:nil];
+
+    info = [self defineControl:_stretchTabsToFillBar
+                           key:kPreferenceKeyStretchTabsToFillBar
+                          type:kPreferenceInfoTypeCheckbox];
+    info.onChange = ^() { [self postRefreshNotification]; };
 
     info = [self defineControl:_windowNumber
                            key:kPreferenceKeyShowWindowNumber

--- a/sources/iTermPreferences.h
+++ b/sources/iTermPreferences.h
@@ -84,6 +84,7 @@ extern NSString *const kPreferenceKeyShowPaneTitles;
 extern NSString *const kPreferenceKeyHideMenuBarInFullscreen;
 extern NSString *const kPreferenceKeyUIElement;
 extern NSString *const kPreferenceKeyFlashTabBarInFullscreen;
+extern NSString *const kPreferenceKeyStretchTabsToFillBar;
 extern NSString *const kPreferenceKeyShowWindowNumber;
 extern NSString *const kPreferenceKeyShowJobName;
 extern NSString *const kPreferenceKeyShowProfileName;

--- a/sources/iTermPreferences.m
+++ b/sources/iTermPreferences.m
@@ -61,6 +61,7 @@ NSString *const kPreferenceKeyHideTabCloseButton = @"HideTabCloseButton";
 NSString *const kPreferenceKeyHideTabActivityIndicator = @"HideActivityIndicator";
 NSString *const kPreferenceKeyShowNewOutputIndicator = @"ShowNewOutputIndicator";
 NSString *const kPreferenceKeyShowPaneTitles = @"ShowPaneTitles";
+NSString *const kPreferenceKeyStretchTabsToFillBar = @"StretchTabsToFillBar";
 NSString *const kPreferenceKeyHideMenuBarInFullscreen = @"HideMenuBarInFullscreen";
 NSString *const kPreferenceKeyUIElement = @"HideFromDockAndAppSwitcher";
 NSString *const kPreferenceKeyFlashTabBarInFullscreen = @"FlashTabBarInFullscreen";
@@ -218,6 +219,7 @@ static NSMutableDictionary *gObservers;
                   kPreferenceKeyHideTabCloseButton: @NO,
                   kPreferenceKeyHideTabActivityIndicator: @NO,
                   kPreferenceKeyShowNewOutputIndicator: @YES,
+                  kPreferenceKeyStretchTabsToFillBar: @NO,
 
                   kPreferenceKeyShowPaneTitles: @YES,
                   kPreferenceKeyHideMenuBarInFullscreen:@YES,

--- a/sources/iTermRootTerminalView.m
+++ b/sources/iTermRootTerminalView.m
@@ -16,7 +16,7 @@
 #import "iTermToolbeltView.h"
 #import "PTYTabView.h"
 
-const CGFloat kHorizontalTabBarHeight = 22;
+const CGFloat kHorizontalTabBarHeight = 24;
 const CGFloat kDivisionViewHeight = 1;
 
 static const CGFloat kMinimumToolbeltSizeInPoints = 100;

--- a/sources/iTermRootTerminalView.m
+++ b/sources/iTermRootTerminalView.m
@@ -421,6 +421,7 @@ static const CGFloat kMaximumToolbeltSizeAsFractionOfWindow = 0.5;
         [self.tabBarControl setCellMinWidth:[iTermAdvancedSettingsModel minTabWidth]];
     }
     [self.tabBarControl setSizeCellsToFit:[iTermAdvancedSettingsModel useUnevenTabs]];
+    [self.tabBarControl setStretchCellsToFit:[iTermPreferences boolForKey:kPreferenceKeyStretchTabsToFillBar]];
     [self.tabBarControl setCellOptimumWidth:[iTermAdvancedSettingsModel optimumTabWidth]];
     self.tabBarControl.smartTruncation = [iTermAdvancedSettingsModel tabTitlesUseSmartTruncation];
     


### PR DESCRIPTION
This PR makes the tab bar styling used in iTerm more closely match the tab bar styling used across OS X. To more closely match Safari et al., the following changes have been made:

- Show a divider line visible between a selected tab and the status bar.
- Increase the tab bar control height to 26 points.
- Center the content within the tab cells.
- Use a font size of 11 points.