### PR TITLE
Auto select the account in the password manager after auth.

### DIFF
--- a/sources/iTermPasswordManagerWindowController.m
+++ b/sources/iTermPasswordManagerWindowController.m
@@ -37,6 +37,7 @@ static BOOL sAuthenticated;
     NSArray *_accounts;
     NSString *_passwordBeingShown;
     NSInteger _rowForPasswordBeingShown;
+    NSString *_selectedAccountNameBeforeAuthenticated;
 }
 
 + (NSArray *)accountNamesWithFilter:(NSString *)filter {
@@ -190,6 +191,8 @@ static BOOL sAuthenticated;
     if (index != NSNotFound) {
         [_tableView selectRowIndexes:[NSIndexSet indexSetWithIndex:index]
                 byExtendingSelection:NO];
+    } else if (!sAuthenticated) {
+        _selectedAccountNameBeforeAuthenticated = name;
     }
 }
 
@@ -351,7 +354,11 @@ static BOOL sAuthenticated;
 
         if (success) {
             [self reloadAccounts];
-            [[self window] makeFirstResponder:_searchField];
+            if (_selectedAccountNameBeforeAuthenticated) {
+                [self selectAccountName:_selectedAccountNameBeforeAuthenticated];
+            } else {
+                [[self window] makeFirstResponder:_searchField];
+            }
         } else {
             [self closeOrEndSheet];
         }


### PR DESCRIPTION
Every time I re-open my compiled iTerm2, it requires re-authentication (Touch ID). Is that because I disabled code-signing? So I wasn't able to test the case when iTerm2 is first opened, but doesn't require authentication.