### PR TITLE
Update bundle identifier for TextMate

### DIFF
--- a/sources/iTermSemanticHistoryPrefsController.m
+++ b/sources/iTermSemanticHistoryPrefsController.m
@@ -19,7 +19,8 @@ NSString *kSublimeText2Identifier = @"com.sublimetext.2";
 NSString *kSublimeText3Identifier = @"com.sublimetext.3";
 NSString *kMacVimIdentifier = @"org.vim.MacVim";
 NSString *kTextmateIdentifier = @"com.macromates.textmate";
-NSString *kTextmate2Identifier = @"com.macromates.TextMate.preview";
+NSString *kTextmate2PreviewIdentifier = @"com.macromates.TextMate.preview";
+NSString *kTextmate2Identifier = @"com.macromates.TextMate";
 NSString *kBBEditIdentifier = @"com.barebones.bbedit";
 NSString *kAtomIdentifier = @"com.github.atom";
 NSString *kSemanticHistoryBestEditorAction = @"best editor";
@@ -45,6 +46,7 @@ enum {
     kSublimeText3Tag,
     kAtomTag,
     kTextmate2Tag,
+    kTextmate2PreviewTag,
     // Only append to the end of the list; never delete or change.
 };
 
@@ -99,6 +101,7 @@ enum {
                                kMacVimIdentifier: @"mvim",
                                kTextmateIdentifier: @"txmt",
                                kTextmate2Identifier: @"txmt",
+                               kTextmate2PreviewIdentifier: @"txmt",
                                kBBEditIdentifier: @"txmt",
                                kAtomIdentifier: @"atom" };
     return schemes[editor];
@@ -111,12 +114,14 @@ enum {
               kMacVimIdentifier,
               kTextmateIdentifier,
               kTextmate2Identifier,
+              kTextmate2PreviewIdentifier,
               kBBEditIdentifier,
               kAtomIdentifier ];
 }
 
 + (NSString *)bestEditor {
-    NSDictionary *overrides = @{ kTextmate2Identifier: kTextmateIdentifier };
+    NSDictionary *overrides = @{ kTextmate2Identifier: kTextmateIdentifier,
+                                 kTextmate2PreviewIdentifier: kTextmateIdentifier };
 
     for (NSString *identifier in [self editorsInPreferenceOrder]) {
         if ([iTermSemanticHistoryPrefsController applicationExists:identifier]) {
@@ -132,6 +137,7 @@ enum {
                                   kMacVimIdentifier,
                                   kTextmateIdentifier,
                                   kTextmate2Identifier,
+                                  kTextmate2PreviewIdentifier,
                                   kBBEditIdentifier,
                                   kAtomIdentifier ];
     return [editorBundleIds containsObject:bundleId];
@@ -143,6 +149,7 @@ enum {
                                   kMacVimIdentifier: @(kMacVimTag),
                                 kTextmateIdentifier: @(kTextmateTag),
                                kTextmate2Identifier: @(kTextmate2Tag),
+                        kTextmate2PreviewIdentifier: @(kTextmate2PreviewTag),
                                   kBBEditIdentifier: @(kBBEditTag),
                                     kAtomIdentifier: @(kAtomTag) };
     return tags;
@@ -152,8 +159,9 @@ enum {
     NSDictionary *names = @{ kSublimeText3Identifier: @"Sublime Text 3",
                              kSublimeText2Identifier: @"Sublime Text 2",
                                    kMacVimIdentifier: @"MacVim",
-                                 kTextmateIdentifier: @"Textmate",
-                                kTextmate2Identifier: @"Textmate 2",
+                                 kTextmateIdentifier: @"Textmate 1",
+                                kTextmate2Identifier: @"Textmate",
+                         kTextmate2PreviewIdentifier: @"Textmate 2 Preview",
                                    kBBEditIdentifier: @"BBEdit",
                                      kAtomIdentifier: @"Atom" };
 
@@ -209,6 +217,7 @@ enum {
                                  @(kMacVimTag): kMacVimIdentifier,
                                @(kTextmateTag): kTextmateIdentifier,
                               @(kTextmate2Tag): kTextmate2Identifier,
+                       @(kTextmate2PreviewTag): kTextmate2PreviewIdentifier,
                                  @(kBBEditTag): kBBEditIdentifier,
                                    @(kAtomTag): kAtomIdentifier };
     return map[@([[editors_ selectedItem] tag])];


### PR DESCRIPTION
Since TextMate has been released as a release candidate it has changed
the bundle identifier and removed the ".preview" suffix [1].

Not sure if we should keep TextMate 1 or not, but I kept it for now.

[1] https://github.com/textmate/textmate/commit/204c735079d01a5bcc43923756827a26a3fbf107