### PR TITLE
Correct "Terminal.app Compatibility" keyboard mapping "⌥←" and "⌥→"

### DIFF
--- a/plists/PresetKeyMappings.plist
+++ b/plists/PresetKeyMappings.plist
@@ -727,9 +727,9 @@
       <key>0xf702-0x280000</key>
       <dict>
         <key>Action</key>
-        <integer>11</integer>
+        <integer>10</integer>
         <key>Text</key>
-        <string>0x1b 0x1b 0x5b 0x44</string>
+        <string>b</string>
       </dict>
       <key>0xf703-0x220000</key>
       <dict>
@@ -755,9 +755,9 @@
       <key>0xf703-0x280000</key>
       <dict>
         <key>Action</key>
-        <integer>11</integer>
+        <integer>10</integer>
         <key>Text</key>
-        <string>0x1b 0x1b 0x5b 0x43</string>
+        <string>f</string>
       </dict>
       <key>0xf708-0x20000</key>
       <dict>


### PR DESCRIPTION
This PR changes the "Terminal.app Compatibility" keyboard mapping to map "⌥←" and "⌥→" to "Escape"+`b` and "Escape"+`f`, respectively, which (for me at least...?) correctly implements the word-jumping functionality in Terminal.app. Seems to work with all shells. I've been manually doing this myself for several years. And I think I saw an open issue on GitLab somewhere about this... perhaps [#2587](https://gitlab.com/gnachman/iterm2/issues/2587), although I'm only fixing the 'option' bits, as 'command' left and right are not implemented in Terminal.app.

---
<img width="779" alt="terminal app" src="https://user-images.githubusercontent.com/3162811/49187282-e0717a80-f31b-11e8-9577-65aade1058da.png">

![iterm2](https://user-images.githubusercontent.com/3162811/49187605-ec117100-f31c-11e8-907b-ba5e5cb561cc.png)
