### PR TITLE
fix activity indicator in the tabbar

### DIFF
--- a/ThirdParty/AMIndeterminateProgressIndicator/AMIndeterminateProgressIndicator.m
+++ b/ThirdParty/AMIndeterminateProgressIndicator/AMIndeterminateProgressIndicator.m
@@ -149,8 +149,8 @@ static CGFloat DegreesToRadians(double radians) {
 
     for (NSInteger i = 0; i < self.numberOfSteps; i++) {
         CGFloat currentAngle = initialAngle - DegreesToRadians(anglePerStep) * i;
-        [[_color colorWithAlphaComponent:1.0 - sqrt(i) * 0.25] set];
-        
+        [[_color colorWithAlphaComponent:1.0 - sqrt(self.numberOfSteps - 1 - i) * 0.25] set];
+
         outerPoint = NSMakePoint(center.x + cos(currentAngle) * outerRadius,
                                  center.y + sin(currentAngle) * outerRadius);
         


### PR DESCRIPTION
The activity spinner in iTerm would look pretty different then in most other apps: a segment would start very light and become darker and darker instead of starting dark and fading out. This diff reverses the fading effect.

Before:
![spinnerbefore](https://cloud.githubusercontent.com/assets/33906/26406865/e1437296-4099-11e7-8c4a-50e18800fe1f.gif)

After:
![spinnerafter](https://cloud.githubusercontent.com/assets/33906/26406875/e598e524-4099-11e7-9efc-08fddf5ea2cf.gif)
