### PR TITLE
define and increase iTermProcPidInfoWrapper timeout

### DIFF
--- a/sources/iTermLSOF.h
+++ b/sources/iTermLSOF.h
@@ -8,6 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
+#define ITERM_CALL_TIMEOUT 1.5
+
 @class iTermSocketAddress;
 
 int iTermProcPidInfoWrapper(int pid, int flavor, uint64_t arg,  void *buffer, int buffersize);

--- a/sources/iTermLSOF.m
+++ b/sources/iTermLSOF.m
@@ -20,7 +20,7 @@
 
 int iTermProcPidInfoWrapper(int pid, int flavor, uint64_t arg,  void *buffer, int buffersize) {
     __block int result;
-    BOOL timeout = [[iTermCallWithTimeout instanceForIdentifier:@"pidinfo"] executeWithTimeout:0.5 block:^{
+    BOOL timeout = [[iTermCallWithTimeout instanceForIdentifier:@"pidinfo"] executeWithTimeout:ITERM_CALL_TIMEOUT block:^{
         result = proc_pidinfo(pid, flavor, arg, buffer, buffersize);
     }];
     return timeout ? -1 : result;


### PR DESCRIPTION
Some cross-device symlinks take longer than .5 to properly return, causing iTerm2 to crash when there is no child cwd.  This bandaid fixes the issue on my system for now, but more graceful failure and configuration of the timeout should probably be instrumented.

```
Process:               iTerm2 [843]
Path:                  /Applications/iTerm.app/Contents/MacOS/iTerm2
Identifier:            com.googlecode.iterm2
Version:               3.1.4 (3.1.4)
Code Type:             X86-64 (Native)
Parent Process:        ??? [1]
Responsible:           iTerm2 [843]
User ID:               501

Date/Time:             2017-10-26 02:42:08.140 -0400
OS Version:            Mac OS X 10.13.1 (17B45a)
Report Version:        12
Anonymous UUID:        36538B81-7910-BFCC-0EA1-A32DC23F32BC


Time Awake Since Boot: 6300 seconds

System Integrity Protection: disabled

Crashed Thread:        0  Dispatch queue: com.apple.main-thread

Exception Type:        EXC_CRASH (SIGABRT)
Exception Codes:       0x0000000000000000, 0x0000000000000000
Exception Note:        EXC_CORPSE_NOTIFY

Application Specific Information:
[843] stack overflow

Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   libsystem_kernel.dylib        	0x00007fff513e9fce __pthread_kill + 10
1   libsystem_pthread.dylib       	0x00007fff51527150 pthread_kill + 333
2   libsystem_c.dylib             	0x00007fff513463a9 __abort + 144
3   libsystem_c.dylib             	0x00007fff51346c54 __stack_chk_fail + 205
4   com.googlecode.iterm2         	0x0000000101a19693 -[PTYTask getWorkingDirectory] + 611
```