### PR TITLE
Fix bug with signal handling in catch.c

### DIFF
--- a/tests/catch.c
+++ b/tests/catch.c
@@ -2,8 +2,10 @@
 #include <signal.h>
 #include <unistd.h>
 
+sig_atomic_t caught_sigint = 0;
+
 void InterruptHandler(int signo) {
-  printf("Caught SIGINT\n");
+  caught_sigint = 1;
 }
 
 int main(int argc, char *argv[]) {
@@ -14,7 +16,9 @@ int main(int argc, char *argv[]) {
 
   while(1) {
     sleep(1);
+    if (caught_sigint) {
+      printf("Caught SIGINT\n");
+      caught_sigint = 0;
+    }
   }
-
-  return 0;
 }


### PR DESCRIPTION
Signal handlers might be called repeatedly. As such they can't call
non-async-safe functions such as printf. Instead set a sentinel and
check for it.