### PR TITLE
Pre-Sierra Compatibility

### DIFF
--- a/sources/PopupWindow.m
+++ b/sources/PopupWindow.m
@@ -15,7 +15,7 @@
 }
 
 - (instancetype)initWithContentRect:(NSRect)contentRect
-                          styleMask:(NSWindowStyleMask)aStyle
+                          styleMask:(NSUInteger)aStyle
                             backing:(NSBackingStoreType)bufferingType
                               defer:(BOOL)flag {
     self = [super initWithContentRect:contentRect

--- a/sources/iTermWindowImpl.m
+++ b/sources/iTermWindowImpl.m
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (instancetype)initWithContentRect:(NSRect)contentRect
-                          styleMask:(NSWindowStyleMask)aStyle
+                          styleMask:(NSUInteger)aStyle
                             backing:(NSBackingStoreType)bufferingType
                               defer:(BOOL)flag
                              screen:(nullable NSScreen *)screen {


### PR DESCRIPTION
I needed to make these changes to compile on OS X 10.10. Not sure if it's worth dropping support for earlier OS X versions to make that type change to `NSWindowStyleMask`.