### PR TITLE
Allow ~ in HTTP URL paths

### DIFF
--- a/plists/SmartSelectionRules.plist
+++ b/plists/SmartSelectionRules.plist
@@ -72,7 +72,7 @@
                 <key>notes</key>
                 <string>HTTP URL</string>
                 <key>regex</key>
-                <string>https?://([a-z0-9A-Z]+(:[a-zA-Z0-9]+)?@)?([a-z0-9A-Z][-a-z0-9A-Z]*\.)+[A-Za-z][-A-Za-z]*((:[0-9]+)?)(/[a-zA-Z0-9;/\.\-_+%?&amp;@=#\(\)]*)?</string>
+                <string>https?://([a-z0-9A-Z]+(:[a-zA-Z0-9]+)?@)?([a-z0-9A-Z][-a-z0-9A-Z]*\.)+[A-Za-z][-A-Za-z]*((:[0-9]+)?)(/[a-zA-Z0-9;/\.\-_+%?&amp;@=#\(\)~]*)?</string>
                 <key>precision</key>
                 <string>very_high</string>
             </dict>


### PR DESCRIPTION
This allows URLs such as http://sharedserver.com/~homedir/index.html to be parsed and opened correctly.

I've updated my own profile preferences, but I feel like people would benefit from having this as the default.