### PR TITLE
Borderless rounded

### DIFF
--- a/sources/PseudoTerminal.m
+++ b/sources/PseudoTerminal.m
@@ -394,7 +394,13 @@ static NSRect iTermRectCenteredVerticallyWithinRect(NSRect frameToCenter, NSRect
         case WINDOW_TYPE_LEFT_PARTIAL:
         case WINDOW_TYPE_RIGHT_PARTIAL:
         case WINDOW_TYPE_NO_TITLE_BAR:
-            return mask | NSBorderlessWindowMask | NSResizableWindowMask;
+            return (mask |
+                    NSTitledWindowMask |
+                    NSClosableWindowMask |
+                    NSMiniaturizableWindowMask |
+                    NSResizableWindowMask |
+                    NSTexturedBackgroundWindowMask |
+                    NSFullSizeContentViewWindowMask);
 
         case WINDOW_TYPE_TRADITIONAL_FULL_SCREEN:
             return mask | NSBorderlessWindowMask;
@@ -609,7 +615,7 @@ static NSRect iTermRectCenteredVerticallyWithinRect(NSRect frameToCenter, NSRect
         [myWindow setFrame:initialFrame display:NO];
     }
 
-    [myWindow setHasShadow:(windowType == WINDOW_TYPE_NORMAL)];
+    [myWindow setHasShadow:((windowType == WINDOW_TYPE_NORMAL) || (windowType == WINDOW_TYPE_NO_TITLE_BAR))];
 
     DLog(@"Create window %@", myWindow);
 
@@ -657,6 +663,11 @@ static NSRect iTermRectCenteredVerticallyWithinRect(NSRect frameToCenter, NSRect
             // TODO: Why is this here?
             self.window.bottomCornerRounded = NO;
         }
+    }
+    
+    if (windowType == WINDOW_TYPE_NO_TITLE_BAR) {
+        [[self window] setTitlebarAppearsTransparent:YES];
+        [[[self window] standardWindowButton:NSWindowCloseButton].superview.superview setHidden:YES];
     }
 
     [self updateTabBarStyle];


### PR DESCRIPTION
![screen shot 2016-12-23 at 5 17 00 am](https://cloud.githubusercontent.com/assets/6215387/21450621/0db7272a-c8cf-11e6-848e-9e8a989199c4.png)

Changes borderless terminal windows to be rounded instead of square, 10.10+ only
