### PR TITLE
Fix position of 'Paste' button

### DIFF
--- a/Interfaces/iTermPasteSpecialWindow.xib
+++ b/Interfaces/iTermPasteSpecialWindow.xib
@@ -28,7 +28,7 @@
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 <subviews>
                     <button verticalHuggingPriority="750" id="S2m-j3-AMJ">
-                        <rect key="frame" x="391" y="13" width="75" height="32"/>
+                        <rect key="frame" x="395" y="11" width="75" height="32"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                         <buttonCell key="cell" type="push" title="Paste" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="lP3-7o-P32">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -78,8 +78,6 @@ Gw
                                     <size key="minSize" width="444" height="108"/>
                                     <size key="maxSize" width="10000000" height="10000000"/>
                                     <color key="insertionPointColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                    <size key="minSize" width="444" height="108"/>
-                                    <size key="maxSize" width="10000000" height="10000000"/>
                                 </textView>
                             </subviews>
                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>


### PR DESCRIPTION
The `Paste` button in the special paste window was not properly aligned.

Before:
<img width="1466" alt="Before" src="https://user-images.githubusercontent.com/1769968/31166652-c4c06bd8-a8ef-11e7-82b4-0f154d439874.png">

After:
<img width="1466" alt="After" src="https://user-images.githubusercontent.com/1769968/31166735-02ca3f6c-a8f0-11e7-9a96-9a9baa570662.png">
