### PR TITLE
Alter auto comp select

### DIFF
--- a/sources/CommandHistoryPopup.m
+++ b/sources/CommandHistoryPopup.m
@@ -99,4 +99,15 @@
     }
 }
 
+- (void)insertNewline:(id)sender
+{
+    [self insertText:@"\n"];
+    [self closePopupWindow];
+}
+
+- (void)insertLineBreak:(id)sender
+{
+    [self rowSelected:self];
+}
+
 @end

--- a/sources/CommandHistoryPopup.m
+++ b/sources/CommandHistoryPopup.m
@@ -110,4 +110,11 @@
     [self rowSelected:self];
 }
 
+- (void)keyDown:(NSEvent *)event
+{
+    if (([event modifierFlags] & (NSControlKeyMask | NSCommandKeyMask | NSAlternateKeyMask)) == NSControlKeyMask
+		    && [event keyCode] == 8) {
+        [self closePopupWindow];
+    }
+}
 @end

--- a/sources/iTermKeyboardNavigatableTableView.m
+++ b/sources/iTermKeyboardNavigatableTableView.m
@@ -11,7 +11,12 @@
 @implementation iTermKeyboardNavigatableTableView
 
 - (void)keyDown:(NSEvent *)theEvent {
-  [self interpretKeyEvents:[NSArray arrayWithObject:theEvent]];
+  if (([theEvent modifierFlags] & (NSControlKeyMask | NSCommandKeyMask | NSAlternateKeyMask)) == NSControlKeyMask
+	&& [theEvent keyCode] == 8) {
+    [super keyDown:theEvent];
+  } else {
+    [self interpretKeyEvents:[NSArray arrayWithObject:theEvent]];
+  }
 }
 
 @end


### PR DESCRIPTION
Does anyone find `Auto Command Completion` annoying as me ?

I add/altered 3 features:

On `Auto Command Completion` displaying,

1. Press `Enter` to send '\n' to psudo-tty
2. Press `^Enter` to select row
3. Press `^C` to close `Auto Command Completion` window