### PR TITLE
Various changes (mainly NSBundle) to make it easier to build an embeddable library/framework

### DIFF
--- a/ThirdParty/PSMTabBarControl/source/PSMYosemiteTabStyle.m
+++ b/ThirdParty/PSMTabBarControl/source/PSMYosemiteTabStyle.m
@@ -136,9 +136,9 @@
 - (id)init {
     if ((self = [super init]))  {
         // Load close buttons 
-        _closeButton = [[NSImage imageNamed:@"TabClose_Front"] retain];
-        _closeButtonDown = [[NSImage imageNamed:@"TabClose_Front_Pressed"] retain];
-        _closeButtonOver = [[NSImage imageNamed:@"TabClose_Front_Rollover"] retain];
+        _closeButton = [[[NSBundle bundleForClass:self.class] imageForResource:@"TabClose_Front"] retain];
+        _closeButtonDown = [[[NSBundle bundleForClass:self.class] imageForResource:@"TabClose_Front_Pressed"] retain];
+        _closeButtonOver = [[[NSBundle bundleForClass:self.class] imageForResource:@"TabClose_Front_Rollover"] retain];
 
         // Load "new tab" buttons
         _addTabButtonImage = [[NSImage alloc] initByReferencingFile:[[PSMTabBarControl bundle] pathForImageResource:@"TabNewMetal"]];

--- a/iTerm2.xcodeproj/project.pbxproj
+++ b/iTerm2.xcodeproj/project.pbxproj
@@ -2186,12 +2186,12 @@
 		A69C93462121140100531438 /* iTermStatusBarLargeComposerViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = A69C933E2121140100531438 /* iTermStatusBarLargeComposerViewController.xib */; };
 		A69C93472121140100531438 /* iTermStatusBarLargeComposerViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = A69C933E2121140100531438 /* iTermStatusBarLargeComposerViewController.xib */; };
 		A69C93482121140100531438 /* iTermStatusBarLargeComposerViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = A69C933E2121140100531438 /* iTermStatusBarLargeComposerViewController.xib */; };
+		A69CCB11211B55FB008ADA71 /* iTermMenuBarObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = A69CCB0F211B55FB008ADA71 /* iTermMenuBarObserver.h */; };
+		A69CCB12211B55FB008ADA71 /* iTermMenuBarObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = A69CCB10211B55FB008ADA71 /* iTermMenuBarObserver.m */; };
 		A69CCB18211BC296008ADA71 /* NSData+GZIP.h in Headers */ = {isa = PBXBuildFile; fileRef = A69CCB15211BC296008ADA71 /* NSData+GZIP.h */; };
 		A69CCB19211BC296008ADA71 /* NSData+GZIP.m in Sources */ = {isa = PBXBuildFile; fileRef = A69CCB16211BC296008ADA71 /* NSData+GZIP.m */; };
 		A69CCB1C211BF4FF008ADA71 /* iTermRecordingCodec.h in Headers */ = {isa = PBXBuildFile; fileRef = A69CCB1A211BF4FF008ADA71 /* iTermRecordingCodec.h */; };
 		A69CCB1D211BF4FF008ADA71 /* iTermRecordingCodec.m in Sources */ = {isa = PBXBuildFile; fileRef = A69CCB1B211BF4FF008ADA71 /* iTermRecordingCodec.m */; };
-		A69CCB11211B55FB008ADA71 /* iTermMenuBarObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = A69CCB0F211B55FB008ADA71 /* iTermMenuBarObserver.h */; };
-		A69CCB12211B55FB008ADA71 /* iTermMenuBarObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = A69CCB10211B55FB008ADA71 /* iTermMenuBarObserver.m */; };
 		A6A13AA218C2D23300B241ED /* iTermColorMap.h in Headers */ = {isa = PBXBuildFile; fileRef = A6A13AA018C2D23300B241ED /* iTermColorMap.h */; };
 		A6A13AA718C2D45900B241ED /* NSColor+iTerm.h in Headers */ = {isa = PBXBuildFile; fileRef = A6A13AA518C2D45900B241ED /* NSColor+iTerm.h */; };
 		A6A13AAC18C3347200B241ED /* VT100Output.h in Headers */ = {isa = PBXBuildFile; fileRef = A6A13AAA18C3347200B241ED /* VT100Output.h */; };
@@ -4531,12 +4531,12 @@
 		A69C933C2121140100531438 /* iTermStatusBarLargeComposerViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = iTermStatusBarLargeComposerViewController.h; sourceTree = "<group>"; };
 		A69C933D2121140100531438 /* iTermStatusBarLargeComposerViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = iTermStatusBarLargeComposerViewController.m; sourceTree = "<group>"; };
 		A69C933E2121140100531438 /* iTermStatusBarLargeComposerViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = iTermStatusBarLargeComposerViewController.xib; sourceTree = "<group>"; };
+		A69CCB0F211B55FB008ADA71 /* iTermMenuBarObserver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = iTermMenuBarObserver.h; sourceTree = "<group>"; };
+		A69CCB10211B55FB008ADA71 /* iTermMenuBarObserver.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = iTermMenuBarObserver.m; sourceTree = "<group>"; };
 		A69CCB15211BC296008ADA71 /* NSData+GZIP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSData+GZIP.h"; path = "GZIP/GZIP/NSData+GZIP.h"; sourceTree = "<group>"; };
 		A69CCB16211BC296008ADA71 /* NSData+GZIP.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSData+GZIP.m"; path = "GZIP/GZIP/NSData+GZIP.m"; sourceTree = "<group>"; };
 		A69CCB1A211BF4FF008ADA71 /* iTermRecordingCodec.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = iTermRecordingCodec.h; sourceTree = "<group>"; };
 		A69CCB1B211BF4FF008ADA71 /* iTermRecordingCodec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = iTermRecordingCodec.m; sourceTree = "<group>"; };
-		A69CCB0F211B55FB008ADA71 /* iTermMenuBarObserver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = iTermMenuBarObserver.h; sourceTree = "<group>"; };
-		A69CCB10211B55FB008ADA71 /* iTermMenuBarObserver.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = iTermMenuBarObserver.m; sourceTree = "<group>"; };
 		A6A13AA018C2D23300B241ED /* iTermColorMap.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.h; path = iTermColorMap.h; sourceTree = "<group>"; tabWidth = 4; };
 		A6A13AA118C2D23300B241ED /* iTermColorMap.mm */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = iTermColorMap.mm; sourceTree = "<group>"; tabWidth = 4; };
 		A6A13AA518C2D45900B241ED /* NSColor+iTerm.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.h; path = "NSColor+iTerm.h"; sourceTree = "<group>"; tabWidth = 4; };
@@ -8865,27 +8865,30 @@
 				LastUpgradeCheck = 0930;
 				TargetAttributes = {
 					1D6ED85219AEA20D005A7799 = {
-						DevelopmentTeam = H7V7XYVQ7D;
+						DevelopmentTeam = VXP8K9EDP6;
 					};
 					1DD39AD3180B8117004E56D5 = {
-						DevelopmentTeam = H7V7XYVQ7D;
+						DevelopmentTeam = VXP8K9EDP6;
 					};
 					1DFA7C661923E83500DF1410 = {
-						DevelopmentTeam = H7V7XYVQ7D;
+						DevelopmentTeam = VXP8K9EDP6;
 					};
 					874206460564169600CFC3F1 = {
-						DevelopmentTeam = H7V7XYVQ7D;
+						DevelopmentTeam = VXP8K9EDP6;
 						ProvisioningStyle = Automatic;
 					};
 					A66717851DCE36C3000CE608 = {
-						DevelopmentTeam = H7V7XYVQ7D;
+						DevelopmentTeam = VXP8K9EDP6;
+					};
+					A6755F481D729A0500F3726C = {
+						DevelopmentTeam = VXP8K9EDP6;
 					};
 					A6C7603F1B45C4CF00E3C992 = {
-						DevelopmentTeam = H7V7XYVQ7D;
+						DevelopmentTeam = VXP8K9EDP6;
 					};
 					A6C7641B1B45CB2800E3C992 = {
 						CreatedOnToolsVersion = 6.3;
-						DevelopmentTeam = H7V7XYVQ7D;
+						DevelopmentTeam = VXP8K9EDP6;
 						ProvisioningStyle = Automatic;
 						TestTargetID = 874206460564169600CFC3F1;
 					};
@@ -10971,6 +10974,7 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				DEVELOPMENT_TEAM = VXP8K9EDP6;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)";
 				GCC_C_LANGUAGE_STANDARD = c99;
@@ -11000,7 +11004,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
-				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)",
@@ -11070,7 +11073,6 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)",
@@ -11139,7 +11141,6 @@
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
-				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)",
@@ -11205,7 +11206,6 @@
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
-				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)",
@@ -11282,7 +11282,6 @@
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
-				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					/Users/gnachman/iTerm2,
@@ -11358,7 +11357,6 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				ENABLE_NS_ASSERTIONS = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -11428,7 +11426,6 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				ENABLE_NS_ASSERTIONS = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -11496,7 +11493,6 @@
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
-				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
@@ -11541,7 +11537,6 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				ENABLE_NS_ASSERTIONS = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
@@ -11579,7 +11574,6 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				ENABLE_NS_ASSERTIONS = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
@@ -11620,6 +11614,7 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				DEVELOPMENT_TEAM = VXP8K9EDP6;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)";
 				GCC_C_LANGUAGE_STANDARD = c99;
@@ -11649,7 +11644,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
-				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)",
@@ -11730,7 +11724,6 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				ENABLE_NS_ASSERTIONS = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -11798,7 +11791,6 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				ENABLE_NS_ASSERTIONS = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
@@ -11824,7 +11816,6 @@
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
-				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)",
@@ -11902,7 +11893,6 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				ENABLE_NS_ASSERTIONS = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -11957,7 +11947,6 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -12047,7 +12036,6 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				ENABLE_NS_ASSERTIONS = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -12093,7 +12081,6 @@
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
-				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/ColorPicker",
@@ -12149,7 +12136,6 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				ENABLE_NS_ASSERTIONS = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -12195,7 +12181,6 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				ENABLE_NS_ASSERTIONS = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -12368,7 +12353,6 @@
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
-				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/ColorPicker",
@@ -12430,7 +12414,6 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				ENABLE_NS_ASSERTIONS = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -12482,7 +12465,6 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				ENABLE_NS_ASSERTIONS = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -12536,7 +12518,6 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
@@ -12599,7 +12580,6 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -12654,7 +12634,6 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -12697,7 +12676,6 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)",
@@ -12773,7 +12751,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
-				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)",
@@ -12856,6 +12833,7 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				DEVELOPMENT_TEAM = VXP8K9EDP6;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)";
@@ -12906,6 +12884,7 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				DEVELOPMENT_TEAM = VXP8K9EDP6;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)";
 				GCC_C_LANGUAGE_STANDARD = c99;

--- a/iTerm2.xcodeproj/project.pbxproj
+++ b/iTerm2.xcodeproj/project.pbxproj
@@ -2186,12 +2186,12 @@
 		A69C93462121140100531438 /* iTermStatusBarLargeComposerViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = A69C933E2121140100531438 /* iTermStatusBarLargeComposerViewController.xib */; };
 		A69C93472121140100531438 /* iTermStatusBarLargeComposerViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = A69C933E2121140100531438 /* iTermStatusBarLargeComposerViewController.xib */; };
 		A69C93482121140100531438 /* iTermStatusBarLargeComposerViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = A69C933E2121140100531438 /* iTermStatusBarLargeComposerViewController.xib */; };
-		A69CCB11211B55FB008ADA71 /* iTermMenuBarObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = A69CCB0F211B55FB008ADA71 /* iTermMenuBarObserver.h */; };
-		A69CCB12211B55FB008ADA71 /* iTermMenuBarObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = A69CCB10211B55FB008ADA71 /* iTermMenuBarObserver.m */; };
 		A69CCB18211BC296008ADA71 /* NSData+GZIP.h in Headers */ = {isa = PBXBuildFile; fileRef = A69CCB15211BC296008ADA71 /* NSData+GZIP.h */; };
 		A69CCB19211BC296008ADA71 /* NSData+GZIP.m in Sources */ = {isa = PBXBuildFile; fileRef = A69CCB16211BC296008ADA71 /* NSData+GZIP.m */; };
 		A69CCB1C211BF4FF008ADA71 /* iTermRecordingCodec.h in Headers */ = {isa = PBXBuildFile; fileRef = A69CCB1A211BF4FF008ADA71 /* iTermRecordingCodec.h */; };
 		A69CCB1D211BF4FF008ADA71 /* iTermRecordingCodec.m in Sources */ = {isa = PBXBuildFile; fileRef = A69CCB1B211BF4FF008ADA71 /* iTermRecordingCodec.m */; };
+		A69CCB11211B55FB008ADA71 /* iTermMenuBarObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = A69CCB0F211B55FB008ADA71 /* iTermMenuBarObserver.h */; };
+		A69CCB12211B55FB008ADA71 /* iTermMenuBarObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = A69CCB10211B55FB008ADA71 /* iTermMenuBarObserver.m */; };
 		A6A13AA218C2D23300B241ED /* iTermColorMap.h in Headers */ = {isa = PBXBuildFile; fileRef = A6A13AA018C2D23300B241ED /* iTermColorMap.h */; };
 		A6A13AA718C2D45900B241ED /* NSColor+iTerm.h in Headers */ = {isa = PBXBuildFile; fileRef = A6A13AA518C2D45900B241ED /* NSColor+iTerm.h */; };
 		A6A13AAC18C3347200B241ED /* VT100Output.h in Headers */ = {isa = PBXBuildFile; fileRef = A6A13AAA18C3347200B241ED /* VT100Output.h */; };
@@ -4531,12 +4531,12 @@
 		A69C933C2121140100531438 /* iTermStatusBarLargeComposerViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = iTermStatusBarLargeComposerViewController.h; sourceTree = "<group>"; };
 		A69C933D2121140100531438 /* iTermStatusBarLargeComposerViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = iTermStatusBarLargeComposerViewController.m; sourceTree = "<group>"; };
 		A69C933E2121140100531438 /* iTermStatusBarLargeComposerViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = iTermStatusBarLargeComposerViewController.xib; sourceTree = "<group>"; };
-		A69CCB0F211B55FB008ADA71 /* iTermMenuBarObserver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = iTermMenuBarObserver.h; sourceTree = "<group>"; };
-		A69CCB10211B55FB008ADA71 /* iTermMenuBarObserver.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = iTermMenuBarObserver.m; sourceTree = "<group>"; };
 		A69CCB15211BC296008ADA71 /* NSData+GZIP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSData+GZIP.h"; path = "GZIP/GZIP/NSData+GZIP.h"; sourceTree = "<group>"; };
 		A69CCB16211BC296008ADA71 /* NSData+GZIP.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSData+GZIP.m"; path = "GZIP/GZIP/NSData+GZIP.m"; sourceTree = "<group>"; };
 		A69CCB1A211BF4FF008ADA71 /* iTermRecordingCodec.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = iTermRecordingCodec.h; sourceTree = "<group>"; };
 		A69CCB1B211BF4FF008ADA71 /* iTermRecordingCodec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = iTermRecordingCodec.m; sourceTree = "<group>"; };
+		A69CCB0F211B55FB008ADA71 /* iTermMenuBarObserver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = iTermMenuBarObserver.h; sourceTree = "<group>"; };
+		A69CCB10211B55FB008ADA71 /* iTermMenuBarObserver.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = iTermMenuBarObserver.m; sourceTree = "<group>"; };
 		A6A13AA018C2D23300B241ED /* iTermColorMap.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.h; path = iTermColorMap.h; sourceTree = "<group>"; tabWidth = 4; };
 		A6A13AA118C2D23300B241ED /* iTermColorMap.mm */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = iTermColorMap.mm; sourceTree = "<group>"; tabWidth = 4; };
 		A6A13AA518C2D45900B241ED /* NSColor+iTerm.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.h; path = "NSColor+iTerm.h"; sourceTree = "<group>"; tabWidth = 4; };
@@ -8865,30 +8865,27 @@
 				LastUpgradeCheck = 0930;
 				TargetAttributes = {
 					1D6ED85219AEA20D005A7799 = {
-						DevelopmentTeam = VXP8K9EDP6;
+						DevelopmentTeam = H7V7XYVQ7D;
 					};
 					1DD39AD3180B8117004E56D5 = {
-						DevelopmentTeam = VXP8K9EDP6;
+						DevelopmentTeam = H7V7XYVQ7D;
 					};
 					1DFA7C661923E83500DF1410 = {
-						DevelopmentTeam = VXP8K9EDP6;
+						DevelopmentTeam = H7V7XYVQ7D;
 					};
 					874206460564169600CFC3F1 = {
-						DevelopmentTeam = VXP8K9EDP6;
+						DevelopmentTeam = H7V7XYVQ7D;
 						ProvisioningStyle = Automatic;
 					};
 					A66717851DCE36C3000CE608 = {
-						DevelopmentTeam = VXP8K9EDP6;
-					};
-					A6755F481D729A0500F3726C = {
-						DevelopmentTeam = VXP8K9EDP6;
+						DevelopmentTeam = H7V7XYVQ7D;
 					};
 					A6C7603F1B45C4CF00E3C992 = {
-						DevelopmentTeam = VXP8K9EDP6;
+						DevelopmentTeam = H7V7XYVQ7D;
 					};
 					A6C7641B1B45CB2800E3C992 = {
 						CreatedOnToolsVersion = 6.3;
-						DevelopmentTeam = VXP8K9EDP6;
+						DevelopmentTeam = H7V7XYVQ7D;
 						ProvisioningStyle = Automatic;
 						TestTargetID = 874206460564169600CFC3F1;
 					};
@@ -10974,7 +10971,6 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				DEVELOPMENT_TEAM = VXP8K9EDP6;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)";
 				GCC_C_LANGUAGE_STANDARD = c99;
@@ -11004,6 +11000,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
+				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)",
@@ -11073,6 +11070,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)",
@@ -11141,6 +11139,7 @@
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
+				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)",
@@ -11206,6 +11205,7 @@
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
+				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)",
@@ -11282,6 +11282,7 @@
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
+				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					/Users/gnachman/iTerm2,
@@ -11357,6 +11358,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				ENABLE_NS_ASSERTIONS = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -11426,6 +11428,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				ENABLE_NS_ASSERTIONS = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -11493,6 +11496,7 @@
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
+				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
@@ -11537,6 +11541,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				ENABLE_NS_ASSERTIONS = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
@@ -11574,6 +11579,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				ENABLE_NS_ASSERTIONS = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
@@ -11614,7 +11620,6 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				DEVELOPMENT_TEAM = VXP8K9EDP6;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)";
 				GCC_C_LANGUAGE_STANDARD = c99;
@@ -11644,6 +11649,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
+				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)",
@@ -11724,6 +11730,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				ENABLE_NS_ASSERTIONS = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -11791,6 +11798,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				ENABLE_NS_ASSERTIONS = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
@@ -11816,6 +11824,7 @@
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
+				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)",
@@ -11893,6 +11902,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				ENABLE_NS_ASSERTIONS = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -11947,6 +11957,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -12036,6 +12047,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				ENABLE_NS_ASSERTIONS = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -12081,6 +12093,7 @@
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
+				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/ColorPicker",
@@ -12136,6 +12149,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				ENABLE_NS_ASSERTIONS = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -12181,6 +12195,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				ENABLE_NS_ASSERTIONS = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -12353,6 +12368,7 @@
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
+				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/ColorPicker",
@@ -12414,6 +12430,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				ENABLE_NS_ASSERTIONS = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -12465,6 +12482,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				ENABLE_NS_ASSERTIONS = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -12518,6 +12536,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
@@ -12580,6 +12599,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -12634,6 +12654,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -12676,6 +12697,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)",
@@ -12751,6 +12773,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
+				DEVELOPMENT_TEAM = H7V7XYVQ7D;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)",
@@ -12833,7 +12856,6 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				DEVELOPMENT_TEAM = VXP8K9EDP6;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)";
@@ -12884,7 +12906,6 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				DEVELOPMENT_TEAM = VXP8K9EDP6;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)";
 				GCC_C_LANGUAGE_STANDARD = c99;

--- a/iTerm2XCTests/PTYTextViewTest.m
+++ b/iTerm2XCTests/PTYTextViewTest.m
@@ -758,7 +758,7 @@ static NSString *const kDiffScriptPath = @"/tmp/diffs";
     } else {
         NSImage *golden = [[NSImage alloc] initWithContentsOfFile:goldenName];
         if (!golden) {
-            golden = [NSImage imageNamed:[self shortNameForGolden:name]];
+            golden = [[NSBundle bundleForClass:self.class] imageForResource:[self shortNameForGolden:name]];
         }
         XCTAssertNotNil(golden, @"Failed to load golden image with name %@, short name %@", goldenName, [self shortNameForGolden:name]);
         NSData *goldenData = [golden rawPixelsInRGBColorSpace];

--- a/sources/GeneralPreferencesViewController.m
+++ b/sources/GeneralPreferencesViewController.m
@@ -15,6 +15,7 @@
 #import "iTermWarning.h"
 #import "PasteboardHistory.h"
 #import "WindowArrangements.h"
+#import "NSImage+iTerm.h"
 
 static const NSInteger iTermMaximumTmuxDashboardLimit = 1000;
 
@@ -437,7 +438,7 @@ enum {
     }
 
     BOOL remoteLocationIsValid = [[iTermRemotePreferences sharedInstance] remoteLocationIsValid];
-    _prefsDirWarning.image = remoteLocationIsValid ? [[NSBundle bundleForClass:self.class] imageForResource:@"CheckMark"] : [[NSBundle bundleForClass:self.class] imageForResource:@"WarningSign"];
+    _prefsDirWarning.image = remoteLocationIsValid ? [NSImage it_imageNamed:@"CheckMark" forClass:self.class] : [NSImage it_imageNamed:@"WarningSign" forClass:self.class];
     BOOL isValidFile = (shouldLoadRemotePrefs &&
                         remoteLocationIsValid &&
                         ![[iTermRemotePreferences sharedInstance] remoteLocationIsURL]);

--- a/sources/GeneralPreferencesViewController.m
+++ b/sources/GeneralPreferencesViewController.m
@@ -437,7 +437,7 @@ enum {
     }
 
     BOOL remoteLocationIsValid = [[iTermRemotePreferences sharedInstance] remoteLocationIsValid];
-    _prefsDirWarning.image = remoteLocationIsValid ? [NSImage imageNamed:@"CheckMark"] : [NSImage imageNamed:@"WarningSign"];
+    _prefsDirWarning.image = remoteLocationIsValid ? [[NSBundle bundleForClass:self.class] imageForResource:@"CheckMark"] : [[NSBundle bundleForClass:self.class] imageForResource:@"WarningSign"];
     BOOL isValidFile = (shouldLoadRemotePrefs &&
                         remoteLocationIsValid &&
                         ![[iTermRemotePreferences sharedInstance] remoteLocationIsURL]);

--- a/sources/Metal/Renderers/iTermBroadcastStripesRenderer.m
+++ b/sources/Metal/Renderers/iTermBroadcastStripesRenderer.m
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                fragmentFunctionName:@"iTermBroadcastStripesFragmentShader"
                                                            blending:[iTermMetalBlending compositeSourceOver]
                                                 transientStateClass:[iTermBroadcastStripesRendererTransientState class]];
-        NSImage *image = [NSImage imageNamed:@"BackgroundStripes"];
+        NSImage *image = [[NSBundle bundleForClass:self.class] imageForResource:@"BackgroundStripes"];
         _size = image.size;
         _texture = [_metalRenderer textureFromImage:image context:nil];
         _verticesPool = [[iTermMetalBufferPool alloc] initWithDevice:device bufferSize:sizeof(iTermVertex) * 6];

--- a/sources/Metal/Renderers/iTermCursorRenderer.m
+++ b/sources/Metal/Renderers/iTermCursorRenderer.m
@@ -187,7 +187,7 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation iTermKeyCursorRendererTransientState
 
 - (NSImage *)newImage {
-    return [NSImage imageNamed:@"key"];
+    return [[NSBundle bundleForClass:self.class] imageForResource:@"key"];
 }
 
 @end
@@ -518,7 +518,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                                        withBytes:&description
                                                                   checkIfChanged:YES];
     if (!_texture) {
-        _texture = [self.cellRenderer textureFromImage:[NSImage imageNamed:@"key"] context:nil];
+        _texture = [self.cellRenderer textureFromImage:[[NSBundle bundleForClass:self.class] imageForResource:@"key"] context:nil];
     }
     [_cellRenderer drawWithTransientState:tState
                             renderEncoder:frameData.renderEncoder

--- a/sources/NSImage+iTerm.h
+++ b/sources/NSImage+iTerm.h
@@ -31,6 +31,8 @@
 // Returns "gif", "png", etc., or nil.
 + (NSString *)extensionForUniformType:(NSString *)type;
 
++ (instancetype)it_imageNamed:(NSImageName)name forClass:(Class)theClass;
+
 // Returns an image blurred by repeated box blurs with |radius| iterations.
 - (NSImage *)blurredImageWithRadius:(int)radius;
 

--- a/sources/NSImage+iTerm.m
+++ b/sources/NSImage+iTerm.m
@@ -103,6 +103,10 @@
     return map[type];
 }
 
++ (instancetype)it_imageNamed:(NSImageName)name forClass:(Class)theClass {
+    return [[NSBundle bundleForClass:theClass] imageForResource:name];
+}
+
 - (NSImage *)blurredImageWithRadius:(int)radius {
     // Initially, this used a CIFilter but this doesn't work on some machines for mysterious reasons.
     // Instead, this algorithm implements a really simple box blur. It's quite fast--about 5ms on

--- a/sources/PTYNoteView.m
+++ b/sources/PTYNoteView.m
@@ -39,7 +39,7 @@ const CGFloat kDragAreaSize = 5;
     self = [super initWithFrame:frame];
     if (self) {
         backgroundColor_ = [[self defaultBackgroundColor] retain];
-        NSImage *closeImage = [NSImage imageNamed:@"closebutton"];
+        NSImage *closeImage = [[NSBundle bundleForClass:self.class] imageForResource:@"closebutton"];
         killButton_ = [[NSButton alloc] initWithFrame:NSMakeRect(0, 0, kButtonSize, kButtonSize)];
         [killButton_ setButtonType:NSMomentaryPushInButton];
         [killButton_ setImage:closeImage];

--- a/sources/PTYNoteView.m
+++ b/sources/PTYNoteView.m
@@ -8,6 +8,7 @@
 
 #import "PTYNoteView.h"
 #import "iTermMouseCursor.h"
+#import "NSImage+iTerm.h"
 
 static const CGFloat kMinWidth = 50;
 static const CGFloat kMinHeight = 33;
@@ -39,7 +40,7 @@ const CGFloat kDragAreaSize = 5;
     self = [super initWithFrame:frame];
     if (self) {
         backgroundColor_ = [[self defaultBackgroundColor] retain];
-        NSImage *closeImage = [[NSBundle bundleForClass:self.class] imageForResource:@"closebutton"];
+        NSImage *closeImage = [NSImage it_imageNamed:@"closebutton" forClass:self.class];
         killButton_ = [[NSButton alloc] initWithFrame:NSMakeRect(0, 0, kButtonSize, kButtonSize)];
         [killButton_ setButtonType:NSMomentaryPushInButton];
         [killButton_ setImage:closeImage];

--- a/sources/PTYSession.m
+++ b/sources/PTYSession.m
@@ -2844,7 +2844,7 @@ ITERM_WEAKLY_REFERENCEABLE
                                        units:kVT100TerminalUnitsCells
                          preserveAspectRatio:NO
                                        inset:zeroInset
-                                       image:[[NSBundle bundleForClass:self.class] imageForResource:@"BrokenPipeDivider"]
+                                       image:[NSImage it_imageNamed:@"BrokenPipeDivider" forClass:self.class]
                                         data:nil];
     }
     [_screen appendStringAtCursor:message];
@@ -2857,7 +2857,7 @@ ITERM_WEAKLY_REFERENCEABLE
                                        units:kVT100TerminalUnitsCells
                          preserveAspectRatio:NO
                                        inset:zeroInset
-                                       image:[[NSBundle bundleForClass:self.class] imageForResource:@"BrokenPipeDivider"]
+                                       image:[NSImage it_imageNamed:@"BrokenPipeDivider" forClass:self.class]
                                         data:nil];
     }
     [_screen crlf];

--- a/sources/PTYSession.m
+++ b/sources/PTYSession.m
@@ -2844,7 +2844,7 @@ ITERM_WEAKLY_REFERENCEABLE
                                        units:kVT100TerminalUnitsCells
                          preserveAspectRatio:NO
                                        inset:zeroInset
-                                       image:[NSImage imageNamed:@"BrokenPipeDivider"]
+                                       image:[[NSBundle bundleForClass:self.class] imageForResource:@"BrokenPipeDivider"]
                                         data:nil];
     }
     [_screen appendStringAtCursor:message];
@@ -2857,7 +2857,7 @@ ITERM_WEAKLY_REFERENCEABLE
                                        units:kVT100TerminalUnitsCells
                          preserveAspectRatio:NO
                                        inset:zeroInset
-                                       image:[NSImage imageNamed:@"BrokenPipeDivider"]
+                                       image:[[NSBundle bundleForClass:self.class] imageForResource:@"BrokenPipeDivider"]
                                         data:nil];
     }
     [_screen crlf];

--- a/sources/PTYSession.m
+++ b/sources/PTYSession.m
@@ -6846,7 +6846,9 @@ ITERM_WEAKLY_REFERENCEABLE
 // Pastes the current string in the clipboard. Uses the sender's tag to get flags.
 - (void)paste:(id)sender {
     DLog(@"PTYSession paste:");
-    [self pasteString:[PTYSession pasteboardString] flags:[sender tag]];
+    
+    // Might not be called from a menu item so just use no flags in this case
+    [self pasteString:[PTYSession pasteboardString] flags:[sender isKindOfClass:NSMenuItem.class] ? [sender tag] : 0];
 }
 
 // Show advanced paste window.

--- a/sources/PTYTab.m
+++ b/sources/PTYTab.m
@@ -19,6 +19,7 @@
 #import "NSDictionary+iTerm.h"
 #import "NSFont+iTerm.h"
 #import "NSView+iTerm.h"
+#import "NSImage+iTerm.h"
 #import "NSView+RecursiveDescription.h"
 #import "NSWindow+PSM.h"
 #import "PreferencePanel.h"
@@ -204,7 +205,7 @@ static void SetAgainstGrainDim(BOOL isVertical, NSSize *dest, CGFloat value) {
 @synthesize lockedSession = lockedSession_;
 
 + (NSImage *)bellImage {
-    return [[NSBundle bundleForClass:self.class] imageForResource:@"important"];
+    return [NSImage it_imageNamed:@"important" forClass:self.class];
 }
 
 + (NSImage *)imageForNewOutputWithAppearance:(NSAppearance *)appearance {
@@ -216,13 +217,13 @@ static void SetAgainstGrainDim(BOOL isVertical, NSSize *dest, CGFloat value) {
             
         case TAB_STYLE_LIGHT:
         case TAB_STYLE_LIGHT_HIGH_CONTRAST:
-            return [[NSBundle bundleForClass:self.class] imageForResource:@"NewOutput"];
+            return [NSImage it_imageNamed:@"NewOutput" forClass:self.class];
         case TAB_STYLE_DARK:
         case TAB_STYLE_DARK_HIGH_CONTRAST:
-            return [[NSBundle bundleForClass:self.class] imageForResource:@"NewOutputForDarkTheme"];
+            return [NSImage it_imageNamed:@"NewOutputForDarkTheme" forClass:self.class];
     }
 
-    return [[NSBundle bundleForClass:self.class] imageForResource:@"NewOutput"];
+    return [NSImage it_imageNamed:@"NewOutput" forClass:self.class];
 }
 
 + (NSImage *)idleImageWithAppearance:(NSAppearance *)appearance {
@@ -240,12 +241,12 @@ static void SetAgainstGrainDim(BOOL isVertical, NSSize *dest, CGFloat value) {
             assert(NO);
         case TAB_STYLE_LIGHT:
         case TAB_STYLE_LIGHT_HIGH_CONTRAST:
-            return [[NSBundle bundleForClass:self.class] imageForResource:@"dead"];
+            return [NSImage it_imageNamed:@"dead" forClass:self.class];
         case TAB_STYLE_DARK:
         case TAB_STYLE_DARK_HIGH_CONTRAST:
-            return [[NSBundle bundleForClass:self.class] imageForResource:@"DeadForDarkTheme"];
+            return [NSImage it_imageNamed:@"DeadForDarkTheme" forClass:self.class];
     }
-    return [[NSBundle bundleForClass:self.class] imageForResource:@"dead"];
+    return [NSImage it_imageNamed:@"dead" forClass:self.class];
 }
 
 + (void)_recursiveRegisterSessionsInArrangement:(NSDictionary *)arrangement {

--- a/sources/PTYTab.m
+++ b/sources/PTYTab.m
@@ -204,7 +204,7 @@ static void SetAgainstGrainDim(BOOL isVertical, NSSize *dest, CGFloat value) {
 @synthesize lockedSession = lockedSession_;
 
 + (NSImage *)bellImage {
-    return [NSImage imageNamed:@"important"];
+    return [[NSBundle bundleForClass:self.class] imageForResource:@"important"];
 }
 
 + (NSImage *)imageForNewOutputWithAppearance:(NSAppearance *)appearance {
@@ -216,13 +216,13 @@ static void SetAgainstGrainDim(BOOL isVertical, NSSize *dest, CGFloat value) {
             
         case TAB_STYLE_LIGHT:
         case TAB_STYLE_LIGHT_HIGH_CONTRAST:
-            return [NSImage imageNamed:@"NewOutput"];
+            return [[NSBundle bundleForClass:self.class] imageForResource:@"NewOutput"];
         case TAB_STYLE_DARK:
         case TAB_STYLE_DARK_HIGH_CONTRAST:
-            return [NSImage imageNamed:@"NewOutputForDarkTheme"];
+            return [[NSBundle bundleForClass:self.class] imageForResource:@"NewOutputForDarkTheme"];
     }
 
-    return [NSImage imageNamed:@"NewOutput"];
+    return [[NSBundle bundleForClass:self.class] imageForResource:@"NewOutput"];
 }
 
 + (NSImage *)idleImageWithAppearance:(NSAppearance *)appearance {
@@ -240,12 +240,12 @@ static void SetAgainstGrainDim(BOOL isVertical, NSSize *dest, CGFloat value) {
             assert(NO);
         case TAB_STYLE_LIGHT:
         case TAB_STYLE_LIGHT_HIGH_CONTRAST:
-            return [NSImage imageNamed:@"dead"];
+            return [[NSBundle bundleForClass:self.class] imageForResource:@"dead"];
         case TAB_STYLE_DARK:
         case TAB_STYLE_DARK_HIGH_CONTRAST:
-            return [NSImage imageNamed:@"DeadForDarkTheme"];
+            return [[NSBundle bundleForClass:self.class] imageForResource:@"DeadForDarkTheme"];
     }
-    return [NSImage imageNamed:@"dead"];
+    return [[NSBundle bundleForClass:self.class] imageForResource:@"dead"];
 }
 
 + (void)_recursiveRegisterSessionsInArrangement:(NSDictionary *)arrangement {

--- a/sources/PTYTextView.h
+++ b/sources/PTYTextView.h
@@ -331,6 +331,10 @@ typedef NS_ENUM(NSInteger, PTYTextViewSelectionExtensionUnit) {
 typedef void (^PTYTextViewDrawingHookBlock)(iTermTextDrawingHelper *);
 @property(nonatomic, copy) PTYTextViewDrawingHookBlock drawingHook;
 
+@property(nonatomic, assign) BOOL showTimestamps;
+
+@property(nonatomic, readonly) BOOL anyAnnotationsAreVisible;
+
 // For tests.
 @property(nonatomic, readonly) NSRect cursorFrame;
 
@@ -588,6 +592,9 @@ typedef void (^PTYTextViewDrawingHookBlock)(iTermTextDrawingHelper *);
 - (void)resetMouseLocationToRefuseFirstResponderAt;
 
 - (void)setTransparencyAffectsOnlyDefaultBackgroundColor:(BOOL)value;
+
+- (IBAction)selectCurrentCommand:(id)sender;
+- (IBAction)selectOutputOfLastCommand:(id)sender;
 
 - (void)showFireworks;
 

--- a/sources/PTYTextView.m
+++ b/sources/PTYTextView.m
@@ -758,6 +758,17 @@ static const int kDragThreshold = 3;
     [self setNeedsDisplay:YES];
 }
 
+- (BOOL)showTimestamps
+{
+    return _drawingHelper.showTimestamps;
+}
+
+- (void)setShowTimestamps:(BOOL)value
+{
+    _drawingHelper.showTimestamps = value;
+    [self setNeedsDisplay:YES];
+}
+
 - (NSRect)scrollViewContentSize {
     NSRect r = NSMakeRect(0, 0, 0, 0);
     r.size = [[self enclosingScrollView] contentSize];

--- a/sources/PTYTextView.m
+++ b/sources/PTYTextView.m
@@ -5120,7 +5120,7 @@ static double EuclideanDistance(NSPoint p1, NSPoint p2) {
     if ([content isKindOfClass:[NSAttributedString class]]) {
         attributedString = content;
         accessory = [[[iTermPrintAccessoryViewController alloc] initWithNibName:@"iTermPrintAccessoryViewController"
-                                                                         bundle:nil] autorelease];
+                                                                         bundle:[NSBundle bundleForClass:self.class]] autorelease];
         accessory.userDidChangeSetting = ^() {
             NSAttributedString *theAttributedString = nil;
             if (accessory.blackAndWhite) {

--- a/sources/PasteViewController.m
+++ b/sources/PasteViewController.m
@@ -27,7 +27,7 @@ static float kAnimationDuration = 0.25;
 - (instancetype)initWithContext:(PasteContext *)pasteContext
                          length:(int)length
                            mini:(BOOL)mini {
-    self = [super initWithNibName:mini ? @"MiniPasteView" : @"PasteView" bundle:nil];
+    self = [super initWithNibName:mini ? @"MiniPasteView" : @"PasteView" bundle:[NSBundle bundleForClass:self.class]];
     if (self) {
         [self view];
 

--- a/sources/ProfileListView.m
+++ b/sources/ProfileListView.m
@@ -557,8 +557,8 @@ const CGFloat kDefaultTagsWidth = 80;
     if ([sortDescriptors count] > 0) {
         NSSortDescriptor* primarySortDesc = [sortDescriptors objectAtIndex:0];
         [aTableView setIndicatorImage:([primarySortDesc ascending] ?
-                                       [NSImage imageNamed:@"NSAscendingSortIndicator"] :
-                                       [NSImage imageNamed:@"NSDescendingSortIndicator"])
+                                       [[NSBundle bundleForClass:self.class] imageForResource:@"NSAscendingSortIndicator"] :
+                                       [[NSBundle bundleForClass:self.class] imageForResource:@"NSDescendingSortIndicator"])
                         inTableColumn:[aTableView tableColumnWithIdentifier:[primarySortDesc key]]];
     }
 

--- a/sources/ProfileListView.m
+++ b/sources/ProfileListView.m
@@ -557,8 +557,8 @@ const CGFloat kDefaultTagsWidth = 80;
     if ([sortDescriptors count] > 0) {
         NSSortDescriptor* primarySortDesc = [sortDescriptors objectAtIndex:0];
         [aTableView setIndicatorImage:([primarySortDesc ascending] ?
-                                       [[NSBundle bundleForClass:self.class] imageForResource:@"NSAscendingSortIndicator"] :
-                                       [[NSBundle bundleForClass:self.class] imageForResource:@"NSDescendingSortIndicator"])
+                                       [NSImage imageNamed:@"NSAscendingSortIndicator"] :
+                                       [NSImage imageNamed:@"NSDescendingSortIndicator"])
                         inTableColumn:[aTableView tableColumnWithIdentifier:[primarySortDesc key]]];
     }
 

--- a/sources/PseudoTerminal+TouchBar.m
+++ b/sources/PseudoTerminal+TouchBar.m
@@ -381,19 +381,19 @@ ITERM_IGNORE_PARTIAL_BEGIN
         selector = @selector(statusTouchBarItemSelected:);
         label = @"Your Message Here";
     } else if ([identifier isEqualToString:iTermTouchBarIdentifierAddMark]) {
-        image = [[[NSBundle bundleForClass:self.class] imageForResource:@"Add Mark Touch Bar Icon"] imageWithColor:[NSColor labelColor]];
+        image = [[NSImage it_imageNamed:@"Add Mark Touch Bar Icon" forClass:self.class] imageWithColor:[NSColor labelColor]];
         selector = @selector(addMarkTouchBarItemSelected:);
         label = @"Add Mark";
     } else if ([identifier isEqualToString:iTermTouchBarIdentifierNextMark]) {
-        image = [[NSBundle bundleForClass:self.class] imageForResource:NSImageNameTouchBarGoDownTemplate];
+        image = [NSImage imageNamed:NSImageNameTouchBarGoDownTemplate];
         selector = @selector(nextMarkTouchBarItemSelected:);
         label = @"Next Mark";
     } else if ([identifier isEqualToString:iTermTouchBarIdentifierPreviousMark]) {
-        image = [[NSBundle bundleForClass:self.class] imageForResource:NSImageNameTouchBarGoUpTemplate];
+        image = [NSImage imageNamed:NSImageNameTouchBarGoUpTemplate];
         selector = @selector(previousMarkTouchBarItemSelected:);
         label = @"Previous Mark";
     } else if ([identifier isEqualToString:iTermTouchBarIdentifierColorPreset]) {
-        image = [[NSBundle bundleForClass:self.class] imageForResource:NSImageNameTouchBarColorPickerFill];
+        image = [NSImage imageNamed:NSImageNameTouchBarColorPickerFill];
         NSPopoverTouchBarItem *item = [[[NSPopoverTouchBarItem alloc] initWithIdentifier:identifier] autorelease];
         item.customizationLabel = @"Color Preset";
         item.showsCloseButton = YES;
@@ -405,7 +405,7 @@ ITERM_IGNORE_PARTIAL_BEGIN
         item.popoverTouchBar = secondaryTouchBar;
         return item;
     } else if ([identifier isEqualToString:iTermTouchBarIdentifierFunctionKeys]) {
-        image = [[NSBundle bundleForClass:self.class] imageForResource:@"Touch Bar Function Keys"];
+        image = [NSImage it_imageNamed:@"Touch Bar Function Keys" forClass:self.class];
         NSPopoverTouchBarItem *item = [[[NSPopoverTouchBarItem alloc] initWithIdentifier:identifier] autorelease];
         item.customizationLabel = @"Function Keys Popover";
         item.showsCloseButton = YES;
@@ -434,7 +434,7 @@ ITERM_IGNORE_PARTIAL_BEGIN
         item.customizationLabel = label;
         if ([identifier isEqualToString:iTermTouchBarIdentifierManPage]) {
             button.title = @"";
-            button.image = [[NSBundle bundleForClass:self.class] imageForResource:@"Man Page Touch Bar Icon"];
+            button.image = [NSImage it_imageNamed:@"Man Page Touch Bar Icon" forClass:self.class];
             button.imagePosition = NSImageOnly;
             button.enabled = NO;
         }

--- a/sources/PseudoTerminal+TouchBar.m
+++ b/sources/PseudoTerminal+TouchBar.m
@@ -381,19 +381,19 @@ ITERM_IGNORE_PARTIAL_BEGIN
         selector = @selector(statusTouchBarItemSelected:);
         label = @"Your Message Here";
     } else if ([identifier isEqualToString:iTermTouchBarIdentifierAddMark]) {
-        image = [[NSImage imageNamed:@"Add Mark Touch Bar Icon"] imageWithColor:[NSColor labelColor]];
+        image = [[[NSBundle bundleForClass:self.class] imageForResource:@"Add Mark Touch Bar Icon"] imageWithColor:[NSColor labelColor]];
         selector = @selector(addMarkTouchBarItemSelected:);
         label = @"Add Mark";
     } else if ([identifier isEqualToString:iTermTouchBarIdentifierNextMark]) {
-        image = [NSImage imageNamed:NSImageNameTouchBarGoDownTemplate];
+        image = [[NSBundle bundleForClass:self.class] imageForResource:NSImageNameTouchBarGoDownTemplate];
         selector = @selector(nextMarkTouchBarItemSelected:);
         label = @"Next Mark";
     } else if ([identifier isEqualToString:iTermTouchBarIdentifierPreviousMark]) {
-        image = [NSImage imageNamed:NSImageNameTouchBarGoUpTemplate];
+        image = [[NSBundle bundleForClass:self.class] imageForResource:NSImageNameTouchBarGoUpTemplate];
         selector = @selector(previousMarkTouchBarItemSelected:);
         label = @"Previous Mark";
     } else if ([identifier isEqualToString:iTermTouchBarIdentifierColorPreset]) {
-        image = [NSImage imageNamed:NSImageNameTouchBarColorPickerFill];
+        image = [[NSBundle bundleForClass:self.class] imageForResource:NSImageNameTouchBarColorPickerFill];
         NSPopoverTouchBarItem *item = [[[NSPopoverTouchBarItem alloc] initWithIdentifier:identifier] autorelease];
         item.customizationLabel = @"Color Preset";
         item.showsCloseButton = YES;
@@ -405,7 +405,7 @@ ITERM_IGNORE_PARTIAL_BEGIN
         item.popoverTouchBar = secondaryTouchBar;
         return item;
     } else if ([identifier isEqualToString:iTermTouchBarIdentifierFunctionKeys]) {
-        image = [NSImage imageNamed:@"Touch Bar Function Keys"];
+        image = [[NSBundle bundleForClass:self.class] imageForResource:@"Touch Bar Function Keys"];
         NSPopoverTouchBarItem *item = [[[NSPopoverTouchBarItem alloc] initWithIdentifier:identifier] autorelease];
         item.customizationLabel = @"Function Keys Popover";
         item.showsCloseButton = YES;
@@ -434,7 +434,7 @@ ITERM_IGNORE_PARTIAL_BEGIN
         item.customizationLabel = label;
         if ([identifier isEqualToString:iTermTouchBarIdentifierManPage]) {
             button.title = @"";
-            button.image = [NSImage imageNamed:@"Man Page Touch Bar Icon"];
+            button.image = [[NSBundle bundleForClass:self.class] imageForResource:@"Man Page Touch Bar Icon"];
             button.imagePosition = NSImageOnly;
             button.enabled = NO;
         }

--- a/sources/PseudoTerminal.m
+++ b/sources/PseudoTerminal.m
@@ -761,7 +761,7 @@ static NSRect iTermRectCenteredVerticallyWithinRect(NSRect frameToCenter, NSRect
     if ([self.window respondsToSelector:@selector(addTitlebarAccessoryViewController:)]) {
         _shortcutAccessoryViewController =
             [[iTermWindowShortcutLabelTitlebarAccessoryViewController alloc] initWithNibName:@"iTermWindowShortcutAccessoryView"
-                                                                                      bundle:nil];
+                                                                                      bundle:[NSBundle bundleForClass:self.class]];
     }
     if ((self.window.styleMask & NSWindowStyleMaskTitled) && _shortcutAccessoryViewController) {
         [self.window addTitlebarAccessoryViewController:_shortcutAccessoryViewController];

--- a/sources/SessionTitleView.m
+++ b/sources/SessionTitleView.m
@@ -49,7 +49,7 @@ static const CGFloat kButtonSize = 17;
         const double kMargin = 5;
         double x = kMargin;
 
-        NSImage *closeImage = [[NSBundle bundleForClass:self.class] imageForResource:@"closebutton"];
+        NSImage *closeImage = [NSImage it_imageNamed:@"closebutton" forClass:self.class];
         closeButton_ = [[NoFirstResponderButton alloc] initWithFrame:NSMakeRect(x,
                                                                                 (frame.size.height - kButtonSize) / 2,
                                                                                 kButtonSize,
@@ -69,7 +69,7 @@ static const CGFloat kButtonSize = 17;
         // some of it is clipped.
         menuButton_ = [[NSButton alloc] initWithFrame:NSMakeRect(0, 0, 14, 14)];
         menuButton_.bordered = NO;
-        menuButton_.image = [[NSBundle bundleForClass:self.class] imageForResource:@"Hamburger"];
+        menuButton_.image = [NSImage it_imageNamed:@"Hamburger" forClass:self.class];
         menuButton_.imagePosition = NSImageOnly;
         menuButton_.target = self;
         menuButton_.action = @selector(openMenu:);

--- a/sources/SessionTitleView.m
+++ b/sources/SessionTitleView.m
@@ -49,7 +49,7 @@ static const CGFloat kButtonSize = 17;
         const double kMargin = 5;
         double x = kMargin;
 
-        NSImage *closeImage = [NSImage imageNamed:@"closebutton"];
+        NSImage *closeImage = [[NSBundle bundleForClass:self.class] imageForResource:@"closebutton"];
         closeButton_ = [[NoFirstResponderButton alloc] initWithFrame:NSMakeRect(x,
                                                                                 (frame.size.height - kButtonSize) / 2,
                                                                                 kButtonSize,
@@ -69,7 +69,7 @@ static const CGFloat kButtonSize = 17;
         // some of it is clipped.
         menuButton_ = [[NSButton alloc] initWithFrame:NSMakeRect(0, 0, 14, 14)];
         menuButton_.bordered = NO;
-        menuButton_.image = [NSImage imageNamed:@"Hamburger"];
+        menuButton_.image = [[NSBundle bundleForClass:self.class] imageForResource:@"Hamburger"];
         menuButton_.imagePosition = NSImageOnly;
         menuButton_.target = self;
         menuButton_.action = @selector(openMenu:);

--- a/sources/SessionView.m
+++ b/sources/SessionView.m
@@ -188,7 +188,7 @@ static NSDate* lastResizeDate_;
 
 - (iTermDropDownFindViewController *)newDropDownFindView {
     iTermDropDownFindViewController *dropDownViewController =
-        [[iTermDropDownFindViewController alloc] initWithNibName:@"FindView" bundle:nil];
+        [[iTermDropDownFindViewController alloc] initWithNibName:@"FindView" bundle:[NSBundle bundleForClass:self.class]];
     [[dropDownViewController view] setHidden:YES];
     [super addSubview:dropDownViewController.view];
     NSRect aRect = [self frame];

--- a/sources/VT100Screen.m
+++ b/sources/VT100Screen.m
@@ -3505,7 +3505,7 @@ basedAtAbsoluteLineNumber:(long long)absoluteLineNumber
     const BOOL isBroken = !image;
     if (isBroken) {
         DLog(@"Image is broken");
-        image = [iTermImage imageWithNativeImage:[NSImage imageNamed:@"broken_image"]];
+        image = [iTermImage imageWithNativeImage:[[NSBundle bundleForClass:self.class] imageForResource:@"broken_image"]];
         assert(image);
     }
 

--- a/sources/VT100Screen.m
+++ b/sources/VT100Screen.m
@@ -24,6 +24,7 @@
 #import "NSData+iTerm.h"
 #import "NSDictionary+iTerm.h"
 #import "NSObject+iTerm.h"
+#import "NSImage+iTerm.h"
 #import "PTYNoteViewController.h"
 #import "PTYTextView.h"
 #import "RegexKitLite.h"
@@ -3505,7 +3506,7 @@ basedAtAbsoluteLineNumber:(long long)absoluteLineNumber
     const BOOL isBroken = !image;
     if (isBroken) {
         DLog(@"Image is broken");
-        image = [iTermImage imageWithNativeImage:[[NSBundle bundleForClass:self.class] imageForResource:@"broken_image"]];
+        image = [iTermImage imageWithNativeImage:[NSImage it_imageNamed:@"broken_image" forClass:self.class]];
         assert(image);
     }
 

--- a/sources/iTermAPIScriptLauncher.m
+++ b/sources/iTermAPIScriptLauncher.m
@@ -108,7 +108,7 @@
 }
 
 + (NSArray *)argumentsToRunScript:(NSString *)filename withVirtualEnv:(NSString *)providedVirtualEnv {
-    NSString *wrapper = [[NSBundle mainBundle] pathForResource:@"it2_api_wrapper" ofType:@"sh"];
+    NSString *wrapper = [[NSBundle bundleForClass:self.class] pathForResource:@"it2_api_wrapper" ofType:@"sh"];
     NSString *pyenv = [[iTermPythonRuntimeDownloader sharedInstance] pathToStandardPyenvPython];
     NSString *virtualEnv = providedVirtualEnv ?: pyenv;
     NSString *command = [NSString stringWithFormat:@"%@ %@ %@",

--- a/sources/iTermAnnouncementView.m
+++ b/sources/iTermAnnouncementView.m
@@ -92,7 +92,7 @@ NSString *const iTermWindowAppearanceDidChange = @"iTermWindowAppearanceDidChang
         _internalView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
         [self addSubview:_internalView];
 
-        NSImage *closeImage = [NSImage imageNamed:@"closebutton"];
+        NSImage *closeImage = [[NSBundle bundleForClass:self.class] imageForResource:@"closebutton"];
         NSSize closeSize = closeImage.size;
         _buttonWidth = ceil(closeSize.width + kMargin);
         NSButton *closeButton = [[[NSButton alloc] initWithFrame:NSMakeRect(frameRect.size.width - _buttonWidth,
@@ -239,7 +239,7 @@ NSString *const iTermWindowAppearanceDidChange = @"iTermWindowAppearanceDidChang
             iconString = @"⚠";  // Warning sign
             break;
         case kiTermAnnouncementViewStyleQuestion:
-            return [NSImage imageNamed:@"QuestionMarkSign"];
+            return [[NSBundle bundleForClass:self.class] imageForResource:@"QuestionMarkSign"];
     }
 
     NSFont *emojiFont = [NSFont fontWithName:@"Apple Color Emoji" size:18];

--- a/sources/iTermAnnouncementView.m
+++ b/sources/iTermAnnouncementView.m
@@ -10,6 +10,7 @@
 #import "DebugLogging.h"
 #import "NSMutableAttributedString+iTerm.h"
 #import "NSStringITerm.h"
+#import "NSImage+iTerm.h"
 
 static const CGFloat kMargin = 8;
 NSString *const iTermWindowAppearanceDidChange = @"iTermWindowAppearanceDidChange";
@@ -92,7 +93,7 @@ NSString *const iTermWindowAppearanceDidChange = @"iTermWindowAppearanceDidChang
         _internalView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
         [self addSubview:_internalView];
 
-        NSImage *closeImage = [[NSBundle bundleForClass:self.class] imageForResource:@"closebutton"];
+        NSImage *closeImage = [NSImage it_imageNamed:@"closebutton" forClass:self.class];
         NSSize closeSize = closeImage.size;
         _buttonWidth = ceil(closeSize.width + kMargin);
         NSButton *closeButton = [[[NSButton alloc] initWithFrame:NSMakeRect(frameRect.size.width - _buttonWidth,
@@ -239,7 +240,7 @@ NSString *const iTermWindowAppearanceDidChange = @"iTermWindowAppearanceDidChang
             iconString = @"⚠";  // Warning sign
             break;
         case kiTermAnnouncementViewStyleQuestion:
-            return [[NSBundle bundleForClass:self.class] imageForResource:@"QuestionMarkSign"];
+            return [NSImage it_imageNamed:@"QuestionMarkSign" forClass:self.class];
     }
 
     NSFont *emojiFont = [NSFont fontWithName:@"Apple Color Emoji" size:18];

--- a/sources/iTermApplication.m
+++ b/sources/iTermApplication.m
@@ -437,11 +437,11 @@ static const char *iTermApplicationKVOKey = "iTermApplicationKVOKey";
         });
 
         if ([iTermAdvancedSettingsModel statusBarIcon]) {
-            NSImage *image = [NSImage imageNamed:@"StatusItem"];
+            NSImage *image = [[NSBundle bundleForClass:self.class] imageForResource:@"StatusItem"];
             self.statusBarItem = [[NSStatusBar systemStatusBar] statusItemWithLength:image.size.width];
             _statusBarItem.title = @"";
             _statusBarItem.image = image;
-            _statusBarItem.alternateImage = [NSImage imageNamed:@"StatusItemAlt"];
+            _statusBarItem.alternateImage = [[NSBundle bundleForClass:self.class] imageForResource:@"StatusItemAlt"];
             _statusBarItem.highlightMode = YES;
 
             _statusBarItem.menu = [[self delegate] statusBarMenu];

--- a/sources/iTermApplication.m
+++ b/sources/iTermApplication.m
@@ -40,6 +40,7 @@
 #import "NSDictionary+iTerm.h"
 #import "NSTextField+iTerm.h"
 #import "NSWindow+iTerm.h"
+#import "NSImage+iTerm.h"
 #import "PreferencePanel.h"
 #import "PseudoTerminal.h"
 #import "PTYSession.h"
@@ -437,11 +438,11 @@ static const char *iTermApplicationKVOKey = "iTermApplicationKVOKey";
         });
 
         if ([iTermAdvancedSettingsModel statusBarIcon]) {
-            NSImage *image = [[NSBundle bundleForClass:self.class] imageForResource:@"StatusItem"];
+            NSImage *image = [NSImage it_imageNamed:@"StatusItem" forClass:self.class];
             self.statusBarItem = [[NSStatusBar systemStatusBar] statusItemWithLength:image.size.width];
             _statusBarItem.title = @"";
             _statusBarItem.image = image;
-            _statusBarItem.alternateImage = [[NSBundle bundleForClass:self.class] imageForResource:@"StatusItemAlt"];
+            _statusBarItem.alternateImage = [NSImage it_imageNamed:@"StatusItemAlt" forClass:self.class];
             _statusBarItem.highlightMode = YES;
 
             _statusBarItem.menu = [[self delegate] statusBarMenu];

--- a/sources/iTermApplicationDelegate.m
+++ b/sources/iTermApplicationDelegate.m
@@ -2107,7 +2107,7 @@ static BOOL hasBecomeActive = NO;
 }
 
 - (IBAction)openSourceLicenses:(id)sender {
-    NSURL *url = [[NSBundle mainBundle] URLForResource:@"Licenses" withExtension:@"txt"];
+    NSURL *url = [[NSBundle bundleForClass:self.class] URLForResource:@"Licenses" withExtension:@"txt"];
     [[NSWorkspace sharedWorkspace] openURL:url];
 }
 

--- a/sources/iTermExposeView.m
+++ b/sources/iTermExposeView.m
@@ -23,7 +23,7 @@
 - (instancetype)initWithFrame:(NSRect)frameRect {
     self = [super initWithFrame:frameRect];
     if (self) {
-        search_ = [[GlobalSearch alloc] initWithNibName:@"GlobalSearch" bundle:nil];
+        search_ = [[GlobalSearch alloc] initWithNibName:@"GlobalSearch" bundle:[NSBundle bundleForClass:self.class]];
         [search_ setDelegate:self];
         const int SEARCH_MARGIN = 10;
         [[search_ view] setFrame:NSMakeRect(SEARCH_MARGIN,

--- a/sources/iTermFindCursorView.m
+++ b/sources/iTermFindCursorView.m
@@ -9,6 +9,7 @@
 #import "iTermFindCursorView.h"
 #import "NSBezierPath+iTerm.h"
 #import "NSDate+iTerm.h"
+#import "NSImage+iTerm.h"
 #import <QuartzCore/QuartzCore.h>
 
 // Delay before teardown.
@@ -96,7 +97,7 @@ const double kFindCursorHoleRadius = 30;
     if (self) {
         [self setWantsLayer:YES];
         _arrowLayer = [[CALayer alloc] init];
-        NSImage *image = [[NSBundle bundleForClass:self.class] imageForResource:@"BigArrow"];
+        NSImage *image = [NSImage it_imageNamed:@"BigArrow" forClass:self.class];
         _arrowLayer.frame = NSMakeRect(0, 0, image.size.width, image.size.height);
         _arrowLayer.contents = (id)[image CGImageForProposedRect:nil context:nil hints:nil];
         [self.layer addSublayer:_arrowLayer];
@@ -236,7 +237,7 @@ const double kFindCursorHoleRadius = 30;
     [cell setScaleSpeed:0.3];
     [cell setScaleRange:0.1];
     NSString *name = [NSString stringWithFormat:@"FindCursorCell%d", imageNumber];
-    NSImage *image = [[NSBundle bundleForClass:self.class] imageForResource:name];
+    NSImage *image = [NSImage it_imageNamed:name forClass:self.class];
     if (image) {
         [cell setContents:(id)[image CGImageForProposedRect:nil context:nil hints:nil]];
     }

--- a/sources/iTermFindCursorView.m
+++ b/sources/iTermFindCursorView.m
@@ -96,7 +96,7 @@ const double kFindCursorHoleRadius = 30;
     if (self) {
         [self setWantsLayer:YES];
         _arrowLayer = [[CALayer alloc] init];
-        NSImage *image = [NSImage imageNamed:@"BigArrow"];
+        NSImage *image = [[NSBundle bundleForClass:self.class] imageForResource:@"BigArrow"];
         _arrowLayer.frame = NSMakeRect(0, 0, image.size.width, image.size.height);
         _arrowLayer.contents = (id)[image CGImageForProposedRect:nil context:nil hints:nil];
         [self.layer addSublayer:_arrowLayer];
@@ -236,7 +236,7 @@ const double kFindCursorHoleRadius = 30;
     [cell setScaleSpeed:0.3];
     [cell setScaleRange:0.1];
     NSString *name = [NSString stringWithFormat:@"FindCursorCell%d", imageNumber];
-    NSImage *image = [NSImage imageNamed:name];
+    NSImage *image = [[NSBundle bundleForClass:self.class] imageForResource:name];
     if (image) {
         [cell setContents:(id)[image CGImageForProposedRect:nil context:nil hints:nil]];
     }

--- a/sources/iTermImageDecoderDriver.m
+++ b/sources/iTermImageDecoderDriver.m
@@ -106,11 +106,11 @@ static void ExecImageDecoder(char *executable, char *sandbox, int jsonFD, int co
 @implementation iTermImageDecoderDriver
 
 - (NSString *)executable {
-    return [[NSBundle mainBundle] pathForResource:@"image_decoder" ofType:nil];
+    return [[NSBundle bundleForClass:self.class] pathForResource:@"image_decoder" ofType:nil];
 }
 
 - (NSString *)sandbox {
-    NSString *sandboxFileName = [[NSBundle mainBundle] pathForResource:@"image_decoder" ofType:@"sb"];
+    NSString *sandboxFileName = [[NSBundle bundleForClass:self.class] pathForResource:@"image_decoder" ofType:@"sb"];
     NSString *sandboxContents = [NSString stringWithContentsOfFile:sandboxFileName encoding:NSUTF8StringEncoding error:nil];
     NSString *executable = [self executable];
     if (!sandboxFileName || !sandboxContents || !executable) {

--- a/sources/iTermIndicatorsHelper.m
+++ b/sources/iTermIndicatorsHelper.m
@@ -65,16 +65,16 @@ CGFloat kiTermIndicatorStandardHeight = 20;
 + (NSDictionary *)indicatorImages {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        gIndicatorImages = @{ kiTermIndicatorBell: [NSImage imageNamed:@"bell"],
-                              kiTermIndicatorWrapToTop: [NSImage imageNamed:@"wrap_to_top"],
-                              kiTermIndicatorWrapToBottom: [NSImage imageNamed:@"wrap_to_bottom"],
-                              kItermIndicatorBroadcastInput: [NSImage imageNamed:@"BroadcastInput"],
-                              kiTermIndicatorMaximized: [NSImage imageNamed:@"Maximized"],
-                              kiTermIndicatorCoprocess: [NSImage imageNamed:@"Coprocess"],
-                              kiTermIndicatorAlert: [NSImage imageNamed:@"Alert"],
-                              kiTermIndicatorAllOutputSuppressed: [NSImage imageNamed:@"SuppressAllOutput"],
-                              kiTermIndicatorZoomedIn: [NSImage imageNamed:@"Zoomed"],
-                              kiTermIndicatorCopyMode: [NSImage imageNamed:@"CopyMode"] };
+        gIndicatorImages = @{ kiTermIndicatorBell: [[NSBundle bundleForClass:self.class] imageForResource:@"bell"],
+                              kiTermIndicatorWrapToTop: [[NSBundle bundleForClass:self.class] imageForResource:@"wrap_to_top"],
+                              kiTermIndicatorWrapToBottom: [[NSBundle bundleForClass:self.class] imageForResource:@"wrap_to_bottom"],
+                              kItermIndicatorBroadcastInput: [[NSBundle bundleForClass:self.class] imageForResource:@"BroadcastInput"],
+                              kiTermIndicatorMaximized: [[NSBundle bundleForClass:self.class] imageForResource:@"Maximized"],
+                              kiTermIndicatorCoprocess: [[NSBundle bundleForClass:self.class] imageForResource:@"Coprocess"],
+                              kiTermIndicatorAlert: [[NSBundle bundleForClass:self.class] imageForResource:@"Alert"],
+                              kiTermIndicatorAllOutputSuppressed: [[NSBundle bundleForClass:self.class] imageForResource:@"SuppressAllOutput"],
+                              kiTermIndicatorZoomedIn: [[NSBundle bundleForClass:self.class] imageForResource:@"Zoomed"],
+                              kiTermIndicatorCopyMode: [[NSBundle bundleForClass:self.class] imageForResource:@"CopyMode"] };
         [gIndicatorImages retain];
     });
 

--- a/sources/iTermIndicatorsHelper.m
+++ b/sources/iTermIndicatorsHelper.m
@@ -9,6 +9,7 @@
 #import "iTermIndicatorsHelper.h"
 #import "DebugLogging.h"
 #import "iTermAdvancedSettingsModel.h"
+#import "NSImage+iTerm.h"
 
 static NSDictionary *gIndicatorImages;
 
@@ -65,16 +66,16 @@ CGFloat kiTermIndicatorStandardHeight = 20;
 + (NSDictionary *)indicatorImages {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        gIndicatorImages = @{ kiTermIndicatorBell: [[NSBundle bundleForClass:self.class] imageForResource:@"bell"],
-                              kiTermIndicatorWrapToTop: [[NSBundle bundleForClass:self.class] imageForResource:@"wrap_to_top"],
-                              kiTermIndicatorWrapToBottom: [[NSBundle bundleForClass:self.class] imageForResource:@"wrap_to_bottom"],
-                              kItermIndicatorBroadcastInput: [[NSBundle bundleForClass:self.class] imageForResource:@"BroadcastInput"],
-                              kiTermIndicatorMaximized: [[NSBundle bundleForClass:self.class] imageForResource:@"Maximized"],
-                              kiTermIndicatorCoprocess: [[NSBundle bundleForClass:self.class] imageForResource:@"Coprocess"],
-                              kiTermIndicatorAlert: [[NSBundle bundleForClass:self.class] imageForResource:@"Alert"],
-                              kiTermIndicatorAllOutputSuppressed: [[NSBundle bundleForClass:self.class] imageForResource:@"SuppressAllOutput"],
-                              kiTermIndicatorZoomedIn: [[NSBundle bundleForClass:self.class] imageForResource:@"Zoomed"],
-                              kiTermIndicatorCopyMode: [[NSBundle bundleForClass:self.class] imageForResource:@"CopyMode"] };
+        gIndicatorImages = @{ kiTermIndicatorBell: [NSImage it_imageNamed:@"bell" forClass:self.class],
+                              kiTermIndicatorWrapToTop: [NSImage it_imageNamed:@"wrap_to_top" forClass:self.class],
+                              kiTermIndicatorWrapToBottom: [NSImage it_imageNamed:@"wrap_to_bottom" forClass:self.class],
+                              kItermIndicatorBroadcastInput: [NSImage it_imageNamed:@"BroadcastInput" forClass:self.class],
+                              kiTermIndicatorMaximized: [NSImage it_imageNamed:@"Maximized" forClass:self.class],
+                              kiTermIndicatorCoprocess: [NSImage it_imageNamed:@"Coprocess" forClass:self.class],
+                              kiTermIndicatorAlert: [NSImage it_imageNamed:@"Alert" forClass:self.class],
+                              kiTermIndicatorAllOutputSuppressed: [NSImage it_imageNamed:@"SuppressAllOutput" forClass:self.class],
+                              kiTermIndicatorZoomedIn: [NSImage it_imageNamed:@"Zoomed" forClass:self.class],
+                              kiTermIndicatorCopyMode: [NSImage it_imageNamed:@"CopyMode" forClass:self.class] };
         [gIndicatorImages retain];
     });
 

--- a/sources/iTermKeyMappingViewController.m
+++ b/sources/iTermKeyMappingViewController.m
@@ -24,7 +24,7 @@ static NSString *const iTermTouchBarIDPrefix = @"touchbar:";
 }
 
 - (instancetype)init {
-    self = [super initWithNibName:@"iTermKeyMapping" bundle:nil];
+    self = [super initWithNibName:@"iTermKeyMapping" bundle:[NSBundle bundleForClass:self.class]];
     if (self) {
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(keyBindingsChanged)

--- a/sources/iTermLogoGenerator.m
+++ b/sources/iTermLogoGenerator.m
@@ -47,8 +47,8 @@ static NSMutableDictionary *gLogoCache;
     NSImage *image = [[[NSImage alloc] initWithSize:NSMakeSize(width, height)] autorelease];
     [image lockFocus];
 
-    NSImage *frame = [NSImage imageNamed:@"LogoFrame.png"];
-    NSImage *shadow = [NSImage imageNamed:@"LogoShadow.png"];
+    NSImage *frame = [[NSBundle bundleForClass:self.class] imageForResource:@"LogoFrame.png"];
+    NSImage *shadow = [[NSBundle bundleForClass:self.class] imageForResource:@"LogoShadow.png"];
 
     [_backgroundColor set];
     NSBezierPath *path = [NSBezierPath bezierPath];

--- a/sources/iTermLogoGenerator.m
+++ b/sources/iTermLogoGenerator.m
@@ -47,8 +47,8 @@ static NSMutableDictionary *gLogoCache;
     NSImage *image = [[[NSImage alloc] initWithSize:NSMakeSize(width, height)] autorelease];
     [image lockFocus];
 
-    NSImage *frame = [[NSBundle bundleForClass:self.class] imageForResource:@"LogoFrame.png"];
-    NSImage *shadow = [[NSBundle bundleForClass:self.class] imageForResource:@"LogoShadow.png"];
+    NSImage *frame = [NSImage it_imageNamed:@"LogoFrame.png" forClass:self.class];
+    NSImage *shadow = [NSImage it_imageNamed:@"LogoShadow.png" forClass:self.class];
 
     [_backgroundColor set];
     NSBezierPath *path = [NSBezierPath bezierPath];

--- a/sources/iTermMenuOpener.m
+++ b/sources/iTermMenuOpener.m
@@ -108,7 +108,7 @@
 
     // Create view controller
     iTermHelpMessageViewController *viewController = [[iTermHelpMessageViewController alloc] initWithNibName:@"iTermHelpMessageViewController"
-                                                                                                      bundle:[NSBundle mainBundle]];
+                                                                                                      bundle:[NSBundle bundleForClass:self.class]];
     [viewController setMessage:message];
 
     // Create popover

--- a/sources/iTermMouseCursor.m
+++ b/sources/iTermMouseCursor.m
@@ -83,7 +83,7 @@ enum {
 - (instancetype)initWithType:(iTermMouseCursorType)cursorType {
     switch (cursorType) {
         case iTermMouseCursorTypeIBeamWithCircle:
-            self = [super initWithImage:[NSImage imageNamed:@"IBarCursorXMR"]
+            self = [super initWithImage:[[NSBundle bundleForClass:self.class] imageForResource:@"IBarCursorXMR"]
                                 hotSpot:NSMakePoint(4, 8)];
             if (self) {
                 _hasImage = YES;
@@ -97,7 +97,7 @@ enum {
                     _type = kIBeamCursor;
                 }
             } else {
-                self = [super initWithImage:[NSImage imageNamed:@"IBarCursor"]
+                self = [super initWithImage:[[NSBundle bundleForClass:self.class] imageForResource:@"IBarCursor"]
                                     hotSpot:NSMakePoint(4, 8)];
                 if (self) {
                     _hasImage = YES;

--- a/sources/iTermMouseCursor.m
+++ b/sources/iTermMouseCursor.m
@@ -8,6 +8,7 @@
 
 #import "iTermMouseCursor.h"
 #import "iTermAdvancedSettingsModel.h"
+#import "NSImage+iTerm.h"
 
 @interface NSCursor ()
 // This is an Apple private method that, when overridden, allows you to use
@@ -83,7 +84,7 @@ enum {
 - (instancetype)initWithType:(iTermMouseCursorType)cursorType {
     switch (cursorType) {
         case iTermMouseCursorTypeIBeamWithCircle:
-            self = [super initWithImage:[[NSBundle bundleForClass:self.class] imageForResource:@"IBarCursorXMR"]
+            self = [super initWithImage:[NSImage it_imageNamed:@"IBarCursorXMR" forClass:self.class]
                                 hotSpot:NSMakePoint(4, 8)];
             if (self) {
                 _hasImage = YES;
@@ -97,7 +98,7 @@ enum {
                     _type = kIBeamCursor;
                 }
             } else {
-                self = [super initWithImage:[[NSBundle bundleForClass:self.class] imageForResource:@"IBarCursor"]
+                self = [super initWithImage:[NSImage it_imageNamed:@"IBarCursor" forClass:self.class]
                                     hotSpot:NSMakePoint(4, 8)];
                 if (self) {
                     _hasImage = YES;

--- a/sources/iTermNoColorAccessoryButton.m
+++ b/sources/iTermNoColorAccessoryButton.m
@@ -7,11 +7,12 @@
 //
 
 #import "iTermNoColorAccessoryButton.h"
+#import "NSImage+iTerm.h"
 
 @implementation iTermNoColorAccessoryButton
 
 - (instancetype)init {
-  NSImage *image = [[NSBundle bundleForClass:self.class] imageForResource:@"NoColor"];
+  NSImage *image = [NSImage it_imageNamed:@"NoColor" forClass:self.class];
   static const CGFloat kTopBottomMargin = 8;
   self = [super initWithFrame:NSMakeRect(0, 0, image.size.width, image.size.height + kTopBottomMargin * 2)];
   [self setButtonType:NSMomentaryPushInButton];

--- a/sources/iTermNoColorAccessoryButton.m
+++ b/sources/iTermNoColorAccessoryButton.m
@@ -11,7 +11,7 @@
 @implementation iTermNoColorAccessoryButton
 
 - (instancetype)init {
-  NSImage *image = [NSImage imageNamed:@"NoColor"];
+  NSImage *image = [[NSBundle bundleForClass:self.class] imageForResource:@"NoColor"];
   static const CGFloat kTopBottomMargin = 8;
   self = [super initWithFrame:NSMakeRect(0, 0, image.size.width, image.size.height + kTopBottomMargin * 2)];
   [self setButtonType:NSMomentaryPushInButton];

--- a/sources/iTermNumberOfSpacesAccessoryViewController.m
+++ b/sources/iTermNumberOfSpacesAccessoryViewController.m
@@ -16,7 +16,7 @@
 }
 
 - (instancetype)init {
-    return [super initWithNibName:@"NumberOfSpacesAccessoryView" bundle:nil];
+    return [super initWithNibName:@"NumberOfSpacesAccessoryView" bundle:[NSBundle bundleForClass:self.class]];
 }
 
 - (void)awakeFromNib {

--- a/sources/iTermOpenQuicklyItem.m
+++ b/sources/iTermOpenQuicklyItem.m
@@ -1,6 +1,7 @@
 #import "iTermOpenQuicklyItem.h"
 #import "iTermLogoGenerator.h"
 #import "iTermOpenQuicklyTableCellView.h"
+#import "NSImage+iTerm.h"
 
 @implementation iTermOpenQuicklyItem
 
@@ -17,20 +18,20 @@
 @implementation iTermOpenQuicklySessionItem
 
 - (instancetype)init {
-  self = [super init];
-  if (self) {
-    _logoGenerator = [[iTermLogoGenerator alloc] init];
-  }
-  return self;
+    self = [super init];
+    if (self) {
+        _logoGenerator = [[iTermLogoGenerator alloc] init];
+    }
+    return self;
 }
 
 - (void)dealloc {
-  [_logoGenerator release];
-  [super dealloc];
+    [_logoGenerator release];
+    [super dealloc];
 }
 
 - (NSImage *)icon {
-  return [_logoGenerator generatedImage];
+    return [_logoGenerator generatedImage];
 }
 
 @end
@@ -38,7 +39,7 @@
 @implementation iTermOpenQuicklyProfileItem
 
 - (NSImage *)icon {
-  return [[NSBundle bundleForClass:self.class] imageForResource:@"new-tab"];
+    return [NSImage it_imageNamed:@"new-tab" forClass:self.class];
 }
 
 @end
@@ -46,7 +47,7 @@
 @implementation iTermOpenQuicklyChangeProfileItem
 
 - (NSImage *)icon {
-    return [[NSBundle bundleForClass:self.class] imageForResource:@"ChangeProfile"];
+    return [NSImage it_imageNamed:@"ChangeProfile" forClass:self.class];
 }
 
 @end
@@ -76,7 +77,7 @@
 @implementation iTermOpenQuicklyArrangementItem
 
 - (NSImage *)icon {
-  return [[NSBundle bundleForClass:self.class] imageForResource:@"restore-arrangement"];
+  return [NSImage it_imageNamed:@"restore-arrangement" forClass:self.class];
 }
 
 @end
@@ -84,7 +85,7 @@
 @implementation iTermOpenQuicklyHelpItem
 
 - (NSImage *)icon {
-    return [[NSBundle bundleForClass:self.class] imageForResource:@"Info"];
+    return [NSImage it_imageNamed:@"Info" forClass:self.class];
 }
 
 @end
@@ -92,7 +93,7 @@
 @implementation iTermOpenQuicklyScriptItem
 
 - (NSImage *)icon {
-    return [[NSBundle bundleForClass:self.class] imageForResource:@"ScriptIcon"];
+    return [NSImage it_imageNamed:@"ScriptIcon" forClass:self.class];
 }
 
 @end

--- a/sources/iTermOpenQuicklyItem.m
+++ b/sources/iTermOpenQuicklyItem.m
@@ -38,7 +38,7 @@
 @implementation iTermOpenQuicklyProfileItem
 
 - (NSImage *)icon {
-  return [NSImage imageNamed:@"new-tab"];
+  return [[NSBundle bundleForClass:self.class] imageForResource:@"new-tab"];
 }
 
 @end
@@ -46,7 +46,7 @@
 @implementation iTermOpenQuicklyChangeProfileItem
 
 - (NSImage *)icon {
-    return [NSImage imageNamed:@"ChangeProfile"];
+    return [[NSBundle bundleForClass:self.class] imageForResource:@"ChangeProfile"];
 }
 
 @end
@@ -76,7 +76,7 @@
 @implementation iTermOpenQuicklyArrangementItem
 
 - (NSImage *)icon {
-  return [NSImage imageNamed:@"restore-arrangement"];
+  return [[NSBundle bundleForClass:self.class] imageForResource:@"restore-arrangement"];
 }
 
 @end
@@ -84,7 +84,7 @@
 @implementation iTermOpenQuicklyHelpItem
 
 - (NSImage *)icon {
-    return [NSImage imageNamed:@"Info"];
+    return [[NSBundle bundleForClass:self.class] imageForResource:@"Info"];
 }
 
 @end
@@ -92,7 +92,7 @@
 @implementation iTermOpenQuicklyScriptItem
 
 - (NSImage *)icon {
-    return [NSImage imageNamed:@"ScriptIcon"];
+    return [[NSBundle bundleForClass:self.class] imageForResource:@"ScriptIcon"];
 }
 
 @end

--- a/sources/iTermPasteSpecialViewController.m
+++ b/sources/iTermPasteSpecialViewController.m
@@ -73,7 +73,7 @@ static NSString *const kSubstitution = @"Substitution";
 }
 
 - (instancetype)init {
-    self = [super initWithNibName:@"iTermPasteSpecialViewController" bundle:nil];
+    self = [super initWithNibName:@"iTermPasteSpecialViewController" bundle:[NSBundle bundleForClass:self.class]];
     return self;
 }
 

--- a/sources/iTermScriptsMenuController.m
+++ b/sources/iTermScriptsMenuController.m
@@ -295,7 +295,7 @@ NS_ASSUME_NONNULL_BEGIN
     NSString *templateName = [NSString stringWithFormat:@"template_%@_%@",
                               environmentNamePart[picker.selectedEnvironment],
                               templateNamePart[picker.selectedTemplate]];
-    NSString *templatePath = [[NSBundle mainBundle] pathForResource:templateName ofType:@"py"];
+    NSString *templatePath = [[NSBundle bundleForClass:self.class] pathForResource:templateName ofType:@"py"];
     return templatePath;
 }
 

--- a/sources/iTermShellHistoryController.m
+++ b/sources/iTermShellHistoryController.m
@@ -164,7 +164,7 @@ static const NSTimeInterval kMaxTimeToRememberDirectories = 60 * 60 * 24 * 90;
 // vacuum a database after changing the setting to in-memory. It doesn't make sense to vacuum RAM,
 // after all.
 - (BOOL)initializeCoreDataWithRetry:(BOOL)retry vacuum:(BOOL)vacuum {
-    NSURL *modelURL = [[NSBundle mainBundle] URLForResource:@"Model" withExtension:@"momd"];
+    NSURL *modelURL = [[NSBundle bundleForClass:self.class] URLForResource:@"Model" withExtension:@"momd"];
     assert(modelURL);
 
     NSManagedObjectModel *managedObjectModel =

--- a/sources/iTermShortcutInputView.m
+++ b/sources/iTermShortcutInputView.m
@@ -46,9 +46,9 @@
 
 - (void)setBackgroundStyle:(NSBackgroundStyle)backgroundStyle {
     if (backgroundStyle == NSBackgroundStyleLight) {
-        [_clearButton setImage:[NSImage imageNamed:@"Erase"]];
+        [_clearButton setImage:[[NSBundle bundleForClass:self.class] imageForResource:@"Erase"]];
     } else {
-        [_clearButton setImage:[NSImage imageNamed:@"EraseDarkBackground"]];
+        [_clearButton setImage:[[NSBundle bundleForClass:self.class] imageForResource:@"EraseDarkBackground"]];
     }
     _backgroundStyle = backgroundStyle;
     [self setNeedsDisplay:YES];
@@ -198,14 +198,14 @@
 
 - (void)addClearButton {
     NSSize size = self.bounds.size;
-    NSSize buttonSize = [[NSImage imageNamed:@"Erase"] size];
+    NSSize buttonSize = [[[NSBundle bundleForClass:self.class] imageForResource:@"Erase"] size];
 
     _clearButton = [[NSButton alloc] initWithFrame:NSMakeRect(size.width - buttonSize.width - 2,
                                                               (size.height - buttonSize.height) / 2.0,
                                                               buttonSize.width,
                                                               buttonSize.height)];
     [_clearButton setTarget:self];
-    [_clearButton setImage:[NSImage imageNamed:@"Erase"]];
+    [_clearButton setImage:[[NSBundle bundleForClass:self.class] imageForResource:@"Erase"]];
     [_clearButton setAction:@selector(clear:)];
     [_clearButton setBordered:NO];
     self.autoresizesSubviews = YES;

--- a/sources/iTermShortcutInputView.m
+++ b/sources/iTermShortcutInputView.m
@@ -9,6 +9,7 @@
 #import "iTermShortcutInputView.h"
 #import "iTermKeyBindingMgr.h"
 #import "NSStringITerm.h"
+#import "NSImage+iTerm.h"
 
 @interface iTermShortcutInputView()
 @property(nonatomic, copy) NSString *hotkeyBeingRecorded;
@@ -46,9 +47,9 @@
 
 - (void)setBackgroundStyle:(NSBackgroundStyle)backgroundStyle {
     if (backgroundStyle == NSBackgroundStyleLight) {
-        [_clearButton setImage:[[NSBundle bundleForClass:self.class] imageForResource:@"Erase"]];
+        [_clearButton setImage:[NSImage it_imageNamed:@"Erase" forClass:self.class]];
     } else {
-        [_clearButton setImage:[[NSBundle bundleForClass:self.class] imageForResource:@"EraseDarkBackground"]];
+        [_clearButton setImage:[NSImage it_imageNamed:@"EraseDarkBackground" forClass:self.class]];
     }
     _backgroundStyle = backgroundStyle;
     [self setNeedsDisplay:YES];
@@ -198,14 +199,14 @@
 
 - (void)addClearButton {
     NSSize size = self.bounds.size;
-    NSSize buttonSize = [[[NSBundle bundleForClass:self.class] imageForResource:@"Erase"] size];
+    NSSize buttonSize = [[NSImage it_imageNamed:@"Erase" forClass:self.class] size];
 
     _clearButton = [[NSButton alloc] initWithFrame:NSMakeRect(size.width - buttonSize.width - 2,
                                                               (size.height - buttonSize.height) / 2.0,
                                                               buttonSize.width,
                                                               buttonSize.height)];
     [_clearButton setTarget:self];
-    [_clearButton setImage:[[NSBundle bundleForClass:self.class] imageForResource:@"Erase"]];
+    [_clearButton setImage:[NSImage it_imageNamed:@"Erase" forClass:self.class]];
     [_clearButton setAction:@selector(clear:)];
     [_clearButton setBordered:NO];
     self.autoresizesSubviews = YES;

--- a/sources/iTermStatusBarComposerComponent.m
+++ b/sources/iTermStatusBarComposerComponent.m
@@ -53,7 +53,7 @@
 
 - (iTermsStatusBarComposerViewController *)viewController {
     if (!_viewController) {
-        _viewController = [[iTermsStatusBarComposerViewController alloc] initWithNibName:@"iTermsStatusBarComposerViewController" bundle:nil];
+        _viewController = [[iTermsStatusBarComposerViewController alloc] initWithNibName:@"iTermsStatusBarComposerViewController" bundle:[NSBundle bundleForClass:self.class]];
         _viewController.delegate = self;
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(commandHistoryDidChange:)

--- a/sources/iTermStatusBarGitComponent.m
+++ b/sources/iTermStatusBarGitComponent.m
@@ -216,7 +216,7 @@ static const NSTimeInterval iTermStatusBarGitComponentDefaultCadence = 2;
 
 - (NSAttributedString *)attributedStringWithImageNamed:(NSString *)imageName {
     NSTextAttachment *textAttachment = [[NSTextAttachment alloc] init];
-    textAttachment.image = [[NSBundle bundleForClass:self.class] imageForResource:imageName];
+    textAttachment.image = [NSImage it_imageNamed:imageName forClass:self.class];
     return [NSAttributedString attributedStringWithAttachment:textAttachment];
 }
 

--- a/sources/iTermStatusBarGitComponent.m
+++ b/sources/iTermStatusBarGitComponent.m
@@ -216,7 +216,7 @@ static const NSTimeInterval iTermStatusBarGitComponentDefaultCadence = 2;
 
 - (NSAttributedString *)attributedStringWithImageNamed:(NSString *)imageName {
     NSTextAttachment *textAttachment = [[NSTextAttachment alloc] init];
-    textAttachment.image = [NSImage imageNamed:imageName];
+    textAttachment.image = [[NSBundle bundleForClass:self.class] imageForResource:imageName];
     return [NSAttributedString attributedStringWithAttachment:textAttachment];
 }
 

--- a/sources/iTermStatusBarSearchFieldComponent.m
+++ b/sources/iTermStatusBarSearchFieldComponent.m
@@ -62,7 +62,7 @@ NSString *iTermStatusBarSearchComponentIsTemporaryKey = @"search: temporary";
 - (NSViewController<iTermFindViewController> *)statusBarComponentSearchViewController {
     if (!_viewController) {
         _viewController = [[iTermMiniSearchFieldViewController alloc] initWithNibName:@"iTermMiniSearchFieldViewController"
-                                                                               bundle:[NSBundle mainBundle]];
+                                                                               bundle:[NSBundle bundleForClass:self.class]];
         const BOOL canClose = [self.configuration[iTermStatusBarComponentConfigurationKeyKnobValues][iTermStatusBarSearchComponentIsTemporaryKey] boolValue];
         _viewController.canClose = canClose;
     }

--- a/sources/iTermStatusBarSetupDestinationCollectionViewController.m
+++ b/sources/iTermStatusBarSetupDestinationCollectionViewController.m
@@ -129,7 +129,7 @@
 - (NSSize)collectionView:(NSCollectionView *)collectionView
                   layout:(NSCollectionViewLayout*)collectionViewLayout
   sizeForItemAtIndexPath:(NSIndexPath *)indexPath {
-    iTermStatusBarSetupCollectionViewItem *item = [[iTermStatusBarSetupCollectionViewItem alloc] initWithNibName:@"iTermStatusBarSetupCollectionViewItem" bundle:nil];
+    iTermStatusBarSetupCollectionViewItem *item = [[iTermStatusBarSetupCollectionViewItem alloc] initWithNibName:@"iTermStatusBarSetupCollectionViewItem" bundle:[NSBundle bundleForClass:self.class]];
     [item view];
     [self initializeItem:item atIndexPath:indexPath];
     [item sizeToFit];

--- a/sources/iTermStatusBarSetupViewController.m
+++ b/sources/iTermStatusBarSetupViewController.m
@@ -47,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (nullable instancetype)initWithLayoutDictionary:(NSDictionary *)layoutDictionary {
-    self = [super initWithNibName:@"iTermStatusBarSetupViewController" bundle:nil];
+    self = [super initWithNibName:@"iTermStatusBarSetupViewController" bundle:[NSBundle bundleForClass:self.class]];
     if (self) {
         _initialLayout = [layoutDictionary copy];
     }
@@ -169,7 +169,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSSize)collectionView:(NSCollectionView *)collectionView
                   layout:(NSCollectionViewLayout*)collectionViewLayout
   sizeForItemAtIndexPath:(NSIndexPath *)indexPath {
-    iTermStatusBarSetupCollectionViewItem *item = [[iTermStatusBarSetupCollectionViewItem alloc] initWithNibName:@"iTermStatusBarSetupCollectionViewItem" bundle:nil];
+    iTermStatusBarSetupCollectionViewItem *item = [[iTermStatusBarSetupCollectionViewItem alloc] initWithNibName:@"iTermStatusBarSetupCollectionViewItem" bundle:[NSBundle bundleForClass:self.class]];
     [item view];
     [self initializeItem:item atIndexPath:indexPath];
     [item sizeToFit];

--- a/sources/iTermTextDrawingHelper.m
+++ b/sources/iTermTextDrawingHelper.m
@@ -611,7 +611,7 @@ typedef struct iTermTextColorContext {
 
 - (void)drawStripesInRect:(NSRect)rect {
     if (!_backgroundStripesImage) {
-        _backgroundStripesImage = [[NSImage imageNamed:@"BackgroundStripes"] retain];
+        _backgroundStripesImage = [[[NSBundle bundleForClass:self.class] imageForResource:@"BackgroundStripes"] retain];
     }
     NSColor *color = [NSColor colorWithPatternImage:_backgroundStripesImage];
     [color set];
@@ -2418,7 +2418,7 @@ static BOOL iTermTextDrawingHelperShouldAntiAlias(screen_char_t *c,
         NSRect rect = [self reallyDrawCursor:cursor at:_cursorCoord outline:outline];
 
         if (_showSearchingCursor) {
-            NSImage *image = [NSImage imageNamed:@"SearchCursor"];
+            NSImage *image = [[NSBundle bundleForClass:self.class] imageForResource:@"SearchCursor"];
             if (image) {
                 NSRect imageRect = rect;
                 CGFloat aspectRatio = image.size.height / image.size.width;
@@ -2472,7 +2472,7 @@ static BOOL iTermTextDrawingHelperShouldAntiAlias(screen_char_t *c,
     }
 
     if (_passwordInput) {
-        NSImage *keyImage = [NSImage imageNamed:@"key"];
+        NSImage *keyImage = [[NSBundle bundleForClass:self.class] imageForResource:@"key"];
         CGPoint point = rect.origin;
         [keyImage drawInRect:NSMakeRect(point.x, point.y, _cellSize.width, _cellSize.height)
                     fromRect:NSZeroRect

--- a/sources/iTermTextDrawingHelper.m
+++ b/sources/iTermTextDrawingHelper.m
@@ -29,6 +29,7 @@
 #import "NSColor+iTerm.h"
 #import "NSDictionary+iTerm.h"
 #import "NSMutableAttributedString+iTerm.h"
+#import "NSImage+iTerm.h"
 #import "NSStringITerm.h"
 #import "PTYFontInfo.h"
 #import "RegexKitLite.h"
@@ -611,7 +612,7 @@ typedef struct iTermTextColorContext {
 
 - (void)drawStripesInRect:(NSRect)rect {
     if (!_backgroundStripesImage) {
-        _backgroundStripesImage = [[[NSBundle bundleForClass:self.class] imageForResource:@"BackgroundStripes"] retain];
+        _backgroundStripesImage = [[NSImage it_imageNamed:@"BackgroundStripes" forClass:self.class] retain];
     }
     NSColor *color = [NSColor colorWithPatternImage:_backgroundStripesImage];
     [color set];
@@ -2418,7 +2419,7 @@ static BOOL iTermTextDrawingHelperShouldAntiAlias(screen_char_t *c,
         NSRect rect = [self reallyDrawCursor:cursor at:_cursorCoord outline:outline];
 
         if (_showSearchingCursor) {
-            NSImage *image = [[NSBundle bundleForClass:self.class] imageForResource:@"SearchCursor"];
+            NSImage *image = [NSImage it_imageNamed:@"SearchCursor" forClass:self.class];
             if (image) {
                 NSRect imageRect = rect;
                 CGFloat aspectRatio = image.size.height / image.size.width;
@@ -2472,7 +2473,7 @@ static BOOL iTermTextDrawingHelperShouldAntiAlias(screen_char_t *c,
     }
 
     if (_passwordInput) {
-        NSImage *keyImage = [[NSBundle bundleForClass:self.class] imageForResource:@"key"];
+        NSImage *keyImage = [NSImage it_imageNamed:@"key" forClass:self.class];
         CGPoint point = rect.origin;
         [keyImage drawInRect:NSMakeRect(point.x, point.y, _cellSize.width, _cellSize.height)
                     fromRect:NSZeroRect

--- a/sources/iTermTipWindowController.m
+++ b/sources/iTermTipWindowController.m
@@ -119,14 +119,14 @@ static const CGFloat kWindowWidth = 400;
 - (void)addButtonsToCard:(iTermTipCardViewController *)card expanded:(BOOL)expanded {
     if (_tip.url) {
         [card addActionWithTitle:kLearnMoreTitle
-                            icon:[NSImage imageNamed:@"Navigate"]
+                            icon:[[NSBundle bundleForClass:self.class] imageForResource:@"Navigate"]
                            block:^(id sendingCard) {
                                [self openURL];
                            }];
     }
     [card addActionWithTitle:kDismissTipTitle
                     shortcut:@"⎋"
-                        icon:[NSImage imageNamed:@"Dismiss"]
+                        icon:[[NSBundle bundleForClass:self.class] imageForResource:@"Dismiss"]
                        block:^(id sendingCard) {
                            [self dismiss];
                        }];
@@ -134,7 +134,7 @@ static const CGFloat kWindowWidth = 400;
     NSString *toggleTitle = expanded ? kFewerOptionsTitle : kMoreOptionsTitle;
     iTermTipCardActionButton *button =
         [card addActionWithTitle:toggleTitle
-                            icon:[NSImage imageNamed:@"ChevronDown"]
+                            icon:[[NSBundle bundleForClass:self.class] imageForResource:@"ChevronDown"]
                            block:^(id sendingCard) {
                                [self toggleOptionsInCard:sendingCard];
                            }];
@@ -142,7 +142,7 @@ static const CGFloat kWindowWidth = 400;
 
     button =
         [card addActionWithTitle:kShowThisLaterTitle
-                            icon:[NSImage imageNamed:@"Later"]
+                            icon:[[NSBundle bundleForClass:self.class] imageForResource:@"Later"]
                            block:^(id sendingCard) {
                                [self showThisLater];
                            }];
@@ -180,7 +180,7 @@ static const CGFloat kWindowWidth = 400;
     }
     button =
         [card addActionWithTitle:frequencyTitle
-                            icon:[NSImage imageNamed:@"TipCalendar"]
+                            icon:[[NSBundle bundleForClass:self.class] imageForResource:@"TipCalendar"]
                            block:^(id sendingCard) {
                                [_delegate toggleTipFrequency];
                                iTermTipCardActionButton *theButton = [card actionWithTitle:kShowTipsWeeklyTitle];
@@ -203,7 +203,7 @@ static const CGFloat kWindowWidth = 400;
     }
     button =
         [card addActionWithTitle:enableOrDisableTitle
-                            icon:[NSImage imageNamed:@"DisableTips"]
+                            icon:[[NSBundle bundleForClass:self.class] imageForResource:@"DisableTips"]
                            block:^(id sendingCard) {
                                if (![_delegate tipWindowTipsAreDisabled]) {
                                    [self disableTips];
@@ -220,7 +220,7 @@ static const CGFloat kWindowWidth = 400;
     if ([_delegate tipWindowTipAfterTipWithIdentifier:self.tip.identifier]) {
         button =
             [card addActionWithTitle:kShowNextTipTitle
-                                icon:[NSImage imageNamed:@"NextTip"]
+                                icon:[[NSBundle bundleForClass:self.class] imageForResource:@"NextTip"]
                                block:^(id sendingCard) {
                                    [self showNextTip];
                                }];
@@ -231,7 +231,7 @@ static const CGFloat kWindowWidth = 400;
     if ([_delegate tipWindowTipBeforeTipWithIdentifier:self.tip.identifier]) {
         button =
             [card addActionWithTitle:kShowPreviousTipTitle
-                                icon:[NSImage imageNamed:@"NextTip"]
+                                icon:[[NSBundle bundleForClass:self.class] imageForResource:@"NextTip"]
                                block:^(id sendingCard) {
                                    [self showPreviousTip];
                                }];

--- a/sources/iTermTipWindowController.m
+++ b/sources/iTermTipWindowController.m
@@ -15,6 +15,7 @@
 #import "iTermTipCardViewController.h"
 #import "iTermFlippedView.h"
 #import "NSView+iTerm.h"
+#import "NSImage+iTerm.h"
 #import "SolidColorView.h"
 
 #import <QuartzCore/QuartzCore.h>
@@ -119,14 +120,14 @@ static const CGFloat kWindowWidth = 400;
 - (void)addButtonsToCard:(iTermTipCardViewController *)card expanded:(BOOL)expanded {
     if (_tip.url) {
         [card addActionWithTitle:kLearnMoreTitle
-                            icon:[[NSBundle bundleForClass:self.class] imageForResource:@"Navigate"]
+                            icon:[NSImage it_imageNamed:@"Navigate" forClass:self.class]
                            block:^(id sendingCard) {
                                [self openURL];
                            }];
     }
     [card addActionWithTitle:kDismissTipTitle
                     shortcut:@"⎋"
-                        icon:[[NSBundle bundleForClass:self.class] imageForResource:@"Dismiss"]
+                        icon:[NSImage it_imageNamed:@"Dismiss" forClass:self.class]
                        block:^(id sendingCard) {
                            [self dismiss];
                        }];
@@ -134,7 +135,7 @@ static const CGFloat kWindowWidth = 400;
     NSString *toggleTitle = expanded ? kFewerOptionsTitle : kMoreOptionsTitle;
     iTermTipCardActionButton *button =
         [card addActionWithTitle:toggleTitle
-                            icon:[[NSBundle bundleForClass:self.class] imageForResource:@"ChevronDown"]
+                            icon:[NSImage it_imageNamed:@"ChevronDown" forClass:self.class]
                            block:^(id sendingCard) {
                                [self toggleOptionsInCard:sendingCard];
                            }];
@@ -142,7 +143,7 @@ static const CGFloat kWindowWidth = 400;
 
     button =
         [card addActionWithTitle:kShowThisLaterTitle
-                            icon:[[NSBundle bundleForClass:self.class] imageForResource:@"Later"]
+                            icon:[NSImage it_imageNamed:@"Later" forClass:self.class]
                            block:^(id sendingCard) {
                                [self showThisLater];
                            }];
@@ -180,7 +181,7 @@ static const CGFloat kWindowWidth = 400;
     }
     button =
         [card addActionWithTitle:frequencyTitle
-                            icon:[[NSBundle bundleForClass:self.class] imageForResource:@"TipCalendar"]
+                            icon:[NSImage it_imageNamed:@"TipCalendar" forClass:self.class]
                            block:^(id sendingCard) {
                                [_delegate toggleTipFrequency];
                                iTermTipCardActionButton *theButton = [card actionWithTitle:kShowTipsWeeklyTitle];
@@ -203,7 +204,7 @@ static const CGFloat kWindowWidth = 400;
     }
     button =
         [card addActionWithTitle:enableOrDisableTitle
-                            icon:[[NSBundle bundleForClass:self.class] imageForResource:@"DisableTips"]
+                            icon:[NSImage it_imageNamed:@"DisableTips" forClass:self.class]
                            block:^(id sendingCard) {
                                if (![_delegate tipWindowTipsAreDisabled]) {
                                    [self disableTips];
@@ -220,7 +221,7 @@ static const CGFloat kWindowWidth = 400;
     if ([_delegate tipWindowTipAfterTipWithIdentifier:self.tip.identifier]) {
         button =
             [card addActionWithTitle:kShowNextTipTitle
-                                icon:[[NSBundle bundleForClass:self.class] imageForResource:@"NextTip"]
+                                icon:[NSImage it_imageNamed:@"NextTip" forClass:self.class]
                                block:^(id sendingCard) {
                                    [self showNextTip];
                                }];
@@ -231,7 +232,7 @@ static const CGFloat kWindowWidth = 400;
     if ([_delegate tipWindowTipBeforeTipWithIdentifier:self.tip.identifier]) {
         button =
             [card addActionWithTitle:kShowPreviousTipTitle
-                                icon:[[NSBundle bundleForClass:self.class] imageForResource:@"NextTip"]
+                                icon:[NSImage it_imageNamed:@"NextTip" forClass:self.class]
                                block:^(id sendingCard) {
                                    [self showPreviousTip];
                                }];

--- a/sources/iTermTipWindowController.m
+++ b/sources/iTermTipWindowController.m
@@ -104,7 +104,7 @@ static const CGFloat kWindowWidth = 400;
 - (void)loadCardExpanded:(BOOL)expanded {
     iTermTipCardViewController *card =
         [[[iTermTipCardViewController alloc] initWithNibName:@"iTermTipCardViewController"
-                                                      bundle:nil] autorelease];
+                                                      bundle:[NSBundle bundleForClass:self.class]] autorelease];
     self.cardViewController = card;
     [card view];
     card.titleString = self.tip.title;

--- a/sources/iTermToolWrapper.m
+++ b/sources/iTermToolWrapper.m
@@ -57,7 +57,7 @@ static const CGFloat kCloseButtonLeftMargin = 5;
         [self addSubview:_title];
         [_title release];
 
-        NSImage *closeImage = [NSImage imageNamed:@"closebutton"];
+        NSImage *closeImage = [[NSBundle bundleForClass:self.class] imageForResource:@"closebutton"];
         _closeButton = [[NSButton alloc] initWithFrame:NSMakeRect(kCloseButtonLeftMargin, 10, kButtonSize, kButtonSize)];
         [_closeButton setButtonType:NSMomentaryPushInButton];
         [_closeButton setImage:closeImage];

--- a/sources/iTermToolWrapper.m
+++ b/sources/iTermToolWrapper.m
@@ -10,6 +10,8 @@
 
 #import "iTermToolbeltView.h"
 
+#import "NSImage+iTerm.h"
+
 static const CGFloat kTitleHeight = 19;
 static const CGFloat kMargin = 4;  // Margin between title bar and content
 static const CGFloat kLeftMargin = 4;
@@ -57,7 +59,7 @@ static const CGFloat kCloseButtonLeftMargin = 5;
         [self addSubview:_title];
         [_title release];
 
-        NSImage *closeImage = [[NSBundle bundleForClass:self.class] imageForResource:@"closebutton"];
+        NSImage *closeImage = [NSImage it_imageNamed:@"closebutton" forClass:self.class];
         _closeButton = [[NSButton alloc] initWithFrame:NSMakeRect(kCloseButtonLeftMargin, 10, kButtonSize, kButtonSize)];
         [_closeButton setButtonType:NSMomentaryPushInButton];
         [_closeButton setImage:closeImage];


### PR DESCRIPTION
- Replace `[NSImage imageNamed:]` with `[NSImage it_imageNamed:forClass:]`
- Replace `[NSBundle mainBundle]` with `[NSBundle bundleForClass:]`
- Pass `[NSBundle bundleForClass:]` to `initWithNibName:bundle:` calls
- Expose some `PTYTextView` properties and methods
  - `showTimestamps`
  - `anyAnnotationsAreVisible`
  - `selectCurrentCommand:`
  - `selectOutputOfLastCommand:`
- In `PTYSession`, handle `paste:` if not sent from an `NSMenuItem`