### PR TITLE
Wrong frame position in highlighted mark (when rendering with Metal)

### DIFF
--- a/sources/Metal/Renderers/iTermHighlightRowRenderer.mm
+++ b/sources/Metal/Renderers/iTermHighlightRowRenderer.mm
@@ -100,12 +100,13 @@ namespace iTerm2 {
     iTermHighlightRowRendererTransientState *tState = transientState;
     const VT100GridSize gridSize = tState.cellConfiguration.gridSize;
     const CGSize cellSize = tState.cellConfiguration.cellSize;
+    const CGFloat top = tState.margins.top;
     const CGFloat left = tState.margins.left;
     const CGFloat right = tState.margins.right;
 
     [tState enumerateDraws:^(vector_float4 color, int row) {
         id<MTLBuffer> vertexBuffer = [self->_cellRenderer newQuadWithFrame:CGRectMake(0,
-                                                                                      (gridSize.height - row - 1) * cellSize.height,
+                                                                                      (gridSize.height - row - 1) * cellSize.height + top,
                                                                                       cellSize.width * gridSize.width + left + right,
                                                                                       cellSize.height)
                                                               textureFrame:CGRectMake(0, 0, 0, 0)


### PR DESCRIPTION
When using GPU rendering and the window height is not divisible by the character height (eg. by ctrl-dragging window's borders) the mark highlight is rendered out of place.

Here's a demonstration of this issue:

On the left is iTerm 3.2.5 and on the right is my fork

![example](https://thumbs.gfycat.com/AdmiredSnivelingIndianglassfish-size_restricted.gif)