### PR TITLE
Move travis to `osx_image: xcode8.1`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 before_install: ./ci/before_install.sh
 bundler_args: --without documentation --without development --deployment --jobs=3 --retry=3
-osx_image: xcode8
+osx_image: xcode8.1
 language: objective-c
 script: ./ci/script.sh
 after_success: ./ci/after_success.sh


### PR DESCRIPTION
This gives us macOS 10.12.1, which contains `NSTouchBar`.