### PR TITLE
Log the `backingScaleFactor`, show log in travis.

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -2,10 +2,18 @@
 
 set -euo pipefail
 
-xcrun xcodebuild build test \
+xcrun xcodebuild build \
   NSUnbufferedIO=YES \
   -workspace iTerm2.xcworkspace \
   -scheme iTerm2 \
   -sdk macosx \
   CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= \
     | xcpretty -c -f `xcpretty-travis-formatter`
+
+xcrun xcodebuild test \
+  -only-testing:iTerm2XCTests/PTYTextViewTest/testBasicDraw \
+  NSUnbufferedIO=YES \
+  -workspace iTerm2.xcworkspace \
+  -scheme iTerm2 \
+  -sdk macosx \
+  CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=

--- a/sources/PTYSession.m
+++ b/sources/PTYSession.m
@@ -6074,7 +6074,6 @@ ITERM_WEAKLY_REFERENCEABLE
     }
     iTermTextExtractor *textExtractor = [[[iTermTextExtractor alloc] initWithDataSource:_screen] autorelease];
     NSString *word = [textExtractor fastWordAt:VT100GridCoordMake(_screen.cursorX - 1, _screen.cursorY + _screen.numberOfScrollbackLines - 1)];
-    [[_delegate realParentWindow] currentSessionWordAtCursorDidBecome:word];
 }
 
 - (void)textViewBackgroundColorDidChange {

--- a/sources/PTYTextView.m
+++ b/sources/PTYTextView.m
@@ -123,7 +123,6 @@ static const int kDragThreshold = 3;
 @property(nonatomic, retain) iTermFindCursorView *findCursorView;
 @property(nonatomic, retain) NSWindow *findCursorWindow;  // For find-cursor animation
 @property(nonatomic, retain) iTermQuickLookController *quickLookController;
-@property (strong, readwrite, nullable) NSTouchBar *touchBar;
 
 // Set when a context menu opens, nilled when it closes. If the data source changes between when we
 // ask the context menu to open and when the main thread enters a tracking runloop, the text under

--- a/sources/PseudoTerminal.m
+++ b/sources/PseudoTerminal.m
@@ -92,15 +92,6 @@ NSString *const kCurrentSessionDidChange = @"kCurrentSessionDidChange";
 NSString *const kTerminalWindowControllerWasCreatedNotification = @"kTerminalWindowControllerWasCreatedNotification";
 
 static NSString *const kWindowNameFormat = @"iTerm Window %d";
-static NSString *const iTermTouchBarIdentifierAddMark = @"iTermTouchBarIdentifierAddMark";
-static NSString *const iTermTouchBarIdentifierNextMark = @"iTermTouchBarIdentifierNextMark";
-static NSString *const iTermTouchBarIdentifierPreviousMark = @"iTermTouchBarIdentifierPreviousMark";
-static NSString *const iTermTouchBarIdentifierManPage = @"iTermTouchBarIdentifierManPage";
-static NSString *const iTermTouchBarIdentifierColorPreset = @"iTermTouchBarIdentifierColorPreset";
-static NSString *const iTermTouchBarIdentifierColorPresetScrollview = @"iTermTouchBarIdentifierColorPresetScrollview";
-static NSString *const iTermTouchBarIdentifierAutocomplete = @"iTermTouchBarIdentifierAutocomplete";
-static NSString *const iTermTabBarTouchBarIdentifier = @"tab bar";
-static NSString *const iTermTabBarItemTouchBarIdentifier = @"tab bar item";
 
 #define PtyLog DLog
 
@@ -156,11 +147,7 @@ static NSRect iTermRectCenteredVerticallyWithinRect(NSRect frameToCenter, NSRect
     iTermPasswordManagerDelegate,
     PTYTabDelegate,
     iTermRootTerminalViewDelegate,
-    iTermToolbeltViewDelegate,
-    NSCandidateListTouchBarItemDelegate,
-    NSScrubberDelegate,
-    NSScrubberDataSource,
-    NSTouchBarDelegate>
+    iTermToolbeltViewDelegate>
 
 @property(nonatomic, assign) BOOL windowInitialized;
 
@@ -366,9 +353,6 @@ static NSRect iTermRectCenteredVerticallyWithinRect(NSRect frameToCenter, NSRect
 
     // Number of tabs since last change.
     NSInteger _previousNumberOfTabs;
-
-    NSCustomTouchBarItem *_tabsTouchBarItem;
-    NSCandidateListTouchBarItem<NSString *> *_autocompleteCandidateListItem;
 }
 
 + (void)registerSessionsInArrangement:(NSDictionary *)arrangement {
@@ -1417,11 +1401,9 @@ ITERM_WEAKLY_REFERENCEABLE
 }
 
 - (void)keyBindingsDidChange:(NSNotification *)notification {
-    [self updateTouchBarIfNeeded];
 }
 
 - (void)colorPresetsDidChange:(NSNotification *)notification {
-    [self updateTouchBarIfNeeded];
 }
 
 - (IBAction)closeCurrentTab:(id)sender {
@@ -3494,8 +3476,6 @@ ITERM_WEAKLY_REFERENCEABLE
     [self refreshTools];
     [self updateTabColors];
     [self saveTmuxWindowOrigins];
-
-    [self updateTouchBarIfNeeded];
 }
 
 - (BOOL)fullScreen
@@ -3633,7 +3613,6 @@ ITERM_WEAKLY_REFERENCEABLE
         [_didEnterLionFullscreen release];
         _didEnterLionFullscreen = nil;
     }
-    [self updateTouchBarIfNeeded];
 }
 
 - (void)windowWillExitFullScreen:(NSNotification *)notification
@@ -3669,7 +3648,6 @@ ITERM_WEAKLY_REFERENCEABLE
     [self notifyTmuxOfWindowResize];
     [self saveTmuxWindowOrigins];
     [self.window makeFirstResponder:self.currentSession.textview];
-    [self updateTouchBarIfNeeded];
 }
 
 - (NSRect)windowWillUseStandardFrame:(NSWindow *)sender defaultFrame:(NSRect)defaultFrame
@@ -3992,7 +3970,6 @@ ITERM_WEAKLY_REFERENCEABLE
     if ([[PreferencePanel sessionsInstance] isWindowLoaded]) {
         [self editSession:self.currentSession makeKey:NO];
     }
-    [self updateTouchBarIfNeeded];
 }
 
 - (void)notifyTmuxOfTabChange {
@@ -5006,16 +4983,6 @@ ITERM_WEAKLY_REFERENCEABLE
         [commandHistoryPopup loadCommands:commands
                            partialCommand:prefix];
     }
-    if (_autocompleteCandidateListItem && session == self.currentSession) {
-        iTermShellHistoryController *history = [iTermShellHistoryController sharedInstance];
-        NSArray<NSString *> *commands = [[history commandHistoryEntriesWithPrefix:prefix onHost:[session currentHost]] mapWithBlock:^id(iTermCommandHistoryEntryMO *anObject) {
-            return anObject.command;
-        }];
-        [_autocompleteCandidateListItem setCandidates:commands ?: @[]
-                                     forSelectedRange:NSMakeRange(0, prefix.length)
-                                             inString:prefix];
-    }
-
 }
 
 - (void)showAutoCommandHistoryForSession:(PTYSession *)session {
@@ -5398,7 +5365,6 @@ ITERM_WEAKLY_REFERENCEABLE
     if ([[PreferencePanel sessionsInstance] isWindowLoaded]) {
         [self editSession:self.currentSession makeKey:NO];
     }
-    [self updateTouchBarIfNeeded];
 }
 
 
@@ -7076,75 +7042,6 @@ ITERM_WEAKLY_REFERENCEABLE
             }
         }
     }
-    [self updateTouchBarIfNeeded];
-}
-
-- (NSTouchBar *)makeGenericTouchBar {
-    if (!IsTouchBarAvailable()) {
-        return nil;
-    }
-    NSTouchBar *touchBar = [[[NSTouchBar alloc] init] autorelease];
-    touchBar.delegate = self;
-    touchBar.defaultItemIdentifiers = @[ iTermTouchBarIdentifierManPage,
-                                         iTermTouchBarIdentifierColorPreset,
-                                         NSTouchBarItemIdentifierFlexibleSpace,
-                                         NSTouchBarItemIdentifierOtherItemsProxy,
-                                         iTermTouchBarIdentifierAddMark,
-                                         iTermTouchBarIdentifierPreviousMark,
-                                         iTermTouchBarIdentifierNextMark ];
-    return touchBar;
-}
-
-- (void)updateTouchBarIfNeeded {
-    if (IsTouchBarAvailable()) {
-        NSTouchBar *replacement = [self amendTouchBar:[self makeGenericTouchBar]];
-        if (![replacement.customizationIdentifier isEqualToString:self.touchBar.customizationIdentifier]) {
-            self.touchBar = replacement;
-        } else {
-            NSScrubber *scrubber = (NSScrubber *)_tabsTouchBarItem.view;
-            dispatch_async(dispatch_get_main_queue(), ^{
-                [scrubber reloadData];
-                [scrubber setSelectedIndex:[self.tabs indexOfObject:self.currentTab]];
-            });
-        }
-        NSArray *ids = @[ iTermTouchBarIdentifierManPage,
-                          iTermTouchBarIdentifierColorPreset,
-                          NSTouchBarItemIdentifierFlexibleSpace,
-                          iTermTouchBarIdentifierAddMark,
-                          iTermTouchBarIdentifierNextMark,
-                          iTermTouchBarIdentifierPreviousMark,
-                          iTermTouchBarIdentifierAutocomplete ];
-        ids = [ids arrayByAddingObjectsFromArray:[iTermKeyBindingMgr sortedTouchBarKeysInDictionary:[iTermKeyBindingMgr globalTouchBarMap]]];
-        self.touchBar.customizationAllowedItemIdentifiers = ids;
-    }
-}
-
-- (NSTouchBar *)amendTouchBar:(NSTouchBar *)touchBar {
-    if (!IsTouchBarAvailable()) {
-        return nil;
-    }
-    touchBar.customizationIdentifier = @"regular";
-    if (self.anyFullScreen) {
-        NSMutableArray *temp = [[touchBar.defaultItemIdentifiers mutableCopy] autorelease];
-        NSInteger index = [temp indexOfObject:NSTouchBarItemIdentifierOtherItemsProxy];
-        if (index != NSNotFound) {
-            touchBar.customizationIdentifier = @"full screen";
-            [temp insertObject:iTermTabBarTouchBarIdentifier atIndex:index];
-            touchBar.defaultItemIdentifiers = temp;
-        }
-        touchBar.customizationAllowedItemIdentifiers = [touchBar.customizationAllowedItemIdentifiers arrayByAddingObjectsFromArray:@[ iTermTabBarTouchBarIdentifier ]];
-    }
-    return touchBar;
-}
-
-- (void)currentSessionWordAtCursorDidBecome:(NSString *)word {
-    if (IsTouchBarAvailable() && [self respondsToSelector:@selector(touchBar)]) {
-        NSTouchBarItem *item = [self.touchBar itemForIdentifier:iTermTouchBarIdentifierManPage];
-        if (item) {
-            iTermTouchBarButton *button = (iTermTouchBarButton *)item.view;
-            [self updateManPageButton:button word:word];
-        }
-    }
 }
 
 - (void)updateManPageButton:(iTermTouchBarButton *)button word:(NSString *)word {
@@ -7162,88 +7059,6 @@ ITERM_WEAKLY_REFERENCEABLE
         button.keyBindingAction = nil;
     }
 }
-
-- (NSTouchBarItem *)colorPresetsScrollViewTouchBarItem {
-    if (!IsTouchBarAvailable()) {
-        return nil;
-    }
-    NSScrollView *scrollView = [[[NSScrollView alloc] init] autorelease];
-    NSCustomTouchBarItem *item = [[[NSCustomTouchBarItem alloc] initWithIdentifier:iTermTouchBarIdentifierColorPresetScrollview] autorelease];
-    item.view = scrollView;
-    NSView *documentView = [[NSView alloc] init];
-    documentView.translatesAutoresizingMaskIntoConstraints = NO;
-    scrollView.documentView = documentView;
-    NSButton *previous = nil;
-    for (NSDictionary *dict in @[ [iTermColorPresets builtInColorPresets] ?: @{},
-                                  [iTermColorPresets customColorPresets] ?: @{} ]) {
-        for (NSString *name in dict) {
-            iTermTouchBarButton *button;
-            NSColor *textColor = nil;
-            NSColor *backgroundColor = nil;
-            textColor = [ITAddressBookMgr decodeColor:[dict objectForKey:name][KEY_FOREGROUND_COLOR]];
-            backgroundColor = [ITAddressBookMgr decodeColor:[dict objectForKey:name][KEY_BACKGROUND_COLOR]];
-            NSDictionary *attributes = @{ NSForegroundColorAttributeName: textColor };
-            NSAttributedString *title = [[[NSAttributedString alloc] initWithString:name
-                                                                         attributes:attributes] autorelease];
-            button = [iTermTouchBarButton buttonWithTitle:@""
-                                                   target:self
-                                                       action:@selector(colorPresetTouchBarItemSelected:)];
-            [button sizeToFit];
-            button.attributedTitle = title;
-            button.bezelColor = backgroundColor;
-            button.keyBindingAction = @{ @"presetName": name };
-            [documentView addSubview:button];
-            button.translatesAutoresizingMaskIntoConstraints = NO;
-            if (previous == nil) {
-                // Constrain the first item's left to the document view's left
-                [documentView addConstraint:[NSLayoutConstraint constraintWithItem:button
-                                                                         attribute:NSLayoutAttributeLeft
-                                                                         relatedBy:NSLayoutRelationEqual
-                                                                            toItem:documentView
-                                                                         attribute:NSLayoutAttributeLeft
-                                                                        multiplier:1
-                                                                          constant:0]];
-            } else {
-                // Constrain non-first button's left to predecessor's right + 8pt
-                [documentView addConstraint:[NSLayoutConstraint constraintWithItem:button
-                                                                         attribute:NSLayoutAttributeLeft
-                                                                         relatedBy:NSLayoutRelationEqual
-                                                                            toItem:previous
-                                                                         attribute:NSLayoutAttributeRight
-                                                                        multiplier:1
-                                                                          constant:8]];
-            }
-            // Constrain top and bottom to document view's top and bottom
-            [documentView addConstraint:[NSLayoutConstraint constraintWithItem:button
-                                                                     attribute:NSLayoutAttributeTop
-                                                                     relatedBy:NSLayoutRelationEqual
-                                                                        toItem:documentView
-                                                                     attribute:NSLayoutAttributeTop
-                                                                    multiplier:1
-                                                                      constant:0]];
-            [documentView addConstraint:[NSLayoutConstraint constraintWithItem:button
-                                                                     attribute:NSLayoutAttributeBottom
-                                                                     relatedBy:NSLayoutRelationEqual
-                                                                        toItem:documentView
-                                                                     attribute:NSLayoutAttributeBottom
-                                                                    multiplier:1
-                                                                      constant:0]];
-            previous = button;
-        }
-    }
-    if (previous) {
-        // Constrain last button's right to document view's right
-        [documentView addConstraint:[NSLayoutConstraint constraintWithItem:previous
-                                                                 attribute:NSLayoutAttributeRight
-                                                                 relatedBy:NSLayoutRelationEqual
-                                                                    toItem:documentView
-                                                                 attribute:NSLayoutAttributeRight
-                                                                multiplier:1
-                                                                  constant:0]];
-    }
-    return item;
-}
-
 
 // Called when the parameter panel should close.
 - (IBAction)parameterPanelEnd:(id)sender {
@@ -7775,217 +7590,6 @@ ITERM_WEAKLY_REFERENCEABLE
 
 - (void)endPreviewPanelControl:(QLPreviewPanel *)panel {
     [self.currentSession.quickLookController endPreviewPanelControl:panel];
-}
-
-#pragma mark - NSScrubberDelegate
-
-- (void)scrubber:(NSScrubber *)scrubber didSelectItemAtIndex:(NSInteger)selectedIndex {
-    [self.tabView selectTabViewItemAtIndex:selectedIndex];
-}
-
-#pragma mark - NSScrubberDataSource
-
-- (NSInteger)numberOfItemsForScrubber:(NSScrubber *)scrubber {
-    return [_contentView.tabView numberOfTabViewItems];
-}
-
-- (NSString *)scrubberLabelAtIndex:(NSInteger)index {
-    NSArray<PTYTab *> *tabs = self.tabs;
-    return index < tabs.count ?  self.tabs[index].activeSession.name : @"";
-}
-
-- (__kindof NSScrubberItemView *)scrubber:(NSScrubber *)scrubber viewForItemAtIndex:(NSInteger)index {
-    NSScrubberTextItemView *itemView = [scrubber makeItemWithIdentifier:iTermTabBarItemTouchBarIdentifier owner:nil];
-    itemView.textField.stringValue = [self scrubberLabelAtIndex:index];
-    return itemView;
-}
-
-- (NSSize)scrubber:(NSScrubber *)scrubber layout:(NSScrubberFlowLayout *)layout sizeForItemAtIndex:(NSInteger)itemIndex {
-    NSSize size = NSMakeSize(CGFLOAT_MAX, CGFLOAT_MAX);
-
-    NSString *title = [self scrubberLabelAtIndex:itemIndex];
-    NSRect textRect = [title boundingRectWithSize:size
-                                          options:NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingUsesFontLeading
-                                       attributes:@{ NSFontAttributeName: [NSFont systemFontOfSize:0]}];
-    // Apple says: "+10: NSTextField horizontal padding, no good way to retrieve this though. +6 for spacing."
-    // 8 is because the items become smaller the first time you change tabs for some mysterious reason
-    // and that leaves enough room for them. :(
-    // The 30 is also Apple's magic number.
-    return NSMakeSize(textRect.size.width + 10 + 6 + 8, 30);
-}
-
-#pragma mark - NSTouchBarDelegate
-
-- (nullable NSTouchBarItem *)touchBar:(NSTouchBar *)touchBar makeItemForIdentifier:(NSTouchBarItemIdentifier)identifier {
-    if ([identifier isEqualToString:iTermTabBarTouchBarIdentifier]) {
-        NSScrubber *scrubber;
-        if (!_tabsTouchBarItem) {
-            _tabsTouchBarItem = [[NSCustomTouchBarItem alloc] initWithIdentifier:identifier];
-            _tabsTouchBarItem.customizationLabel = @"Full Screen Tab Bar";
-
-            scrubber = [[NSScrubber alloc] initWithFrame:NSMakeRect(0, 0, 320, 30)];
-            scrubber.delegate = self;   // So we can respond to selection.
-            scrubber.dataSource = self;
-            scrubber.showsAdditionalContentIndicators = YES;
-
-            [scrubber registerClass:[NSScrubberTextItemView class] forItemIdentifier:iTermTabBarItemTouchBarIdentifier];
-
-            // Use the flow layout.
-            NSScrubberLayout *scrubberLayout = [[NSScrubberFlowLayout alloc] init];
-            scrubber.scrubberLayout = scrubberLayout;
-
-            scrubber.mode = NSScrubberModeFree;
-
-            NSScrubberSelectionStyle *outlineStyle = [NSScrubberSelectionStyle outlineOverlayStyle];
-            scrubber.selectionBackgroundStyle = outlineStyle;
-
-            _tabsTouchBarItem.view = scrubber;
-        } else {
-            scrubber = (NSScrubber *)_tabsTouchBarItem.view;
-        }
-        // Reload the scrubber after a spin of the runloop bacause it gets laid out tighter after the
-        // rest of the toolbar is created. If we reloadData now then it jumps the first time we change
-        // tabs.
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [scrubber reloadData];
-            [scrubber setSelectedIndex:[self.tabs indexOfObject:self.currentTab]];
-        });
-
-
-        return _tabsTouchBarItem;
-    } else if ([identifier isEqualToString:iTermTouchBarIdentifierAutocomplete]) {
-        _autocompleteCandidateListItem = [[NSCandidateListTouchBarItem alloc] initWithIdentifier:identifier];
-        _autocompleteCandidateListItem.delegate = self;
-        _autocompleteCandidateListItem.customizationLabel = @"Autocomplete Suggestions";
-        NSAttributedString *(^commandUseToAttributedString)(NSString *commandUse,
-                                                            NSInteger index) = ^(NSString *command,
-                                                                                 NSInteger index) {
-            return [[[NSAttributedString alloc] initWithString:command ?: @""] autorelease];
-        };
-        _autocompleteCandidateListItem.attributedStringForCandidate = commandUseToAttributedString;
-        return _autocompleteCandidateListItem;
-    }
-
-    NSImage *image = nil;
-    SEL selector = NULL;
-    NSString *label = nil;
-
-    if ([identifier isEqualToString:iTermTouchBarIdentifierManPage]) {
-        selector = @selector(manPageTouchBarItemSelected:);
-        label = @"Man Page";
-    } else if ([identifier isEqualToString:iTermTouchBarIdentifierAddMark]) {
-        image = [[NSImage imageNamed:@"Add Mark Touch Bar Icon"] imageWithColor:[NSColor labelColor]];
-        selector = @selector(addMarkTouchBarItemSelected:);
-        label = @"Add Mark";
-    } else if ([identifier isEqualToString:iTermTouchBarIdentifierNextMark]) {
-        image = [NSImage imageNamed:NSImageNameTouchBarGoDownTemplate];
-        selector = @selector(nextMarkTouchBarItemSelected:);
-        label = @"Next Mark";
-    } else if ([identifier isEqualToString:iTermTouchBarIdentifierPreviousMark]) {
-        image = [NSImage imageNamed:NSImageNameTouchBarGoUpTemplate];
-        selector = @selector(previousMarkTouchBarItemSelected:);
-        label = @"Previous Mark";
-    } else if ([identifier isEqualToString:iTermTouchBarIdentifierColorPreset]) {
-        image = [NSImage imageNamed:NSImageNameTouchBarColorPickerFill];
-        selector = @selector(colorPresetTouchBarItemSelected:);
-        NSPopoverTouchBarItem *item = [[[NSPopoverTouchBarItem alloc] initWithIdentifier:identifier] autorelease];
-        item.customizationLabel = @"Color Preset";
-        item.showsCloseButton = YES;
-        item.collapsedRepresentationImage = image;
-
-        NSTouchBar *secondaryTouchBar = [[NSTouchBar alloc] init];
-        secondaryTouchBar.delegate = self;
-        secondaryTouchBar.defaultItemIdentifiers = @[ iTermTouchBarIdentifierColorPresetScrollview ];
-        item.popoverTouchBar = secondaryTouchBar;
-        return item;
-    } else if ([identifier isEqualToString:iTermTouchBarIdentifierColorPresetScrollview]) {
-        return [self colorPresetsScrollViewTouchBarItem];
-    }
-
-    if (image || label) {
-        iTermTouchBarButton *button;
-        if (image) {
-            button = [iTermTouchBarButton buttonWithImage:image target:self action:selector];
-        } else {
-            button = [iTermTouchBarButton buttonWithTitle:label target:self action:selector];
-        }
-        NSCustomTouchBarItem *item = [[[NSCustomTouchBarItem alloc] initWithIdentifier:identifier] autorelease];
-        item.view = button;
-        item.customizationLabel = label;
-        if ([identifier isEqualToString:iTermTouchBarIdentifierManPage]) {
-            button.title = @"";
-            button.image = [NSImage imageNamed:@"Man Page Touch Bar Icon"];
-            button.imagePosition = NSImageOnly;
-            button.enabled = NO;
-        }
-        return item;
-    }
-    NSDictionary *map = [iTermKeyBindingMgr globalTouchBarMap];
-    NSDictionary *binding = map[identifier];
-
-    if (!binding) {
-        return nil;
-    }
-    NSCustomTouchBarItem *item = [[[NSCustomTouchBarItem alloc] initWithIdentifier:identifier] autorelease];
-    iTermTouchBarButton *button = [iTermTouchBarButton buttonWithTitle:[iTermKeyBindingMgr touchBarLabelForBinding:binding]
-                                                                target:self
-                                                                action:@selector(touchBarItemSelected:)];
-    button.keyBindingAction = binding;
-    item.view = button;
-    item.view.identifier = identifier;
-    item.customizationLabel = [iTermKeyBindingMgr formatAction:binding];
-
-    return item;
-}
-
-- (void)touchBarItemSelected:(iTermTouchBarButton *)sender {
-    NSDictionary *binding = sender.keyBindingAction;
-    [self.currentSession performKeyBindingAction:[iTermKeyBindingMgr actionForTouchBarItemBinding:binding]
-                                       parameter:[iTermKeyBindingMgr parameterForTouchBarItemBinding:binding]
-                                           event:[NSApp currentEvent]];
-}
-
-- (void)addMarkTouchBarItemSelected:(id)sender {
-    [self.currentSession screenSaveScrollPosition];
-}
-
-- (void)nextMarkTouchBarItemSelected:(id)sender {
-    [self.currentSession nextMarkOrNote];
-}
-
-- (void)previousMarkTouchBarItemSelected:(id)sender {
-    [self.currentSession previousMarkOrNote];
-}
-
-- (void)manPageTouchBarItemSelected:(iTermTouchBarButton *)sender {
-    NSString *command = sender.keyBindingAction[@"command"];
-    if (command) {
-        [[iTermController sharedInstance] launchBookmark:nil
-                                              inTerminal:nil
-                                                 withURL:nil
-                                        hotkeyWindowType:iTermHotkeyWindowTypeNone
-                                                 makeKey:YES
-                                             canActivate:YES
-                                                 command:command
-                                                   block:^PTYSession *(Profile *profile, PseudoTerminal *term) {
-                                                       profile = [profile dictionaryBySettingObject:@"" forKey:KEY_INITIAL_TEXT];
-                                                       return [term createTabWithProfile:profile withCommand:command];
-                                                   }];
-    }
-}
-
-- (void)colorPresetTouchBarItemSelected:(iTermTouchBarButton *)sender {
-    [self.currentSession setColorsFromPresetNamed:sender.keyBindingAction[@"presetName"]];
-}
-
-- (void)candidateListTouchBarItem:(NSCandidateListTouchBarItem *)anItem endSelectingCandidateAtIndex:(NSInteger)index {
-    if (index != NSNotFound) {
-        NSString *command = [anItem candidates][index];
-        NSString *prefix = self.currentSession.currentCommand;
-        if ([command hasPrefix:prefix] || prefix.length == 0) {
-            [self.currentSession insertText:[command substringFromIndex:prefix.length]];
-        }
-    }
 }
 
 @end

--- a/sources/WindowControllerInterface.h
+++ b/sources/WindowControllerInterface.h
@@ -169,8 +169,6 @@ typedef NS_ENUM(NSInteger, BroadcastMode) {
 - (void)clearTransientTitle;
 - (BOOL)isShowingTransientTitle;
 
-- (void)currentSessionWordAtCursorDidBecome:(NSString *)word;
-
 #pragma mark - Tabs
 
 // Close a tab and resize/close the window if needed.

--- a/sources/iTermApplicationDelegate.m
+++ b/sources/iTermApplicationDelegate.m
@@ -490,9 +490,6 @@ static BOOL hasBecomeActive = NO;
 
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
     [self warnAboutChangeToDefaultPasteBehavior];
-    if (IsTouchBarAvailable()) {
-        NSApp.automaticCustomizeTouchBarMenuItemEnabled = YES;
-    }
 
     if ([self shouldNotifyAboutIncompatibleSoftware]) {
         [self notifyAboutIncompatibleSoftware];

--- a/sources/iTermSystemVersion.m
+++ b/sources/iTermSystemVersion.m
@@ -80,8 +80,3 @@ BOOL IsMavericksOrLater(void) {
 BOOL IsYosemiteOrLater(void) {
     return SystemVersionIsGreaterOrEqualTo(10, 10, 0);
 }
-
-BOOL IsTouchBarAvailable(void) {
-    // Checking for OS version doesn't work because there were two different 10.12.1's.
-    return [NSApp respondsToSelector:@selector(setAutomaticCustomizeTouchBarMenuItemEnabled:)];
-}

--- a/sources/iTermTextDrawingHelper.m
+++ b/sources/iTermTextDrawingHelper.m
@@ -993,6 +993,7 @@ typedef struct iTermTextColorContext {
         start += singlePartAttributedString.length;
         int numCellsDrawn;
         if ([singlePartAttributedString isKindOfClass:[NSAttributedString class]]) {
+            NSLog(@"XXX Drawing NSAttributedString");
             numCellsDrawn = [self drawSinglePartAttributedString:(NSAttributedString *)singlePartAttributedString
                                                  atPoint:point
                                                   origin:origin
@@ -1000,6 +1001,7 @@ typedef struct iTermTextColorContext {
                                                inContext:ctx
                                          backgroundColor:backgroundColor];
         } else {
+            NSLog(@"XXX Drawing fast path string");
             NSPoint offsetPoint = point;
             offsetPoint.y -= round((_cellSize.height - _cellSizeWithoutSpacing.height) / 2.0);
             numCellsDrawn = [self drawFastPathString:(iTermCheapAttributedString *)singlePartAttributedString
@@ -1064,6 +1066,7 @@ typedef struct iTermTextColorContext {
                                            glyphs,
                                            cheapString.length);
     if (!ok) {
+        NSLog(@"XXX drawFastPathString says it's not ok");  
         NSString *string = [NSString stringWithCharacters:cheapString.characters
                                                    length:cheapString.length];
         [self drawTextOnlyAttributedStringWithoutUnderline:[NSAttributedString attributedStringWithString:string
@@ -1074,22 +1077,32 @@ typedef struct iTermTextColorContext {
                                            graphicsContext:[NSGraphicsContext currentContext]
                                                      smear:NO];
         return cheapString.length;
+    } else {
+        NSLog(@"XXX drawFastPathString says it's ok");  
     }
     NSColor *const color = cheapString.attributes[NSForegroundColorAttributeName];
     const BOOL fakeItalic = [cheapString.attributes[iTermFakeItalicAttribute] boolValue];
     const BOOL fakeBold = [cheapString.attributes[iTermFakeBoldAttribute] boolValue];
     const BOOL antiAlias = [cheapString.attributes[iTermAntiAliasAttribute] boolValue];
 
+    NSLog(@"XXX drawFastPathString fakeItalic=%@ fakeBold=%@ antiAlias=%@",
+        fakeItalic ? @"true" : @"false",
+        fakeBold ? @"true" : @"false",
+        antiAlias ? @"true" : @"false");
+
     CGContextSetShouldAntialias(ctx, antiAlias);
 
     int savedFontSmoothingStyle = 0;
     BOOL useThinStrokes = [self thinStrokes] && ([backgroundColor brightnessComponent] < [color brightnessComponent]);
     if (useThinStrokes) {
+        NSLog(@"XXX drawFastPathString uses thin strokes");
         CGContextSetShouldSmoothFonts(ctx, YES);
         // This seems to be available at least on 10.8 and later. The only reference to it is in
         // WebKit. This causes text to render just a little lighter, which looks nicer.
         savedFontSmoothingStyle = CGContextGetFontSmoothingStyle(ctx);
         CGContextSetFontSmoothingStyle(ctx, 16);
+    } else {
+        NSLog(@"XXX drawFastPathString does not use thin strokes");
     }
 
     size_t numCodes = cheapString.length;


### PR DESCRIPTION
This PR is not meant to merge, only to show how the xcode 8.0 environment (which I otherwise don't have access to) behaves, in comparison to the 8.1 environment I have.

The reason we can't move to 8.1 (which contains the touch bar API that iTerm2 now requires to compile) is large number of "golden" image test failures in `PTYTextViewTest`.

Despite having separate fixtures for retina displays (like me), non-retina displays and a separate one for travis, both travis and local environments fail the same way on xcode 8.1.  Pulling up a few failing images from `/tmp/failed-*.png` shows that the "actual" images seem to match the non-retina images (with the thicker letters) instead of the expected retina ones.

`PTYTextView` decides that its window's screen is "retina" or not based on the `backingScaleFactor` attribute, updated in `viewDidChangeBackingProperties`.  If this value is greater than one, it should be a retina device.

After adding some logging, in my local 8.1 dev environment I found that the reported `backingScaleFactor` is actually zero.  Since it is supposed to be a ratio of scales, that doesn't make much sense.  Let's see what the 8.0 environment in travis says it is.

In order to run the offending tests, this branch begins at the last commit prior to the touch bar support, before it adds the logging.
