### PR TITLE
Make tmux detection in imgcat more reliable

### DIFF
--- a/tests/imgcat
+++ b/tests/imgcat
@@ -4,7 +4,7 @@
 # <sequence> ST, and for all ESCs in <sequence> to be replaced with ESC ESC. It
 # only accepts ESC backslash for ST.
 function print_osc() {
-    if [[ $TERM == screen* ]] ; then
+    if [[ -n $TMUX ]] ; then
         printf "\033Ptmux;\033\033]"
     else
         printf "\033]"
@@ -13,7 +13,7 @@ function print_osc() {
 
 # More of the tmux workaround described above.
 function print_st() {
-    if [[ $TERM == screen* ]] ; then
+    if [[ -n $TMUX ]] ; then
         printf "\a\033\\"
     else
         printf "\a"


### PR DESCRIPTION
Detecting whether `imgcat` is used inside `tmux` by checking the `$TERM` variable is not reliable.
The current version checks whether a `screen*` terminal is running.
I'm running `xterm-256color` however, therefore `tmux` is not detected by `imgcat`.

This PR checks for `tmux` using the `$TMUX` variable instead, a variable `tmux` creates when attaching to a session.