### PR TITLE
Update the command range when the cursor moves.

### DIFF
--- a/sources/VT100Screen.m
+++ b/sources/VT100Screen.m
@@ -2728,7 +2728,7 @@ basedAtAbsoluteLineNumber:(long long)absoluteLineNumber
     }
     [delegate_ screenTriggerableChangeDidOccur];
     if (commandStartX_ != -1) {
-        [delegate_ screenCommandDidEndWithRange:[self commandRange]];
+        [delegate_ screenCommandDidChangeWithRange:[self commandRange]];
     }
 }
 

--- a/sources/VT100Screen.m
+++ b/sources/VT100Screen.m
@@ -2533,6 +2533,9 @@ basedAtAbsoluteLineNumber:(long long)absoluteLineNumber
 {
     [currentGrid_ moveCursorLeft:n];
     [delegate_ screenTriggerableChangeDidOccur];
+    if (commandStartX_ != -1) {
+        [delegate_ screenCommandDidChangeWithRange:[self commandRange]];
+    }
 }
 
 - (void)terminalCursorDown:(int)n andToStartOfLine:(BOOL)toStart {
@@ -2541,12 +2544,18 @@ basedAtAbsoluteLineNumber:(long long)absoluteLineNumber
         [currentGrid_ moveCursorToLeftMargin];
     }
     [delegate_ screenTriggerableChangeDidOccur];
+    if (commandStartX_ != -1) {
+        [delegate_ screenCommandDidChangeWithRange:[self commandRange]];
+    }
 }
 
 - (void)terminalCursorRight:(int)n
 {
     [currentGrid_ moveCursorRight:n];
     [delegate_ screenTriggerableChangeDidOccur];
+    if (commandStartX_ != -1) {
+        [delegate_ screenCommandDidChangeWithRange:[self commandRange]];
+    }
 }
 
 - (void)terminalCursorUp:(int)n andToStartOfLine:(BOOL)toStart{
@@ -2555,12 +2564,18 @@ basedAtAbsoluteLineNumber:(long long)absoluteLineNumber
         [currentGrid_ moveCursorToLeftMargin];
     }
     [delegate_ screenTriggerableChangeDidOccur];
+    if (commandStartX_ != -1) {
+        [delegate_ screenCommandDidChangeWithRange:[self commandRange]];
+    }
 }
 
 - (void)terminalMoveCursorToX:(int)x y:(int)y
 {
     [self cursorToX:x Y:y];
     [delegate_ screenTriggerableChangeDidOccur];
+    if (commandStartX_ != -1) {
+        [delegate_ screenCommandDidChangeWithRange:[self commandRange]];
+    }
 }
 
 - (BOOL)terminalShouldSendReport
@@ -2712,6 +2727,9 @@ basedAtAbsoluteLineNumber:(long long)absoluteLineNumber
         [currentGrid_ moveCursorToLeftMargin];
     }
     [delegate_ screenTriggerableChangeDidOccur];
+    if (commandStartX_ != -1) {
+        [delegate_ screenCommandDidEndWithRange:[self commandRange]];
+    }
 }
 
 - (void)terminalReverseIndex {


### PR DESCRIPTION
Previously when:

1. Move the cursor to the right
2. A command occupies more than one line, the cursor is at the second column and second line, and move the cursor 1 column left

The command range became incorrect, and "Select Current Commands" would select a wrong range.

Calling `-screenCommandDidChangeWithRange:` in `-terminalCursorRight:` fixes (1), `-terminalCarriageReturn:` fixes (2).

I'm not sure it's necessary in other methods, but they seem to be related.