### PR TITLE
Support option key for zoom button in compact mode

### DIFF
--- a/sources/iTermRootTerminalView.m
+++ b/sources/iTermRootTerminalView.m
@@ -311,6 +311,12 @@ static const CGFloat kMaximumToolbeltSizeAsFractionOfWindow = 0.5;
         frame.origin.x = x;
         frame.origin.y = 4;
         button.frame = frame;
+        
+        if (self.windowButtonTypes[i] == NSWindowZoomButton) {
+            button.target = _standardWindowButtonsView;
+            button.action = @selector(zoomButtonEvent);
+        }
+        
         [_standardWindowButtonsView addSubview:button];
         _standardButtons[@(self.windowButtonTypes[i])] = button;
         x += stride;
@@ -319,6 +325,15 @@ static const CGFloat kMaximumToolbeltSizeAsFractionOfWindow = 0.5;
         });
     }
     [self layoutSubviews];
+}
+
+- (void)flagsChanged:(NSEvent *)event {
+    if (_standardWindowButtonsView) {
+        NSUInteger modifiers = ([NSEvent modifierFlags] & NSEventModifierFlagDeviceIndependentFlagsMask);
+        BOOL optionKey = modifiers & NSEventModifierFlagOption ? YES : NO;
+        
+        [_standardWindowButtonsView setOptionModifier:optionKey];
+    }
 }
 
 - (void)drawRect:(NSRect)dirtyRect {

--- a/sources/iTermStandardWindowButtonsView.h
+++ b/sources/iTermStandardWindowButtonsView.h
@@ -11,6 +11,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface iTermStandardWindowButtonsView : NSView
 
+- (void)setOptionModifier:(BOOL)optionModifier;
+- (void)zoomButtonEvent;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/sources/iTermStandardWindowButtonsView.m
+++ b/sources/iTermStandardWindowButtonsView.m
@@ -9,6 +9,7 @@
 
 @implementation iTermStandardWindowButtonsView {
     BOOL _mouseInGroup;
+    BOOL _optionModifier;
     NSTrackingArea *_trackingArea;
 }
 
@@ -81,14 +82,29 @@
         return;
     }
     _mouseInGroup = mouseInGroup;
-    for (NSView *subview in self.subviews) {
-        [subview setNeedsDisplay:YES];
-    }
+    [self redraw];
 }
 
 // Overrides a private method. Returns YES to show icons in the buttons.
 - (BOOL)_mouseInGroup:(NSButton*)button {
     return _mouseInGroup;
+}
+
+#pragma mark - Option key handling
+
+- (void)setOptionModifier:(BOOL)optionModifier {
+    if (_mouseInGroup && optionModifier != _optionModifier) {
+        [self redraw];
+    }
+    _optionModifier = optionModifier;
+}
+
+- (void)zoomButtonEvent {
+    if (_optionModifier) {
+        [self.window zoom:self];
+    } else {
+        [self.window toggleFullScreen:self];
+    }
 }
 
 @end


### PR DESCRIPTION
Thank you for making this awesome emulator, been using it since I first got my mac and could not imagine working without it! Also thanks for implementing the compact mode which looks real nice 🙂

This PR fixes on of the bugs with manual placement of the stoplight buttons, on macOS you can press and hold the option key to zoom instead of going fullscreen. This PR reimplements that functionality for the custom buttons.

Demo:
First window: TextEditor
Second window: iTerm2 compiled from ```master```
Third window: iTerm2 compiled from this branch with the fix applied

![iterm2zoom](https://user-images.githubusercontent.com/3395492/48494846-f7e63900-e82e-11e8-9366-37863a9b0540.gif)