### PR TITLE
Fix build failure on case-sensitive file systems

### DIFF
--- a/sources/iTermInitialDirectory.h
+++ b/sources/iTermInitialDirectory.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import "Profile.h"
+#import "ProfileModel.h"
 #import "ITAddressBookMgr.h"
 
 typedef NS_ENUM(NSUInteger, iTermInitialDirectoryMode) {


### PR DESCRIPTION
On a case-sensitive file system iTerm2 fails to build because of missing Profile.h. I believe this is a typo, and actually ProfileModel.h is meant (and iTerm2 builds successfully then).

The build succeeds on case-insensitive file systems, because ProfileModel.h is pulled via ITAddressBookMgr.h, and Profile.h resolves to the system header profile.h (note the small letter p).