### PR TITLE
Fixes singleton, refactor power monitoring mode (#6550)

### DIFF
--- a/sources/iTermPowerManager.m
+++ b/sources/iTermPowerManager.m
@@ -11,29 +11,48 @@
 
 NSString *const iTermPowerManagerStateDidChange = @"iTermPowerManagerStateDidChange";
 
-@implementation iTermPowerManager
+@implementation iTermPowerManager {
+    CFRunLoopRef _runLoop;
+    CFRunLoopSourceRef _runLoopSource;
+}
+
+static BOOL iTermPowerManagerIsConnectedToPower(void) {
+    CFStringRef source = IOPSGetProvidingPowerSourceType(NULL);
+    return [@kIOPMACPowerKey isEqualToString:(__bridge NSString *)(source)];
+}
+
+static void ITPMpowerSourceChanged(void *context) {
+    iTermPowerManager* pm = (__bridge iTermPowerManager *)(context);
+    [pm setConnected:iTermPowerManagerIsConnectedToPower()];
+}
 
 + (instancetype)sharedInstance {
-    return [[self alloc] initPrivate];
+    static iTermPowerManager *sharedInstance = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedInstance = [[self alloc] initPrivate];
+    });
+    return sharedInstance;
 }
 
 - (instancetype)initPrivate {
     self = [super init];
     if (self) {
-        [self updateCharging];
-        [NSTimer it_scheduledTimerWithTimeInterval:5 repeats:YES block:^(NSTimer * _Nonnull timer) {
-            BOOL before = _connectedToPower;
-            [self updateCharging];
-            if (_connectedToPower != before) {
-                [[NSNotificationCenter defaultCenter] postNotificationName:iTermPowerManagerStateDidChange object:nil];
-            }
-        }];
+        _runLoop = CFRunLoopGetMain();
+        _runLoopSource = IOPSCreateLimitedPowerNotification(ITPMpowerSourceChanged,(__bridge void *)(self));
+        _connectedToPower = iTermPowerManagerIsConnectedToPower();
+        if (_runLoop && _runLoopSource){
+            CFRunLoopAddSource(_runLoop,_runLoopSource,kCFRunLoopDefaultMode);
+        }
     }
     return self;
 }
 
-- (void)updateCharging {
-    _connectedToPower = (IOPSGetTimeRemainingEstimate() == kIOPSTimeRemainingUnlimited);
+- (void)setConnected:(BOOL)connected {
+    if (_connectedToPower != connected) {
+        _connectedToPower = connected;
+        [[NSNotificationCenter defaultCenter] postNotificationName:iTermPowerManagerStateDidChange object:nil];
+    }
 }
 
 @end


### PR DESCRIPTION
- Fixes singleton implementation of the power manager instance (bug #6550)
- Changes the way power status is monitored to a more optimal callback
when power source has been changed to a limited power source
(IOPSCreateLimitedPowerNotification)

ps. excuse my objc, it's a little bit rusty. :)