### PR TITLE
Support OSC 10 and OSC 11 (dynamic colors)

### DIFF
--- a/sources/VT100Output.h
+++ b/sources/VT100Output.h
@@ -51,6 +51,7 @@ typedef NS_ENUM(NSInteger, MouseFormat) {
 - (NSData *)reportDeviceAttribute;
 - (NSData *)reportSecondaryDeviceAttribute;
 - (NSData *)reportColor:(NSColor *)color atIndex:(int)index;
+- (NSData *)reportColor:(NSColor *)color forDynamicColor:(int)index;
 - (NSData *)reportChecksum:(int)checksum withIdentifier:(int)identifier;
 - (NSData *)reportFocusGained:(BOOL)gained;
 - (NSData *)reportiTerm2Version;

--- a/sources/VT100Output.m
+++ b/sources/VT100Output.m
@@ -576,6 +576,16 @@ typedef enum {
     return [string dataUsingEncoding:NSUTF8StringEncoding];
 }
 
+- (NSData *)reportColor:(NSColor *)color forDynamicColor:(int)index {
+    NSString *string = [NSString stringWithFormat:@"%c]%d;rgb:%02x/%02x/%02x%c",
+                            ESC, index,
+                            (int) ([color redComponent] * 255.0),
+                            (int) ([color greenComponent] * 255.0),
+                            (int) ([color blueComponent] * 255.0),
+                        7];
+    return [string dataUsingEncoding:NSUTF8StringEncoding];
+}
+
 - (NSData *)reportChecksum:(int)checksum withIdentifier:(int)identifier {
     // DCS Pid ! ~ D..D ST
     NSString *string =

--- a/sources/VT100Screen.m
+++ b/sources/VT100Screen.m
@@ -3729,6 +3729,14 @@ static NSString *const kInilineFileInset = @"inset";  // NSValue of NSEdgeInsets
     return [iTermAdvancedSettingsModel focusReportingEnabled];
 }
 
+- (NSColor *)terminalForegroundColor {
+    return [[delegate_ screenColorMap] colorForKey:kColorMapForeground];
+}
+
+- (NSColor *)terminalBackgroundColor {
+    return [[delegate_ screenColorMap] colorForKey:kColorMapBackground];
+}
+
 - (NSColor *)terminalColorForIndex:(int)index {
     if (index < 0 || index > 255) {
         return nil;

--- a/sources/VT100TerminalDelegate.h
+++ b/sources/VT100TerminalDelegate.h
@@ -340,6 +340,8 @@ typedef NS_ENUM(NSUInteger, VT100AttentionRequestType) {
 - (void)terminalSetTabColorGreenComponentTo:(CGFloat)color;
 - (void)terminalSetTabColorBlueComponentTo:(CGFloat)color;
 
+- (NSColor *)terminalForegroundColor;
+- (NSColor *)terminalBackgroundColor;
 - (NSColor *)terminalColorForIndex:(int)index;
 
 // Returns the current cursor position.

--- a/sources/VT100Token.h
+++ b/sources/VT100Token.h
@@ -131,6 +131,8 @@ typedef enum {
     XTERMCC_PROPRIETARY_ETERM_EXT,
     XTERMCC_PWD_URL,
     XTERMCC_LINK,
+    XTERMCC_SET_FG,
+    XTERMCC_SET_BG,
     XTERMCC_SET_PALETTE,
     XTERMCC_SET_KVP,
     // OSC 1337;File=(args):(data) gets changed by the parser from XTERMCC_SET_KVP to a

--- a/sources/VT100Token.m
+++ b/sources/VT100Token.m
@@ -198,6 +198,8 @@ static iTermObjectPool *gPool;
                           @(XTERMCC_PASTE64):                 @"XTERMCC_PASTE64",
                           @(XTERMCC_FINAL_TERM):              @"XTERMCC_FINAL_TERM",
                           @(XTERMCC_LINK):                    @"XTERMCC_LINK",
+                          @(XTERMCC_SET_FG):                  @"XTERMCC_SET_FG",
+                          @(XTERMCC_SET_BG):                  @"XTERMCC_SET_BG",
                           @(ANSICSI_CHA):                     @"ANSICSI_CHA",
                           @(ANSICSI_VPA):                     @"ANSICSI_VPA",
                           @(ANSICSI_VPR):                     @"ANSICSI_VPR",

--- a/sources/VT100XtermParser.m
+++ b/sources/VT100XtermParser.m
@@ -201,6 +201,8 @@ typedef enum {
                @7: @(XTERMCC_PWD_URL),
                @8: @(XTERMCC_LINK),
                @9: @(ITERM_GROWL),
+               @10: @(XTERMCC_SET_FG),
+               @11: @(XTERMCC_SET_BG),
                // 50 is a nonstandard escape code implemented by Konsole.
                // xterm since started using it for setting the font, so 1337 is the preferred code
                // for this in iTerm2.


### PR DESCRIPTION
The foreground color can be set or reported using OSC 10. The background
color can be set or reported using OSC 11. There are 10 dynamic colors
defined, this only implements the first two and does not implement the
resetting (OSC 110 and OSC 111).

This PR has the side effect of changing how colors are parsed in OSC 4 in two ways.

1. Like XTerm, it supports `rgb:R/G/B`, `rgb:RR/GG/BB`, `rgb:RRR/GGG/BBB`, and `rgb:RRRR/GGGG/BBBB` (or any mixing of component lengths). This should be a strict superset of the current functionality.
2. Colors are not translated into the calibrated color space. Doing so meant that setting a color to `rgb:ff/ff/ff` did not get reported as ff/ff/ff:

   ``` bash
   $ echo -ne '\033]4;105;rgb:ff/ff/ff\033\\'
   $ echo -ne '\033]4;105;?\033\\'
   ^[]4;105;rgb:fe/fe/fe^G
   ```

   With this patch, the colors round-trip correctly:

   ``` bash
   $ echo -ne '\033]4;105;rgb:ff/ff/ff\033\\'
   $ echo -ne '\033]4;105;?\033\\'
   ^[]4;105;rgb:ff/ff/ff^G
   ```

I suspect that the second change is likely to make this PR unpalatable given that the rest of the codebase uses the calibrated color space. Perhaps the report functions should convert back to sRGB.