### PR TITLE
Add advanced option to customize path to ssh for ssh:// links

### DIFF
--- a/sources/iTermAdvancedSettingsModel.h
+++ b/sources/iTermAdvancedSettingsModel.h
@@ -215,6 +215,7 @@
 + (double)activeUpdateCadence;
 + (BOOL)openNewWindowAtStartup;
 + (BOOL)resetSGROnPrompt;
++ (NSString *)sshSchemePath;
 
 #if ENABLE_LOW_POWER_GPU_DETECTION
 + (BOOL)useLowPowerGPUWhenUnplugged;

--- a/sources/iTermAdvancedSettingsModel.m
+++ b/sources/iTermAdvancedSettingsModel.m
@@ -172,6 +172,8 @@ DEFINE_FLOAT(verticalBarCursorWidth, 1, @"Terminal: Width of vertical bar cursor
 DEFINE_BOOL(acceptOSC7, YES, @"Terminal: Accept OSC 7 to set username, hostname, and path.");
 DEFINE_BOOL(detectPasswordInput, YES, @"Terminal: Show key at cursor at password prompt?");
 DEFINE_BOOL(tabsWrapAround, NO, @"Terminal: Tabs wrap around to the next line.\nThis is useful for preserving tabs for later copying to the pasteboard. It breaks backward compatibility and may cause layout problems with programs that don’t expect this behavior.");
+DEFINE_STRING(sshSchemePath, @"ssh", @"Terminal: Path to binary for ssh:// links.\nCan be used to add custom options such as ProxyJump, etc.");
+
 #pragma mark Hotkey
 DEFINE_FLOAT(hotkeyTermAnimationDuration, 0.25, @"Hotkey: Duration in seconds of the hotkey window animation.\nWarning: reducing this value may cause problems if you have multiple displays.");
 DEFINE_BOOL(dockIconTogglesWindow, NO, @"Hotkey: If the only window is a hotkey window, then clicking the dock icon shows or hides it.");

--- a/sources/iTermAdvancedSettingsModel.m
+++ b/sources/iTermAdvancedSettingsModel.m
@@ -172,7 +172,7 @@ DEFINE_FLOAT(verticalBarCursorWidth, 1, @"Terminal: Width of vertical bar cursor
 DEFINE_BOOL(acceptOSC7, YES, @"Terminal: Accept OSC 7 to set username, hostname, and path.");
 DEFINE_BOOL(detectPasswordInput, YES, @"Terminal: Show key at cursor at password prompt?");
 DEFINE_BOOL(tabsWrapAround, NO, @"Terminal: Tabs wrap around to the next line.\nThis is useful for preserving tabs for later copying to the pasteboard. It breaks backward compatibility and may cause layout problems with programs that don’t expect this behavior.");
-DEFINE_STRING(sshSchemePath, @"ssh", @"Terminal: Path to binary for ssh:// links.\nCan be used to add custom options such as ProxyJump, etc.");
+DEFINE_STRING(sshSchemePath, @"ssh", @"Terminal: Command to run when handling an ssh:// URL.");
 
 #pragma mark Hotkey
 DEFINE_FLOAT(hotkeyTermAnimationDuration, 0.25, @"Hotkey: Duration in seconds of the hotkey window animation.\nWarning: reducing this value may cause problems if you have multiple displays.");

--- a/sources/iTermController.m
+++ b/sources/iTermController.m
@@ -1042,7 +1042,8 @@ static iTermController *gSharedInstance;
 }
 
 - (Profile *)profileByModifyingProfile:(NSDictionary *)prototype toSshTo:(NSURL *)url {
-    NSMutableString *tempString = [NSMutableString stringWithString:@"ssh "];
+    NSMutableString *tempString = [NSMutableString stringWithString:[iTermAdvancedSettingsModel sshSchemePath]];
+    [tempString appendString:@" "];
     NSString *username = url.user;
     BOOL cd = ([iTermAdvancedSettingsModel sshURLsSupportPath] && url.path.length > 1);
     if (username) {

--- a/sources/iTermController.m
+++ b/sources/iTermController.m
@@ -1043,6 +1043,11 @@ static iTermController *gSharedInstance;
 
 - (Profile *)profileByModifyingProfile:(NSDictionary *)prototype toSshTo:(NSURL *)url {
     NSMutableString *tempString = [NSMutableString stringWithString:[iTermAdvancedSettingsModel sshSchemePath]];
+    NSCharacterSet *alphanumericSet = [NSMutableCharacterSet alphanumericCharacterSet];
+    if ([tempString rangeOfCharacterFromSet:alphanumericSet].location == NSNotFound) {
+        // if the setting is set to an empty string, we will default to "ssh" for safety reasons
+        tempString = [NSMutableString stringWithString:@"ssh"];
+    }
     [tempString appendString:@" "];
     NSString *username = url.user;
     BOOL cd = ([iTermAdvancedSettingsModel sshURLsSupportPath] && url.path.length > 1);


### PR DESCRIPTION
Hi there. I am far from an expert, so please let me know if you want me to make any changes.

I've been using this modification for months, and I figured it is time that I tried to contribute it upstream.

I have a chrome extension that adds ssh:// links to the AWS console, but the only problem is that I have to add extra options, such as ProxyJump, because the servers are not accessible without tunneling through another host first.

So to accomplish this, I made iTerm run a shell script, which parses the arguments, and adds more arguments in turn. It then runs the standard ssh binary.

My shell script:
```shell
#!/bin/bash -e
extra_args=()
for arg in "$@"; do
  if [[ "$arg" == *".example.com" ]]; then
    extra_args+=("-J")
    extra_args+=("bastion.example.com")
  fi
done
echo ssh "${extra_args[@]}" "$@"
ssh "${extra_args[@]}" "$@"
```

Example ([jsfiddle](https://jsfiddle.net/ztp4mcu6/1/)):
- Clicking `ssh://server.example.com` will result in `ssh -J bastion.example.com server.example.com` being run.
- Clicking `ssh://username@server.example.com` will result in `ssh -J bastion.example.com -l username server.example.com` being run.

Let me know what your opinion is on this change. Thank you!