### PR TITLE
Add missing DLog import

### DIFF
--- a/sources/iTermEchoProbe.m
+++ b/sources/iTermEchoProbe.m
@@ -5,6 +5,7 @@
 //  Created by George Nachman on 8/1/18.
 //
 
+#import "DebugLogging.h"
 #import "iTermEchoProbe.h"
 
 #import "iTermAdvancedSettingsModel.h"


### PR DESCRIPTION
This fixes an `Undefined symbol _DLog` error when building on Mojave. `DLog` is used in the file but not imported.