### PR TITLE
use case-sensitive path for Cocoa

### DIFF
--- a/sources/iTermFindDriver.h
+++ b/sources/iTermFindDriver.h
@@ -5,7 +5,7 @@
 //  Created by GEORGE NACHMAN on 7/4/18.
 //
 
-#import <cocoa/cocoa.h>
+#import <Cocoa/Cocoa.h>
 #import "iTermFindViewController.h"
 
 @class FindViewController;


### PR DESCRIPTION
I have a case-sensitive filesystem. The build was failing saying that it couldn't find `cocoa/cocoa.h` here. Changing the path to `Cocoa/Cocoa.h` seems to have fixed it.