### PR TITLE
Fix imgcat writing -n in output

### DIFF
--- a/tests/imgcat
+++ b/tests/imgcat
@@ -45,7 +45,7 @@ function print_image() {
     echo -n "$3" | base64 $BASE64ARG | wc -c | awk '{printf "size=%d",$1}'
     printf ";inline=$2"
     printf ":"
-    echo -n "$3"
+    printf "%s" "$3"
     print_st
     printf '\n'
     if [[ -n "$4" ]]; then


### PR DESCRIPTION
It seems that 'echo -n' is unreliable. printf never outputs a newline and is safer.

Fixes GL-5201