### PR TITLE
Make iTerm2 display a message in macOS that tells the user the app is…

### DIFF
--- a/plists/iTerm2.plist
+++ b/plists/iTerm2.plist
@@ -300,5 +300,7 @@
 	<string>https://iterm2.com/appcasts/final.xml</string>
 	<key>SUFeedURL</key>
 	<string>https://iterm2.com/appcasts/final.xml</string>
+	<key>NSSystemAdministrationUsageDescription</key>
+	<string>The requested operation in iTerm2 requires elevation to be executed</string>
 </dict>
 </plist>


### PR DESCRIPTION
… requesting elevation to manipulate the system (if iTerm2 is not included in Privacy > Full Disk Access)

This makes iTerm2 acts exactly like Apple's Terminal.app does when it need such access permission.