### PR TITLE
Native Notifications

### DIFF
--- a/iTerm2.xcodeproj/project.pbxproj
+++ b/iTerm2.xcodeproj/project.pbxproj
@@ -595,7 +595,7 @@
 		1D5FDD601208E8F000C46BA3 /* PSMTabStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = DD02573909CB9398008F320C /* PSMTabStyle.h */; };
 		1D5FDD621208E8F000C46BA3 /* PSMTabDragAssistant.h in Headers */ = {isa = PBXBuildFile; fileRef = F6E708B70A9D0EA400D0C4EF /* PSMTabDragAssistant.h */; };
 		1D5FDD651208E8F000C46BA3 /* PSMTabDragWindow.h in Headers */ = {isa = PBXBuildFile; fileRef = F62D15F00AA64B2F0075A287 /* PSMTabDragWindow.h */; };
-		1D5FDD661208E8F000C46BA3 /* iTermGrowlDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = F69E78910AB7AC85001EC0FF /* iTermGrowlDelegate.h */; };
+		1D5FDD661208E8F000C46BA3 /* iTermNotificationController.h in Headers */ = {isa = PBXBuildFile; fileRef = F69E78910AB7AC85001EC0FF /* iTermNotificationController.h */; };
 		1D5FDD681208E8F000C46BA3 /* CarbonHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = F6441F620E748404000EC682 /* CarbonHelpers.h */; };
 		1D5FDD691208E8F000C46BA3 /* CGSAccessibility.h in Headers */ = {isa = PBXBuildFile; fileRef = F6441F630E748404000EC682 /* CGSAccessibility.h */; };
 		1D5FDD6A1208E8F000C46BA3 /* CGSCIFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = F6441F640E748404000EC682 /* CGSCIFilter.h */; };
@@ -670,7 +670,7 @@
 		1D6ED87F19AEA20D005A7799 /* VT100StringParser.h in Headers */ = {isa = PBXBuildFile; fileRef = A647E3A718C353C500450FA1 /* VT100StringParser.h */; };
 		1D6ED88019AEA20D005A7799 /* PSMTabDragWindow.h in Headers */ = {isa = PBXBuildFile; fileRef = F62D15F00AA64B2F0075A287 /* PSMTabDragWindow.h */; };
 		1D6ED88119AEA20D005A7799 /* NSImage+iTerm.h in Headers */ = {isa = PBXBuildFile; fileRef = A69B45B6197C60FB00F5444D /* NSImage+iTerm.h */; };
-		1D6ED88219AEA20D005A7799 /* iTermGrowlDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = F69E78910AB7AC85001EC0FF /* iTermGrowlDelegate.h */; };
+		1D6ED88219AEA20D005A7799 /* iTermNotificationController.h in Headers */ = {isa = PBXBuildFile; fileRef = F69E78910AB7AC85001EC0FF /* iTermNotificationController.h */; };
 		1D6ED88319AEA20D005A7799 /* iTermOpenQuicklyTableCellView.h in Headers */ = {isa = PBXBuildFile; fileRef = A69B4598197319CA00F5444D /* iTermOpenQuicklyTableCellView.h */; };
 		1D6ED88419AEA20D005A7799 /* iTermAnnouncementView.h in Headers */ = {isa = PBXBuildFile; fileRef = A6AE1EDB192723F700780C19 /* iTermAnnouncementView.h */; };
 		1D6ED88519AEA20D005A7799 /* CarbonHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = F6441F620E748404000EC682 /* CarbonHelpers.h */; };
@@ -2080,7 +2080,7 @@
 		A6C762CA1B45C52B00E3C992 /* iTermApplicationDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 20D5CC6404E7AA0500000106 /* iTermApplicationDelegate.m */; };
 		A6C762CB1B45C52B00E3C992 /* iTermController.m in Sources */ = {isa = PBXBuildFile; fileRef = E8A66F030272453F03A80106 /* iTermController.m */; };
 		A6C762CC1B45C52B00E3C992 /* iTermCursor.m in Sources */ = {isa = PBXBuildFile; fileRef = A635C4351AB38205008A2DEE /* iTermCursor.m */; };
-		A6C762CD1B45C52B00E3C992 /* iTermGrowlDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = F69E788C0AB7AC6D001EC0FF /* iTermGrowlDelegate.m */; };
+		A6C762CD1B45C52B00E3C992 /* iTermNotificationController.m in Sources */ = {isa = PBXBuildFile; fileRef = F69E788C0AB7AC6D001EC0FF /* iTermNotificationController.m */; };
 		A6C762CE1B45C52B00E3C992 /* iTermKeyBindingMgr.m in Sources */ = {isa = PBXBuildFile; fileRef = DDDB7ABD05D7736600E197C2 /* iTermKeyBindingMgr.m */; };
 		A6C762CF1B45C52B00E3C992 /* iTermObjectPool.m in Sources */ = {isa = PBXBuildFile; fileRef = A647E3B618C5884600450FA1 /* iTermObjectPool.m */; };
 		A6C762D01B45C52B00E3C992 /* iTermSelection.m in Sources */ = {isa = PBXBuildFile; fileRef = A63BA39418A9CB43002BE075 /* iTermSelection.m */; };
@@ -4260,8 +4260,8 @@
 		F6441F700E748404000EC682 /* CGSWindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CGSWindow.h; sourceTree = "<group>"; };
 		F6441F710E748404000EC682 /* CGSWorkspace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CGSWorkspace.h; sourceTree = "<group>"; };
 		F69E774A0AB78CDB001EC0FF /* Growl-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Growl-Info.plist"; sourceTree = "<group>"; };
-		F69E788C0AB7AC6D001EC0FF /* iTermGrowlDelegate.m */ = {isa = PBXFileReference; fileEncoding = 30; indentWidth = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = iTermGrowlDelegate.m; sourceTree = "<group>"; tabWidth = 4; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		F69E78910AB7AC85001EC0FF /* iTermGrowlDelegate.h */ = {isa = PBXFileReference; fileEncoding = 30; indentWidth = 4; lastKnownFileType = sourcecode.c.h; path = iTermGrowlDelegate.h; sourceTree = "<group>"; tabWidth = 4; };
+		F69E788C0AB7AC6D001EC0FF /* iTermNotificationController.m */ = {isa = PBXFileReference; fileEncoding = 30; indentWidth = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = iTermNotificationController.m; sourceTree = "<group>"; tabWidth = 4; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		F69E78910AB7AC85001EC0FF /* iTermNotificationController.h */ = {isa = PBXFileReference; fileEncoding = 30; indentWidth = 4; lastKnownFileType = sourcecode.c.h; path = iTermNotificationController.h; sourceTree = "<group>"; tabWidth = 4; };
 		F6E2DED70AE2F67200D20B3B /* Sparkle.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Sparkle.framework; sourceTree = "<group>"; };
 		F6E708B70A9D0EA400D0C4EF /* PSMTabDragAssistant.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = PSMTabDragAssistant.h; sourceTree = "<group>"; };
 		F6E708B80A9D0EA400D0C4EF /* PSMTabDragAssistant.m */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.objc; path = PSMTabDragAssistant.m; sourceTree = "<group>"; };
@@ -4523,7 +4523,7 @@
 				A6E77F7F1A23F484009B1CB6 /* iTermFindOnPageHelper.h */,
 				A682DE991915DB1F00BE8758 /* iTermFlippedView.h */,
 				1D2F3B3B1516BA460044C337 /* iTermFontPanel.h */,
-				F69E78910AB7AC85001EC0FF /* iTermGrowlDelegate.h */,
+				F69E78910AB7AC85001EC0FF /* iTermNotificationController.h */,
 				A67F57B51B01A01800B4F135 /* iTermImageInfo.h */,
 				A62C3B401BD40E7C00B5629D /* iTermImageMark.h */,
 				1D0318261A42563A00932107 /* iTermImageWell.h */,
@@ -5481,7 +5481,7 @@
 				E8A66F030272453F03A80106 /* iTermController.m */,
 				A635C4351AB38205008A2DEE /* iTermCursor.m */,
 				1DF121081C344DF100E39F1F /* iTermDynamicProfileManager.m */,
-				F69E788C0AB7AC6D001EC0FF /* iTermGrowlDelegate.m */,
+				F69E788C0AB7AC6D001EC0FF /* iTermNotificationController.m */,
 				DDDB7ABD05D7736600E197C2 /* iTermKeyBindingMgr.m */,
 				A647E3B618C5884600450FA1 /* iTermObjectPool.m */,
 				A63BA39418A9CB43002BE075 /* iTermSelection.m */,
@@ -6593,7 +6593,7 @@
 				1D6ED87F19AEA20D005A7799 /* VT100StringParser.h in Headers */,
 				1D6ED88019AEA20D005A7799 /* PSMTabDragWindow.h in Headers */,
 				1D6ED88119AEA20D005A7799 /* NSImage+iTerm.h in Headers */,
-				1D6ED88219AEA20D005A7799 /* iTermGrowlDelegate.h in Headers */,
+				1D6ED88219AEA20D005A7799 /* iTermNotificationController.h in Headers */,
 				1D6ED88319AEA20D005A7799 /* iTermOpenQuicklyTableCellView.h in Headers */,
 				1D6ED88419AEA20D005A7799 /* iTermAnnouncementView.h in Headers */,
 				1D6ED88519AEA20D005A7799 /* CarbonHelpers.h in Headers */,
@@ -6939,7 +6939,7 @@
 				A647E3A918C353C500450FA1 /* VT100StringParser.h in Headers */,
 				1D5FDD651208E8F000C46BA3 /* PSMTabDragWindow.h in Headers */,
 				A69B45B8197C60FB00F5444D /* NSImage+iTerm.h in Headers */,
-				1D5FDD661208E8F000C46BA3 /* iTermGrowlDelegate.h in Headers */,
+				1D5FDD661208E8F000C46BA3 /* iTermNotificationController.h in Headers */,
 				A69B459A197319CA00F5444D /* iTermOpenQuicklyTableCellView.h in Headers */,
 				A6AE1EDD192723F700780C19 /* iTermAnnouncementView.h in Headers */,
 				1D5FDD681208E8F000C46BA3 /* CarbonHelpers.h in Headers */,
@@ -9329,7 +9329,7 @@
 				A6C763BD1B45C52B00E3C992 /* iTermTipRootView.m in Sources */,
 				A6C763BE1B45C52B00E3C992 /* iTermTipWindowController.m in Sources */,
 				A6C762F81B45C52B00E3C992 /* iTermExposeTabView.m in Sources */,
-				A6C762CD1B45C52B00E3C992 /* iTermGrowlDelegate.m in Sources */,
+				A6C762CD1B45C52B00E3C992 /* iTermNotificationController.m in Sources */,
 				A6CEC0731DCE80C9009F4FD2 /* Api.pbobjc.m in Sources */,
 				A6C763DD1B45C6DD00E3C992 /* PSMProgressIndicator.m in Sources */,
 				A6C7631C1B45C52B00E3C992 /* iTermRule.m in Sources */,

--- a/sources/GrowlTrigger.m
+++ b/sources/GrowlTrigger.m
@@ -35,7 +35,7 @@
                     atAbsoluteLineNumber:(long long)lineNumber
                                     stop:(BOOL *)stop {
     iTermNotificationController *gd = [iTermNotificationController sharedInstance];
-    [gd growlNotify:[self paramWithBackreferencesReplacedWithValues:capturedStrings count:captureCount]
+    [gd notify:[self paramWithBackreferencesReplacedWithValues:capturedStrings count:captureCount]
         withDescription:[NSString stringWithFormat:@"A trigger fired in session \"%@\" in tab #%d.",
                          [aSession name],
                          aSession.delegate.tabNumber]

--- a/sources/GrowlTrigger.m
+++ b/sources/GrowlTrigger.m
@@ -6,7 +6,7 @@
 //
 
 #import "GrowlTrigger.h"
-#import "iTermGrowlDelegate.h"
+#import "iTermNotificationController.h"
 #import "PTYSession.h"
 #import "PTYTab.h"
 
@@ -34,7 +34,7 @@
                                 onString:(iTermStringLine *)stringLine
                     atAbsoluteLineNumber:(long long)lineNumber
                                     stop:(BOOL *)stop {
-    iTermGrowlDelegate *gd = [iTermGrowlDelegate sharedInstance];
+    iTermNotificationController *gd = [iTermNotificationController sharedInstance];
     [gd growlNotify:[self paramWithBackreferencesReplacedWithValues:capturedStrings count:captureCount]
         withDescription:[NSString stringWithFormat:@"A trigger fired in session \"%@\" in tab #%d.",
                          [aSession name],

--- a/sources/PTYSession.h
+++ b/sources/PTYSession.h
@@ -46,7 +46,7 @@ extern NSString *const PTYSessionRevivedNotification;
 @class iTermColorMap;
 @class iTermCommandHistoryCommandUseMO;
 @class iTermController;
-@class iTermGrowlDelegate;
+@class iTermNotificationController;
 @class iTermPromptOnCloseReason;
 @class iTermQuickLookController;
 @class SessionView;

--- a/sources/PTYSession.m
+++ b/sources/PTYSession.m
@@ -2643,7 +2643,7 @@ ITERM_WEAKLY_REFERENCEABLE
     [_shell killServerIfRunning];
     if ([self shouldPostGrowlNotification] &&
         [iTermProfilePreferences boolForKey:KEY_SEND_SESSION_ENDED_ALERT inProfile:self.profile]) {
-        [[iTermNotificationController sharedInstance] growlNotify:@"Session Ended"
+        [[iTermNotificationController sharedInstance] notify:@"Session Ended"
                                          withDescription:[NSString stringWithFormat:@"Session \"%@\" in tab #%d just terminated.",
                                                           [self name],
                                                           [_delegate tabNumber]]
@@ -3108,7 +3108,7 @@ ITERM_WEAKLY_REFERENCEABLE
             if ([_textview keyIsARepeat] == NO &&
                 [self shouldPostGrowlNotification] &&
                 [iTermProfilePreferences boolForKey:KEY_SEND_BELL_ALERT inProfile:self.profile]) {
-                [[iTermNotificationController sharedInstance] growlNotify:@"Bell"
+                [[iTermNotificationController sharedInstance] notify:@"Bell"
                                                  withDescription:[NSString stringWithFormat:@"Session %@ #%d just rang a bell!",
                                                                   [self name],
                                                                   [_delegate tabNumber]]
@@ -7669,7 +7669,7 @@ ITERM_WEAKLY_REFERENCEABLE
     if (self.alertOnNextMark) {
         NSString *action = [iTermApplication.sharedApplication delegate].markAlertAction;
         if ([action isEqualToString:kMarkAlertActionPostNotification]) {
-            [[iTermNotificationController sharedInstance] growlNotify:@"Mark Set"
+            [[iTermNotificationController sharedInstance] notify:@"Mark Set"
                                              withDescription:[NSString stringWithFormat:@"Session %@ #%d had a mark set.",
                                                               [self name],
                                                               [_delegate tabNumber]]

--- a/sources/PTYSession.m
+++ b/sources/PTYSession.m
@@ -18,7 +18,7 @@
 #import "iTermCommandHistoryCommandUseMO+Addtions.h"
 #import "iTermController.h"
 #import "iTermCopyModeState.h"
-#import "iTermGrowlDelegate.h"
+#import "iTermNotificationController.h"
 #import "iTermHistogram.h"
 #import "iTermHotKeyController.h"
 #import "iTermInitialDirectory.h"
@@ -2643,7 +2643,7 @@ ITERM_WEAKLY_REFERENCEABLE
     [_shell killServerIfRunning];
     if ([self shouldPostGrowlNotification] &&
         [iTermProfilePreferences boolForKey:KEY_SEND_SESSION_ENDED_ALERT inProfile:self.profile]) {
-        [[iTermGrowlDelegate sharedInstance] growlNotify:@"Session Ended"
+        [[iTermNotificationController sharedInstance] growlNotify:@"Session Ended"
                                          withDescription:[NSString stringWithFormat:@"Session \"%@\" in tab #%d just terminated.",
                                                           [self name],
                                                           [_delegate tabNumber]]
@@ -3108,7 +3108,7 @@ ITERM_WEAKLY_REFERENCEABLE
             if ([_textview keyIsARepeat] == NO &&
                 [self shouldPostGrowlNotification] &&
                 [iTermProfilePreferences boolForKey:KEY_SEND_BELL_ALERT inProfile:self.profile]) {
-                [[iTermGrowlDelegate sharedInstance] growlNotify:@"Bell"
+                [[iTermNotificationController sharedInstance] growlNotify:@"Bell"
                                                  withDescription:[NSString stringWithFormat:@"Session %@ #%d just rang a bell!",
                                                                   [self name],
                                                                   [_delegate tabNumber]]
@@ -7669,7 +7669,7 @@ ITERM_WEAKLY_REFERENCEABLE
     if (self.alertOnNextMark) {
         NSString *action = [iTermApplication.sharedApplication delegate].markAlertAction;
         if ([action isEqualToString:kMarkAlertActionPostNotification]) {
-            [[iTermGrowlDelegate sharedInstance] growlNotify:@"Mark Set"
+            [[iTermNotificationController sharedInstance] growlNotify:@"Mark Set"
                                              withDescription:[NSString stringWithFormat:@"Session %@ #%d had a mark set.",
                                                               [self name],
                                                               [_delegate tabNumber]]

--- a/sources/PTYTab.m
+++ b/sources/PTYTab.m
@@ -4627,7 +4627,7 @@ static void SetAgainstGrainDim(BOOL isVertical, NSSize *dest, CGFloat value) {
                             [session name],
                             [self tabNumber]];
                     if ([iTermProfilePreferences boolForKey:KEY_SEND_IDLE_ALERT inProfile:session.profile]) {
-                        [[iTermNotificationController sharedInstance] growlNotify:@"Idle"
+                        [[iTermNotificationController sharedInstance] notify:@"Idle"
                                                          withDescription:theDescription
                                                          andNotification:@"Idle"
                                                              windowIndex:[session screenWindowIndex]
@@ -4665,7 +4665,7 @@ static void SetAgainstGrainDim(BOOL isVertical, NSSize *dest, CGFloat value) {
         notify &&
         [[NSDate date] timeIntervalSinceDate:[SessionView lastResizeDate]] > POST_WINDOW_RESIZE_SILENCE_SEC) {
         if ([iTermProfilePreferences boolForKey:KEY_SEND_NEW_OUTPUT_ALERT inProfile:self.activeSession.profile]) {
-            [[iTermNotificationController sharedInstance] growlNotify:NSLocalizedStringFromTableInBundle(@"New Output",
+            [[iTermNotificationController sharedInstance] notify:NSLocalizedStringFromTableInBundle(@"New Output",
                                                                                                 @"iTerm",
                                                                                                 [NSBundle bundleForClass:[self class]],
                                                                                                 @"Growl Alerts")

--- a/sources/PTYTab.m
+++ b/sources/PTYTab.m
@@ -5,7 +5,7 @@
 #import "iTermAdvancedSettingsModel.h"
 #import "iTermApplicationDelegate.h"
 #import "iTermController.h"
-#import "iTermGrowlDelegate.h"
+#import "iTermNotificationController.h"
 #import "iTermPowerManager.h"
 #import "iTermPreferences.h"
 #import "iTermPromptOnCloseReason.h"
@@ -4627,7 +4627,7 @@ static void SetAgainstGrainDim(BOOL isVertical, NSSize *dest, CGFloat value) {
                             [session name],
                             [self tabNumber]];
                     if ([iTermProfilePreferences boolForKey:KEY_SEND_IDLE_ALERT inProfile:session.profile]) {
-                        [[iTermGrowlDelegate sharedInstance] growlNotify:@"Idle"
+                        [[iTermNotificationController sharedInstance] growlNotify:@"Idle"
                                                          withDescription:theDescription
                                                          andNotification:@"Idle"
                                                              windowIndex:[session screenWindowIndex]
@@ -4665,7 +4665,7 @@ static void SetAgainstGrainDim(BOOL isVertical, NSSize *dest, CGFloat value) {
         notify &&
         [[NSDate date] timeIntervalSinceDate:[SessionView lastResizeDate]] > POST_WINDOW_RESIZE_SILENCE_SEC) {
         if ([iTermProfilePreferences boolForKey:KEY_SEND_NEW_OUTPUT_ALERT inProfile:self.activeSession.profile]) {
-            [[iTermGrowlDelegate sharedInstance] growlNotify:NSLocalizedStringFromTableInBundle(@"New Output",
+            [[iTermNotificationController sharedInstance] growlNotify:NSLocalizedStringFromTableInBundle(@"New Output",
                                                                                                 @"iTerm",
                                                                                                 [NSBundle bundleForClass:[self class]],
                                                                                                 @"Growl Alerts")

--- a/sources/PTYTask.m
+++ b/sources/PTYTask.m
@@ -2,7 +2,7 @@
 
 #import "Coprocess.h"
 #import "DebugLogging.h"
-#import "iTermGrowlDelegate.h"
+#import "iTermNotificationController.h"
 #import "NSWorkspace+iTerm.h"
 #import "PreferencePanel.h"
 #import "ProcessCache.h"
@@ -606,7 +606,7 @@ static int MyForkPty(int *amaster,
     } else if (pid < (pid_t)0) {
         // Error
         DLog(@"Unable to fork %@: %s", progpath, strerror(errno));
-        [[iTermGrowlDelegate sharedInstance] growlNotify:@"Unable to fork!" withDescription:@"You may have too many processes already running."];
+        [[iTermNotificationController sharedInstance] growlNotify:@"Unable to fork!" withDescription:@"You may have too many processes already running."];
 
         for (int j = 0; newEnviron[j]; j++) {
             free(newEnviron[j]);

--- a/sources/PTYTask.m
+++ b/sources/PTYTask.m
@@ -606,7 +606,7 @@ static int MyForkPty(int *amaster,
     } else if (pid < (pid_t)0) {
         // Error
         DLog(@"Unable to fork %@: %s", progpath, strerror(errno));
-        [[iTermNotificationController sharedInstance] growlNotify:@"Unable to fork!" withDescription:@"You may have too many processes already running."];
+        [[iTermNotificationController sharedInstance] notify:@"Unable to fork!" withDescription:@"You may have too many processes already running."];
 
         for (int j = 0; newEnviron[j]; j++) {
             free(newEnviron[j]);

--- a/sources/PseudoTerminal.m
+++ b/sources/PseudoTerminal.m
@@ -24,7 +24,7 @@
 #import "iTermController.h"
 #import "iTermFindCursorView.h"
 #import "iTermFontPanel.h"
-#import "iTermGrowlDelegate.h"
+#import "iTermNotificationController.h"
 #import "iTermHotKeyController.h"
 #import "iTermHotKeyMigrationHelper.h"
 #import "iTermInstantReplayWindowController.h"

--- a/sources/TransferrableFile.m
+++ b/sources/TransferrableFile.m
@@ -126,13 +126,13 @@
                     break;
 
                 case kTransferrableFileStatusFinishedSuccessfully:
-                    [[iTermNotificationController sharedInstance] growlNotify:
+                    [[iTermNotificationController sharedInstance] notify:
                         [NSString stringWithFormat:@"%@ of “%@” finished!",
                             self.isDownloading ? @"Download" : @"Upload", [self shortName]]];
                     break;
 
                 case kTransferrableFileStatusFinishedWithError:
-                    [[iTermNotificationController sharedInstance] growlNotify:
+                    [[iTermNotificationController sharedInstance] notify:
                      [NSString stringWithFormat:@"%@ of “%@” failed.",
                       self.isDownloading ? @"Download" : @"Upload", [self shortName]]];
             }

--- a/sources/TransferrableFile.m
+++ b/sources/TransferrableFile.m
@@ -9,7 +9,7 @@
 #import "TransferrableFile.h"
 
 #import "NSFileManager+iTerm.h"
-#import "iTermGrowlDelegate.h"
+#import "iTermNotificationController.h"
 
 @implementation TransferrableFile {
     NSTimeInterval _timeOfLastStatusChange;
@@ -126,13 +126,13 @@
                     break;
 
                 case kTransferrableFileStatusFinishedSuccessfully:
-                    [[iTermGrowlDelegate sharedInstance] growlNotify:
+                    [[iTermNotificationController sharedInstance] growlNotify:
                         [NSString stringWithFormat:@"%@ of “%@” finished!",
                             self.isDownloading ? @"Download" : @"Upload", [self shortName]]];
                     break;
 
                 case kTransferrableFileStatusFinishedWithError:
-                    [[iTermGrowlDelegate sharedInstance] growlNotify:
+                    [[iTermNotificationController sharedInstance] growlNotify:
                      [NSString stringWithFormat:@"%@ of “%@” failed.",
                       self.isDownloading ? @"Download" : @"Upload", [self shortName]]];
             }

--- a/sources/VT100Screen.h
+++ b/sources/VT100Screen.h
@@ -7,7 +7,7 @@
 #import "VT100Token.h"
 
 @class DVR;
-@class iTermGrowlDelegate;
+@class iTermNotificationController;
 @class iTermMark;
 @class iTermStringLine;
 @class LineBuffer;

--- a/sources/VT100Screen.m
+++ b/sources/VT100Screen.m
@@ -3093,7 +3093,7 @@ static NSString *const kInilineFileInset = @"inset";  // NSValue of NSEdgeInsets
                                     [delegate_ screenNumber],
                                     message];
         BOOL sent = [[iTermNotificationController sharedInstance]
-                        growlNotify:@"Alert"
+                                 notify:@"Alert"
                         withDescription:description
                         andNotification:@"Customized Message"
                             windowIndex:[delegate_ screenWindowIndex]

--- a/sources/VT100Screen.m
+++ b/sources/VT100Screen.m
@@ -9,7 +9,7 @@
 #import "iTermCapturedOutputMark.h"
 #import "iTermColorMap.h"
 #import "iTermExpose.h"
-#import "iTermGrowlDelegate.h"
+#import "iTermNotificationController.h"
 #import "iTermImage.h"
 #import "iTermImageInfo.h"
 #import "iTermImageMark.h"
@@ -205,7 +205,7 @@ static NSString *const kInilineFileInset = @"inset";  // NSValue of NSEdgeInsets
         [self setInitialTabStops];
         linebuffer_ = [[LineBuffer alloc] init];
 
-        [iTermGrowlDelegate sharedInstance];
+        [iTermNotificationController sharedInstance];
 
         dvr_ = [DVR alloc];
         [dvr_ initWithBufferCapacity:[iTermPreferences intForKey:kPreferenceKeyInstantReplayMemoryMegabytes] * 1024 * 1024];
@@ -3092,7 +3092,7 @@ static NSString *const kInilineFileInset = @"inset";  // NSValue of NSEdgeInsets
                                     [delegate_ screenName],
                                     [delegate_ screenNumber],
                                     message];
-        BOOL sent = [[iTermGrowlDelegate sharedInstance]
+        BOOL sent = [[iTermNotificationController sharedInstance]
                         growlNotify:@"Alert"
                         withDescription:description
                         andNotification:@"Customized Message"

--- a/sources/iTermAdvancedSettingsModel.h
+++ b/sources/iTermAdvancedSettingsModel.h
@@ -206,5 +206,6 @@
 + (BOOL)middleClickClosesTab;
 + (BOOL)disableMetalWhenUnplugged;
 + (BOOL)disableMetalWhenIdle;
++ (BOOL)disableGrowl;
 
 @end

--- a/sources/iTermAdvancedSettingsModel.m
+++ b/sources/iTermAdvancedSettingsModel.m
@@ -169,6 +169,12 @@ DEFINE_BOOL(hideStuckTooltips, YES, @"General: Hide stuck tooltips.\nWhen you hi
 DEFINE_BOOL(openFileOverridesSendText, YES, @"General: Should opening a script with iTerm2 disable the default profile's “Send Text at Start” setting?\nIf you use “open iTerm2 file.command” or drag a script onto iTerm2's icon and this setting is enabled then the script will be executed in lieu of the profile's “Send Text at Start” setting. If this setting is off then both will be executed.");
 DEFINE_BOOL(statusBarIcon, YES, @"General: Add status bar icon when excluded from dock?\nWhen you turn on “Exclude from Dock and Cmd-Tab Application Switcher” a status bar icon is added to the menu bar so you can switch the setting back off. Disable this to remove the status bar icon. Doing so makes it very hard to get to Preferences. You must restart iTerm2 after changing this setting.");
 DEFINE_BOOL(wrapFocus, YES, @"General: Should the directional focus hotkeys wrap");
+#if BETA
+#define ADVANCED_SETTINGS_DISABLE_GROWL YES
+#else
+#define ADVANCED_SETTINGS_DISABLE_GROWL NO
+#endif
+DEFINE_BOOL(disableGrowl, ADVANCED_SETTINGS_DISABLE_GROWL, @"General: Disable Growl notifications.\nSend notifications directly to Notification Center instead of relying on Growl to deliver them. Enables sound alerts on notifications.");
 
 #pragma mark - Drawing
 DEFINE_BOOL(zippyTextDrawing, YES, @"Drawing: Use zippy text drawing algorithm?\nThis draws non-ASCII text more quickly but with lower fidelity. This setting is ignored if ligatures are enabled in Prefs > Profiles > Text.");

--- a/sources/iTermController.m
+++ b/sources/iTermController.m
@@ -54,7 +54,7 @@
 #import "iTermApplicationDelegate.h"
 #import "iTermExpose.h"
 #import "iTermFullScreenWindowManager.h"
-#import "iTermGrowlDelegate.h"
+#import "iTermNotificationController.h"
 #import "iTermKeyBindingMgr.h"
 #import "iTermPreferences.h"
 #import "iTermProfilePreferences.h"
@@ -126,7 +126,7 @@ static iTermController *gSharedInstance;
         _restorableSessions = [[NSMutableArray alloc] init];
         _currentRestorableSessionsStack = [[NSMutableArray alloc] init];
         // Activate Growl. This loads the Growl framework and initializes it.
-        [iTermGrowlDelegate sharedInstance];
+        [iTermNotificationController sharedInstance];
 
         [[[NSWorkspace sharedWorkspace] notificationCenter] addObserver:self
                                                                selector:@selector(workspaceWillPowerOff:)

--- a/sources/iTermNotificationController.h
+++ b/sources/iTermNotificationController.h
@@ -7,8 +7,9 @@
  **
  **  Project: iTerm
  **
- **  Description: Implements the delegate for Growl notifications. When
- **      available, Notifiation Center is used as a fallback.
+ **  Description: Implements the delegate for notifications. When available
+ **      Notification Center is used either as a fallback from Growl or
+ **      directly (if the corresponding advanced setting is turned on).
  **
  **  Usage:
  **      In your class header file, add the following @class directive
@@ -27,7 +28,7 @@
  **
  **          gd = [iTermNotificationController sharedInstance];
  **
- **      There are several growlNotify methods in iTermNotificationController.
+ **      There are several notify methods in iTermNotificationController.
  **      See the header file for details.
  **
  **      Example usage:
@@ -60,19 +61,19 @@
 
 + (instancetype)sharedInstance;
 
-// Generate a Growl message with no description and a notification type
+// Generate a message with no description and a Growl notification type
 // of "Miscellaneous".
 - (void)notify:(NSString *)title;
 
-// Generate a Growl message with a notification type of "Miscellaneous".
+// Generate a message with a Growl notification type of "Miscellaneous".
 - (void)notify:(NSString *)title withDescription:(NSString *)description;
 
-//  Generate a 'full' Growl message with a specified notification type.
+//  Generate a 'full' message with a specified notification type.
 - (void)notify:(NSString *)title
     withDescription:(NSString *)description
     andNotification:(NSString *)notification;
 
-// Generate a 'full' Growl message with a specified notification type,
+// Generate a 'full' message with a specified notification type,
 // associated with a particular window/tab/view.
 //
 // Returns YES if the notification was posted.
@@ -83,7 +84,7 @@
            tabIndex:(int)tabIndex
           viewIndex:(int)viewIndex;
 
-// Adds the sticky argument. Only works with Growl, not notification center.
+// Adds the sticky argument.
 - (BOOL)notify:(NSString *)title
     withDescription:(NSString *)description
     andNotification:(NSString *)notification

--- a/sources/iTermNotificationController.h
+++ b/sources/iTermNotificationController.h
@@ -32,7 +32,7 @@
  **
  **      Example usage:
  **
- **          [gd growlNotify: @"This is the title"
+ **          [gd notify: @"This is the title"
  **          withDescription: @"This is the description"
  **          andNotification: @"Bells"];
  **
@@ -62,13 +62,13 @@
 
 // Generate a Growl message with no description and a notification type
 // of "Miscellaneous".
-- (void)growlNotify:(NSString *)title;
+- (void)notify:(NSString *)title;
 
 // Generate a Growl message with a notification type of "Miscellaneous".
-- (void)growlNotify:(NSString *)title withDescription:(NSString *)description;
+- (void)notify:(NSString *)title withDescription:(NSString *)description;
 
 //  Generate a 'full' Growl message with a specified notification type.
-- (void)growlNotify:(NSString *)title
+- (void)notify:(NSString *)title
     withDescription:(NSString *)description
     andNotification:(NSString *)notification;
 
@@ -76,7 +76,7 @@
 // associated with a particular window/tab/view.
 //
 // Returns YES if the notification was posted.
-- (BOOL)growlNotify:(NSString *)title
+- (BOOL)notify:(NSString *)title
     withDescription:(NSString *)description
     andNotification:(NSString *)notification
         windowIndex:(int)windowIndex
@@ -84,7 +84,7 @@
           viewIndex:(int)viewIndex;
 
 // Adds the sticky argument. Only works with Growl, not notification center.
-- (BOOL)growlNotify:(NSString *)title
+- (BOOL)notify:(NSString *)title
     withDescription:(NSString *)description
     andNotification:(NSString *)notification
         windowIndex:(int)windowIndex

--- a/sources/iTermNotificationController.h
+++ b/sources/iTermNotificationController.h
@@ -1,5 +1,5 @@
 /*
- **  iTermGrowlDelegate.h
+ **  iTermNotificationController.h
  **
  **  Copyright (c) 2006
  **
@@ -13,21 +13,21 @@
  **  Usage:
  **      In your class header file, add the following @class directive
  **
- **          @class iTermGrowlDelegate;
+ **          @class iTermNotificationController;
  **
- **      and declare an iTermGrowlDelegate variable in the @interface
+ **      and declare an iTermNotificationController variable in the @interface
  **
- **          iTermGrowlDelegate* gd;
+ **          iTermNotificationController* gd;
  **
  **      In your class implementation file, add the following import
  **
- **          #import "iTermGrowlDelegate.h"
+ **          #import "iTermNotificationController.h"
  **
  **      In the class init, get a copy of the shared delegate
  **
- **          gd = [iTermGrowlDelegate sharedInstance];
+ **          gd = [iTermNotificationController sharedInstance];
  **
- **      There are several growlNotify methods in iTermGrowlDelegate.
+ **      There are several growlNotify methods in iTermNotificationController.
  **      See the header file for details.
  **
  **      Example usage:
@@ -54,7 +54,7 @@
 #import <Cocoa/Cocoa.h>
 #import <Growl/Growl.h>
 
-@interface iTermGrowlDelegate : NSObject <
+@interface iTermNotificationController : NSObject <
   GrowlApplicationBridgeDelegate,
   NSUserNotificationCenterDelegate>
 

--- a/sources/iTermNotificationController.m
+++ b/sources/iTermNotificationController.m
@@ -68,21 +68,21 @@ static NSString *const kDefaultNotification = @"Miscellaneous";
     return self;
 }
 
-- (void)growlNotify:(NSString *)title {
-    [self growlNotify:title withDescription:nil];
+- (void)notify:(NSString *)title {
+    [self notify:title withDescription:nil];
 }
 
-- (void)growlNotify:(NSString *)title
+- (void)notify:(NSString *)title
      withDescription:(NSString *)description {
-    [self growlNotify:title
+    [self notify:title
       withDescription:description
       andNotification:kDefaultNotification];
 }
 
-- (void)growlNotify:(NSString *)title
+- (void)notify:(NSString *)title
     withDescription:(NSString *)description
     andNotification:(NSString *)notification {
-      [self growlNotify:title
+      [self notify:title
         withDescription:description
         andNotification:notification
             windowIndex:-1
@@ -90,13 +90,13 @@ static NSString *const kDefaultNotification = @"Miscellaneous";
               viewIndex:-1];
 }
 
-- (BOOL)growlNotify:(NSString *)title
+- (BOOL)notify:(NSString *)title
     withDescription:(NSString *)description
     andNotification:(NSString *)notification
         windowIndex:(int)windowIndex
            tabIndex:(int)tabIndex
           viewIndex:(int)viewIndex {
-    return [self growlNotify:title
+    return [self notify:title
              withDescription:description
              andNotification:notification
                  windowIndex:windowIndex
@@ -105,7 +105,7 @@ static NSString *const kDefaultNotification = @"Miscellaneous";
                       sticky:NO];
 }
 
-- (BOOL)growlNotify:(NSString *)title
+- (BOOL)notify:(NSString *)title
     withDescription:(NSString *)description
     andNotification:(NSString *)notification
         windowIndex:(int)windowIndex

--- a/sources/iTermNotificationController.m
+++ b/sources/iTermNotificationController.m
@@ -1,5 +1,5 @@
 /*
- **  iTermGrowlDelegate.m
+ **  iTermNotificationController.m
  **
  **  Copyright (c) 2006
  **
@@ -8,7 +8,7 @@
  **  Project: iTerm
  **
  **  Description: Implements the delegate for Growl notifications.
- **               See iTermGrowlDelegate.h for usage information.
+ **               See iTermNotificationController.h for usage information.
  **
  **  This program is free software; you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
@@ -25,7 +25,7 @@
  **  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-#import "iTermGrowlDelegate.h"
+#import "iTermNotificationController.h"
 
 #import "iTermController.h"
 #import "PreferencePanel.h"
@@ -38,10 +38,10 @@
 static NSString *const kGrowlAppName = @"iTerm";
 static NSString *const kDefaultNotification = @"Miscellaneous";
 
-@implementation iTermGrowlDelegate
+@implementation iTermNotificationController
 
 + (id)sharedInstance {
-    static iTermGrowlDelegate *instance;
+    static iTermNotificationController *instance;
     static dispatch_once_t once;
     dispatch_once(&once, ^{
         instance = [[self alloc] init];
@@ -52,7 +52,7 @@ static NSString *const kDefaultNotification = @"Miscellaneous";
 - (instancetype)init {
     self = [super init];
     if (self) {
-        NSBundle *myBundle = [NSBundle bundleForClass:[iTermGrowlDelegate class]];
+        NSBundle *myBundle = [NSBundle bundleForClass:[iTermNotificationController class]];
         NSString *growlPath =
             [[myBundle privateFrameworksPath] stringByAppendingPathComponent:@"Growl.framework"];
         NSBundle *growlBundle = [NSBundle bundleWithPath:growlPath];


### PR DESCRIPTION
After the introduction of the built-in notification system in Mountain Lion (10.8) Growl has been falling into disuse. The 2.0 framework supports the native `NSUserNotificationCenter` and acts as a bridge, which iTerm is still using to send notifications. Considering iTerm2 was made for 10.10+, Growl is in fact acting as a forward service only in most of the cases (except for users who still prefer to install and use Growl).

The main problem with using Growl as a forwarding service is the lack of customization. The framework hasn't been updated for a long time, meaning iTerm is stuck with the frozen notification format implemented by Growl. Forwarded notifications don't have a sound, for example. Even though `NSUserNotificationCenter` supports it, Growl does not use it. Nor implements support for action buttons which could be used in the future.

This PR might be the first step into deprecating Growl without actually deprecating it. A new advanced setting was added (enabled by default to beta users only) to skip Growl and send the notification directly. The class `iTermGrowlDelegate` was renamed to `iTermNotificationController` and so were its methods, to remove Growl references. Clicking a native notification will also bring the corresponding view to front.