### PR TITLE
Add "check for updates" to menubar icon

### DIFF
--- a/Interfaces/MainMenu.xib
+++ b/Interfaces/MainMenu.xib
@@ -1120,6 +1120,7 @@ DQ
                 <outlet property="sendInputToAllPanes" destination="1266" id="1279"/>
                 <outlet property="sendInputToAllSessions" destination="1264" id="1278"/>
                 <outlet property="showFullScreenTabs" destination="1257" id="1260"/>
+                <outlet property="suUpdater" destination="879" id="FRj-mW-Vma"/>
                 <outlet property="toolbeltMenu" destination="1296" id="1299"/>
                 <outlet property="useTransparency" destination="1228" id="1230"/>
                 <outlet property="windowArrangementsAsTabs_" destination="z6V-EJ-Ntf" id="wse-Wc-WVw"/>

--- a/sources/iTermApplicationDelegate.m
+++ b/sources/iTermApplicationDelegate.m
@@ -166,6 +166,7 @@ static const NSTimeInterval kOneMonth = 30 * 24 * 60 * 60;
     IBOutlet NSMenuItem *showFullScreenTabs;
     IBOutlet NSMenuItem *useTransparency;
     IBOutlet NSMenuItem *maximizePane;
+    IBOutlet SUUpdater * suUpdater;
     IBOutlet NSMenuItem *_showTipOfTheDay;  // Here because we must remove it for older OS versions.
     BOOL secureInputDesired_;
     BOOL quittingBecauseLastWindowClosed_;
@@ -1067,6 +1068,7 @@ static const NSTimeInterval kOneMonth = 30 * 24 * 60 * 60;
 - (NSMenu *)statusBarMenu {
     NSMenu *menu = [[NSMenu alloc] init];
     NSMenuItem *item;
+
     item = [[[NSMenuItem alloc] initWithTitle:@"Preferences"
                                        action:@selector(showAndOrderFrontRegardlessPrefWindow:)
                                 keyEquivalent:@""] autorelease];
@@ -1074,6 +1076,11 @@ static const NSTimeInterval kOneMonth = 30 * 24 * 60 * 60;
     
     item = [[[NSMenuItem alloc] initWithTitle:@"Bring All Windows to Front"
                                        action:@selector(arrangeInFront:)
+                                keyEquivalent:@""] autorelease];
+    [menu addItem:item];
+
+    item = [[[NSMenuItem alloc] initWithTitle:@"Check For Updates"
+                                       action:@selector(checkForUpdatesFromMenu:)
                                 keyEquivalent:@""] autorelease];
     [menu addItem:item];
 
@@ -1476,6 +1483,10 @@ static const NSTimeInterval kOneMonth = 30 * 24 * 60 * 60;
         [alert addButtonWithTitle:@"OK"];
         [alert runModal];
     }
+}
+
+- (IBAction)checkForUpdatesFromMenu:(id)sender {
+    [suUpdater checkForUpdates:(sender)];
 }
 
 - (void)warnAboutChangeToDefaultPasteBehavior {


### PR DESCRIPTION
If you don't restart iTerm for a long time you can miss updates. This is typically solved by using the option in the "iTerm" menu. However if you have the "Exclude from Dock and ⌘-Tab Application Switcher" option enabled, there is no easy way to check for updates without disabling this option or restarting iTerm.

This pull request adds an option to the menu bar icon to trigger the "Check for Updates" functionality.

<img width="491" alt="screen shot 2017-10-01 at 23 31 26" src="https://user-images.githubusercontent.com/1374614/31059895-d2833bba-a700-11e7-950d-30f098cc5159.png">
