### PR TITLE
Add advanced setting preventing directional focus from wrapping

### DIFF
--- a/sources/PTYTab.m
+++ b/sources/PTYTab.m
@@ -1010,7 +1010,7 @@ static void SetAgainstGrainDim(BOOL isVertical, NSSize *dest, CGFloat value) {
                       verticalDir:(BOOL)verticalDir
                             after:(BOOL)after {
     NSArray<PTYSession *> *sessions = [self sessionsAdjacentToSession:session verticalDir:verticalDir after:after];
-    if (sessions.count) {
+    if (sessions.count || ![iTermAdvancedSettingsModel wrapFocus]) {
         return [sessions maxWithComparator:^NSComparisonResult(PTYSession *a, PTYSession *b) {
             return [a.activityCounter compare:b.activityCounter];
         }];

--- a/sources/iTermAdvancedSettingsModel.h
+++ b/sources/iTermAdvancedSettingsModel.h
@@ -194,6 +194,7 @@
 + (BOOL)lowFiCombiningMarks;
 + (CGFloat)verticalBarCursorWidth;
 + (BOOL)statusBarIcon;
++ (BOOL)wrapFocus;
 + (BOOL)sensitiveScrollWheel;
 + (BOOL)disableCustomBoxDrawing;
 + (BOOL)useExperimentalFontMetrics;

--- a/sources/iTermAdvancedSettingsModel.m
+++ b/sources/iTermAdvancedSettingsModel.m
@@ -167,6 +167,7 @@ DEFINE_STRING(viewManPageCommand, @"man %@ || sleep 3", @"General: Command to vi
 DEFINE_BOOL(hideStuckTooltips, YES, @"General: Hide stuck tooltips.\nWhen you hide iTerm2 using a hotkey while a tooltip is fading out it gets stuck because of an OS bug. Work around it with a nasty hack by enabling this feature.")
 DEFINE_BOOL(openFileOverridesSendText, YES, @"General: Should opening a script with iTerm2 disable the default profile's “Send Text at Start” setting?\nIf you use “open iTerm2 file.command” or drag a script onto iTerm2's icon and this setting is enabled then the script will be executed in lieu of the profile's “Send Text at Start” setting. If this setting is off then both will be executed.");
 DEFINE_BOOL(statusBarIcon, YES, @"General: Add status bar icon when excluded from dock?\nWhen you turn on “Exclude from Dock and Cmd-Tab Application Switcher” a status bar icon is added to the menu bar so you can switch the setting back off. Disable this to remove the status bar icon. Doing so makes it very hard to get to Preferences. You must restart iTerm2 after changing this setting.");
+DEFINE_BOOL(wrapFocus, YES, @"General: Should the directional focus hotkeys wrap");
 
 #pragma mark - Drawing
 DEFINE_BOOL(zippyTextDrawing, YES, @"Drawing: Use zippy text drawing algorithm?\nThis draws non-ASCII text more quickly but with lower fidelity. This setting is ignored if ligatures are enabled in Prefs > Profiles > Text.");


### PR DESCRIPTION
Currently the directional focus hotkeys will wrap, focusing a view on the opposite side of the window.

Personally I find this very confusing and often end up in situations whereby I have no idea where focus has gone, (mostly because I've come from a tiling window manager that behaved slightly differently).

This commit adds an advanced option (probably not important enough to be a real option) that prevents such wrapping.