### PR TITLE
Fixes a typo 'screen' not 'scren'

### DIFF
--- a/Interfaces/PreferencePanel.xib
+++ b/Interfaces/PreferencePanel.xib
@@ -4870,7 +4870,7 @@ DQ
                 <button id="awA-hH-ziY">
                     <rect key="frame" x="18" y="38" width="306" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <string key="toolTip">For this setting to take effect you must disable "Native full scren windows" in Prefs&gt;General. If this setting is enabled, the menu bar will remain visible. This is useful for multi-monitor systems.</string>
+                    <string key="toolTip">For this setting to take effect you must disable "Native full screen windows" in Prefs&gt;General. If this setting is enabled, the menu bar will remain visible. This is useful for multi-monitor systems.</string>
                     <buttonCell key="cell" type="check" title="Auto-hide menu bar in non-native fullscreen" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="MM6-3I-2ep">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>


### PR DESCRIPTION
The tooltip otherwise reads:

For this setting to take effect you must disable "Native full scren windows"