### PR TITLE
Vertical Cursor Guide

### DIFF
--- a/Interfaces/MainMenu.xib
+++ b/Interfaces/MainMenu.xib
@@ -668,6 +668,12 @@ Gw
                                     <action selector="toggleCursorGuide:" target="-1" id="Vxk-ww-Ugb"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Show Vertical Cursor Guide" identifier="Show Vertical Cursor Guide" id="pPk-Wb-7b8">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="toggleVerticalCursorGuide:" target="-1" id="I31-ik-Ak8"/>
+                                </connections>
+                            </menuItem>
                             <menuItem title="Show Timestamps" keyEquivalent="E" identifier="Show Timestamps" id="TnF-kz-Lf0">
                                 <connections>
                                     <action selector="toggleShowTimestamps:" target="-1" id="oGg-h2-Ex7"/>

--- a/Interfaces/MainMenu.xib
+++ b/Interfaces/MainMenu.xib
@@ -671,7 +671,7 @@ Gw
                             <menuItem title="Show Vertical Cursor Guide" identifier="Show Vertical Cursor Guide" id="pPk-Wb-7b8">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
-                                    <action selector="toggleVCursorGuide:" target="-1" id="9p8-5y-S8s"/>
+                                    <action selector="toggleVerticalCursorGuide:" target="-1" id="I31-ik-Ak8"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="Show Timestamps" keyEquivalent="E" identifier="Show Timestamps" id="TnF-kz-Lf0">

--- a/Interfaces/MainMenu.xib
+++ b/Interfaces/MainMenu.xib
@@ -668,6 +668,12 @@ Gw
                                     <action selector="toggleCursorGuide:" target="-1" id="Vxk-ww-Ugb"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Show Vertical Cursor Guide" identifier="Show Vertical Cursor Guide" id="pPk-Wb-7b8">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="toggleVCursorGuide:" target="-1" id="9p8-5y-S8s"/>
+                                </connections>
+                            </menuItem>
                             <menuItem title="Show Timestamps" keyEquivalent="E" identifier="Show Timestamps" id="TnF-kz-Lf0">
                                 <connections>
                                     <action selector="toggleShowTimestamps:" target="-1" id="oGg-h2-Ex7"/>

--- a/Interfaces/PreferencePanel.xib
+++ b/Interfaces/PreferencePanel.xib
@@ -1471,7 +1471,7 @@ DQ
                 <outlet property="_useSmartCursorColor" destination="4889" id="GhQ-EU-ndl"/>
                 <outlet property="_useTabColor" destination="j7F-r8-oes" id="HoY-6m-E99"/>
                 <outlet property="_useUnderlineColor" destination="Cqf-RZ-UnO" id="HoY-6m-xxx"/>
-                <outlet property="_useVGuide" destination="CDY-GW-Oi5" id="31z-FX-BPt"/>
+                <outlet property="_useVerticalGuide" destination="CDY-GW-Oi5" id="31z-FX-BPt"/>
                 <outlet property="delegate" destination="HVI-63-mNz" id="NFg-pP-EcM"/>
                 <outlet property="view" destination="SCN-fS-hNB" id="yvb-17-eJa"/>
             </connections>

--- a/Interfaces/PreferencePanel.xib
+++ b/Interfaces/PreferencePanel.xib
@@ -1545,6 +1545,7 @@ DQ
                 <outlet property="_useSmartCursorColor" destination="4889" id="GhQ-EU-ndl"/>
                 <outlet property="_useTabColor" destination="j7F-r8-oes" id="HoY-6m-E99"/>
                 <outlet property="_useUnderlineColor" destination="Cqf-RZ-UnO" id="HoY-6m-xxx"/>
+                <outlet property="_useVGuide" destination="CDY-GW-Oi5" id="31z-FX-BPt"/>
                 <outlet property="delegate" destination="HVI-63-mNz" id="NFg-pP-EcM"/>
                 <outlet property="view" destination="SCN-fS-hNB" id="yvb-17-eJa"/>
             </connections>
@@ -2272,7 +2273,7 @@ DQ
                     </textFieldCell>
                 </textField>
                 <customView id="Yny-j0-8Wk" customClass="CPKColorWell">
-                    <rect key="frame" x="304" y="73" width="32" height="21"/>
+                    <rect key="frame" x="304" y="84" width="32" height="21"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <userDefinedRuntimeAttributes>
                         <userDefinedRuntimeAttribute type="boolean" keyPath="alphaAllowed" value="YES"/>
@@ -2323,7 +2324,7 @@ DQ
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                 </customView>
                 <button id="Rpk-o3-4ec">
-                    <rect key="frame" x="193" y="74" width="105" height="18"/>
+                    <rect key="frame" x="173" y="85" width="105" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Cursor guide" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="Ai2-im-FjJ">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -2332,6 +2333,18 @@ DQ
                     <connections>
                         <action selector="settingChanged:" target="p8i-eM-oBc" id="IhP-Ds-PqB"/>
                         <outlet property="nextKeyView" destination="4896" id="kw5-A8-LVc"/>
+                    </connections>
+                </button>
+                <button id="CDY-GW-Oi5" userLabel="Use Vertical Guide">
+                    <rect key="frame" x="173" y="65" width="148" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="check" title="Vertical cursor guide" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="2Co-vY-kv7">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="settingChanged:" target="p8i-eM-oBc" id="T94-1y-jPl"/>
+                        <outlet property="nextKeyView" destination="4896" id="H8S-V8-cYY"/>
                     </connections>
                 </button>
                 <customView id="2286" customClass="CPKColorWell">

--- a/Interfaces/PreferencePanel.xib
+++ b/Interfaces/PreferencePanel.xib
@@ -1545,7 +1545,7 @@ DQ
                 <outlet property="_useSmartCursorColor" destination="4889" id="GhQ-EU-ndl"/>
                 <outlet property="_useTabColor" destination="j7F-r8-oes" id="HoY-6m-E99"/>
                 <outlet property="_useUnderlineColor" destination="Cqf-RZ-UnO" id="HoY-6m-xxx"/>
-                <outlet property="_useVGuide" destination="CDY-GW-Oi5" id="31z-FX-BPt"/>
+                <outlet property="_useVerticalGuide" destination="CDY-GW-Oi5" id="31z-FX-BPt"/>
                 <outlet property="delegate" destination="HVI-63-mNz" id="NFg-pP-EcM"/>
                 <outlet property="view" destination="SCN-fS-hNB" id="yvb-17-eJa"/>
             </connections>

--- a/Interfaces/PreferencePanel.xib
+++ b/Interfaces/PreferencePanel.xib
@@ -1471,6 +1471,7 @@ DQ
                 <outlet property="_useSmartCursorColor" destination="4889" id="GhQ-EU-ndl"/>
                 <outlet property="_useTabColor" destination="j7F-r8-oes" id="HoY-6m-E99"/>
                 <outlet property="_useUnderlineColor" destination="Cqf-RZ-UnO" id="HoY-6m-xxx"/>
+                <outlet property="_useVGuide" destination="CDY-GW-Oi5" id="31z-FX-BPt"/>
                 <outlet property="delegate" destination="HVI-63-mNz" id="NFg-pP-EcM"/>
                 <outlet property="view" destination="SCN-fS-hNB" id="yvb-17-eJa"/>
             </connections>
@@ -2206,7 +2207,7 @@ DQ
                     </textFieldCell>
                 </textField>
                 <customView id="Yny-j0-8Wk" customClass="CPKColorWell">
-                    <rect key="frame" x="304" y="73" width="32" height="21"/>
+                    <rect key="frame" x="304" y="84" width="32" height="21"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <userDefinedRuntimeAttributes>
                         <userDefinedRuntimeAttribute type="boolean" keyPath="alphaAllowed" value="YES"/>
@@ -2257,7 +2258,7 @@ DQ
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                 </customView>
                 <button id="Rpk-o3-4ec">
-                    <rect key="frame" x="193" y="74" width="105" height="18"/>
+                    <rect key="frame" x="173" y="85" width="105" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Cursor guide" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="Ai2-im-FjJ">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -2266,6 +2267,18 @@ DQ
                     <connections>
                         <action selector="settingChanged:" target="p8i-eM-oBc" id="IhP-Ds-PqB"/>
                         <outlet property="nextKeyView" destination="4896" id="kw5-A8-LVc"/>
+                    </connections>
+                </button>
+                <button id="CDY-GW-Oi5" userLabel="Use Vertical Guide">
+                    <rect key="frame" x="173" y="65" width="148" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="check" title="Vertical cursor guide" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="2Co-vY-kv7">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="settingChanged:" target="p8i-eM-oBc" id="T94-1y-jPl"/>
+                        <outlet property="nextKeyView" destination="4896" id="H8S-V8-cYY"/>
                     </connections>
                 </button>
                 <customView id="2286" customClass="CPKColorWell">

--- a/Interfaces/PreferencePanel.xib
+++ b/Interfaces/PreferencePanel.xib
@@ -1471,6 +1471,7 @@ DQ
                 <outlet property="_useSmartCursorColor" destination="4889" id="GhQ-EU-ndl"/>
                 <outlet property="_useTabColor" destination="j7F-r8-oes" id="HoY-6m-E99"/>
                 <outlet property="_useUnderlineColor" destination="Cqf-RZ-UnO" id="HoY-6m-xxx"/>
+                <outlet property="_useVerticalGuide" destination="CDY-GW-Oi5" id="31z-FX-BPt"/>
                 <outlet property="delegate" destination="HVI-63-mNz" id="NFg-pP-EcM"/>
                 <outlet property="view" destination="SCN-fS-hNB" id="yvb-17-eJa"/>
             </connections>
@@ -2206,7 +2207,7 @@ DQ
                     </textFieldCell>
                 </textField>
                 <customView id="Yny-j0-8Wk" customClass="CPKColorWell">
-                    <rect key="frame" x="304" y="73" width="32" height="21"/>
+                    <rect key="frame" x="304" y="84" width="32" height="21"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <userDefinedRuntimeAttributes>
                         <userDefinedRuntimeAttribute type="boolean" keyPath="alphaAllowed" value="YES"/>
@@ -2257,7 +2258,7 @@ DQ
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                 </customView>
                 <button id="Rpk-o3-4ec">
-                    <rect key="frame" x="193" y="74" width="105" height="18"/>
+                    <rect key="frame" x="173" y="85" width="105" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Cursor guide" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="Ai2-im-FjJ">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -2266,6 +2267,18 @@ DQ
                     <connections>
                         <action selector="settingChanged:" target="p8i-eM-oBc" id="IhP-Ds-PqB"/>
                         <outlet property="nextKeyView" destination="4896" id="kw5-A8-LVc"/>
+                    </connections>
+                </button>
+                <button id="CDY-GW-Oi5" userLabel="Use Vertical Guide">
+                    <rect key="frame" x="173" y="65" width="148" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="check" title="Vertical cursor guide" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="2Co-vY-kv7">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="settingChanged:" target="p8i-eM-oBc" id="T94-1y-jPl"/>
+                        <outlet property="nextKeyView" destination="4896" id="H8S-V8-cYY"/>
                     </connections>
                 </button>
                 <customView id="2286" customClass="CPKColorWell">

--- a/iTerm2XCTests/PTYTextViewTest.m
+++ b/iTerm2XCTests/PTYTextViewTest.m
@@ -992,13 +992,13 @@ static NSString *const kDiffScriptPath = @"/tmp/diffs";
 }
 
 // Draws a cursor guide on the col with b.
-- (void)testVCursorGuide {
+- (void)testVerticalCursorGuide {
     [self doGoldenTestForInput:@"abcd\x1b[2A"
                           name:NSStringFromSelector(_cmd)
                           hook:^(PTYTextView *textView) {
                               textView.drawingHook = ^(iTermTextDrawingHelper *helper) {
                                   helper.shouldDrawFilledInCursor = YES;
-                                  helper.highlightCursorCol = YES;
+                                  helper.highlightCursorColumn = YES;
                               };
                           }
               profileOverrides:nil

--- a/iTerm2XCTests/PTYTextViewTest.m
+++ b/iTerm2XCTests/PTYTextViewTest.m
@@ -991,6 +991,21 @@ static NSString *const kDiffScriptPath = @"/tmp/diffs";
                           size:VT100GridSizeMake(5, 5)];
 }
 
+// Draws a cursor guide on the col with b.
+- (void)testVCursorGuide {
+    [self doGoldenTestForInput:@"abcd\x1b[2A"
+                          name:NSStringFromSelector(_cmd)
+                          hook:^(PTYTextView *textView) {
+                              textView.drawingHook = ^(iTermTextDrawingHelper *helper) {
+                                  helper.shouldDrawFilledInCursor = YES;
+                                  helper.highlightCursorCol = YES;
+                              };
+                          }
+              profileOverrides:nil
+                  createGolden:YES
+                          size:VT100GridSizeMake(5, 5)];
+}
+
 // Draws a badge which blends with nondefault background colors.
 - (void)testBadge {
     [self doGoldenTestForInput:@"\n\n\n\nxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\x1b[42mabc"

--- a/iTerm2XCTests/PTYTextViewTest.m
+++ b/iTerm2XCTests/PTYTextViewTest.m
@@ -991,6 +991,21 @@ static NSString *const kDiffScriptPath = @"/tmp/diffs";
                           size:VT100GridSizeMake(5, 5)];
 }
 
+// Draws a cursor guide on the col with b.
+- (void)testVerticalCursorGuide {
+    [self doGoldenTestForInput:@"abcd\x1b[2A"
+                          name:NSStringFromSelector(_cmd)
+                          hook:^(PTYTextView *textView) {
+                              textView.drawingHook = ^(iTermTextDrawingHelper *helper) {
+                                  helper.shouldDrawFilledInCursor = YES;
+                                  helper.highlightCursorColumn = YES;
+                              };
+                          }
+              profileOverrides:nil
+                  createGolden:YES
+                          size:VT100GridSizeMake(5, 5)];
+}
+
 // Draws a badge which blends with nondefault background colors.
 - (void)testBadge {
     [self doGoldenTestForInput:@"\n\n\n\nxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\x1b[42mabc"

--- a/iTerm2XCTests/VT100GridTest.m
+++ b/iTerm2XCTests/VT100GridTest.m
@@ -53,6 +53,9 @@ do { \
 - (void)gridCursorDidChangeLine {
 }
 
+- (void)gridCursorDidChangeCol {
+}
+
 - (iTermUnicodeNormalization)gridUnicodeNormalizationForm {
     return iTermUnicodeNormalizationNone;
 }

--- a/iTerm2XCTests/VT100GridTest.m
+++ b/iTerm2XCTests/VT100GridTest.m
@@ -53,7 +53,7 @@ do { \
 - (void)gridCursorDidChangeLine {
 }
 
-- (void)gridCursorDidChangeCol {
+- (void)gridCursorDidChangeColumn {
 }
 
 - (iTermUnicodeNormalization)gridUnicodeNormalizationForm {

--- a/iTerm2XCTests/VT100GridTest.m
+++ b/iTerm2XCTests/VT100GridTest.m
@@ -53,6 +53,9 @@ do { \
 - (void)gridCursorDidChangeLine {
 }
 
+- (void)gridCursorDidChangeColumn {
+}
+
 - (iTermUnicodeNormalization)gridUnicodeNormalizationForm {
     return iTermUnicodeNormalizationNone;
 }

--- a/iTerm2XCTests/VT100ScreenTest.m
+++ b/iTerm2XCTests/VT100ScreenTest.m
@@ -748,6 +748,12 @@ NSLog(@"Known bug: %s should be true, but %s is.", #expressionThatShouldBeTrue, 
 - (void)screenCursorDidMoveToLine:(int)line {
 }
 
+- (void)screenSetHighlightCursorColumn:(BOOL)highlight {
+}
+
+- (void)screenCursorDidMoveToColumn:(int)line {
+}
+
 - (void)screenSaveScrollPosition {
 }
 

--- a/iTerm2XCTests/VT100ScreenTest.m
+++ b/iTerm2XCTests/VT100ScreenTest.m
@@ -748,10 +748,10 @@ NSLog(@"Known bug: %s should be true, but %s is.", #expressionThatShouldBeTrue, 
 - (void)screenCursorDidMoveToLine:(int)line {
 }
 
-- (void)screenSetHighlightCursorCol:(BOOL)highlight {
+- (void)screenSetHighlightCursorColumn:(BOOL)highlight {
 }
 
-- (void)screenCursorDidMoveToCol:(int)line {
+- (void)screenCursorDidMoveToColumn:(int)line {
 }
 
 - (void)screenSaveScrollPosition {

--- a/iTerm2XCTests/VT100ScreenTest.m
+++ b/iTerm2XCTests/VT100ScreenTest.m
@@ -748,6 +748,12 @@ NSLog(@"Known bug: %s should be true, but %s is.", #expressionThatShouldBeTrue, 
 - (void)screenCursorDidMoveToLine:(int)line {
 }
 
+- (void)screenSetHighlightCursorCol:(BOOL)highlight {
+}
+
+- (void)screenCursorDidMoveToCol:(int)line {
+}
+
 - (void)screenSaveScrollPosition {
 }
 

--- a/sources/ITAddressBookMgr.h
+++ b/sources/ITAddressBookMgr.h
@@ -114,6 +114,7 @@
 #define KEY_USE_UNDERLINE_COLOR    @"Use Underline Color"
 #define KEY_CURSOR_BOOST           @"Cursor Boost"
 #define KEY_USE_CURSOR_GUIDE       @"Use Cursor Guide"
+#define KEY_USE_VERTICAL_CURSOR_GUIDE  @"Use Vertical Cursor Guide"
 #define KEY_CURSOR_GUIDE_COLOR     @"Cursor Guide Color"
 #define KEY_BADGE_COLOR            @"Badge Color"
 

--- a/sources/ITAddressBookMgr.h
+++ b/sources/ITAddressBookMgr.h
@@ -114,6 +114,7 @@
 #define KEY_USE_UNDERLINE_COLOR    @"Use Underline Color"
 #define KEY_CURSOR_BOOST           @"Cursor Boost"
 #define KEY_USE_CURSOR_GUIDE       @"Use Cursor Guide"
+#define KEY_USE_VERT_CURSOR_GUIDE  @"Use Vertical Cursor Guide"
 #define KEY_CURSOR_GUIDE_COLOR     @"Cursor Guide Color"
 #define KEY_BADGE_COLOR            @"Badge Color"
 

--- a/sources/ITAddressBookMgr.h
+++ b/sources/ITAddressBookMgr.h
@@ -114,7 +114,7 @@
 #define KEY_USE_UNDERLINE_COLOR    @"Use Underline Color"
 #define KEY_CURSOR_BOOST           @"Cursor Boost"
 #define KEY_USE_CURSOR_GUIDE       @"Use Cursor Guide"
-#define KEY_USE_VERT_CURSOR_GUIDE  @"Use Vertical Cursor Guide"
+#define KEY_USE_VERTICAL_CURSOR_GUIDE  @"Use Vertical Cursor Guide"
 #define KEY_CURSOR_GUIDE_COLOR     @"Cursor Guide Color"
 #define KEY_BADGE_COLOR            @"Badge Color"
 

--- a/sources/Metal/Infrastructure/iTermMetalRenderer.h
+++ b/sources/Metal/Infrastructure/iTermMetalRenderer.h
@@ -46,6 +46,7 @@ NS_CLASS_AVAILABLE(10_11, NA)
 @interface iTermMetalRendererTransientState : NSObject
 @property (nonatomic, strong, readonly) __kindof iTermRenderConfiguration *configuration;
 @property (nonatomic, strong) id<MTLBuffer> vertexBuffer;
+@property (nonatomic, strong) id<MTLBuffer> vvertexBuffer;
 @property (nonatomic, readonly) iTermMetalBufferPoolContext *poolContext;
 @property (nonatomic, weak) iTermMetalDebugInfo *debugInfo;
 @property (nonatomic, strong) NSImage *renderedOutputForDebugging;

--- a/sources/Metal/Infrastructure/iTermMetalRenderer.h
+++ b/sources/Metal/Infrastructure/iTermMetalRenderer.h
@@ -46,7 +46,7 @@ NS_CLASS_AVAILABLE(10_11, NA)
 @interface iTermMetalRendererTransientState : NSObject
 @property (nonatomic, strong, readonly) __kindof iTermRenderConfiguration *configuration;
 @property (nonatomic, strong) id<MTLBuffer> vertexBuffer;
-@property (nonatomic, strong) id<MTLBuffer> vvertexBuffer;
+@property (nonatomic, strong) id<MTLBuffer> verticalGuideVertexBuffer;
 @property (nonatomic, readonly) iTermMetalBufferPoolContext *poolContext;
 @property (nonatomic, weak) iTermMetalDebugInfo *debugInfo;
 @property (nonatomic, strong) NSImage *renderedOutputForDebugging;

--- a/sources/Metal/Infrastructure/iTermMetalRenderer.h
+++ b/sources/Metal/Infrastructure/iTermMetalRenderer.h
@@ -46,7 +46,6 @@ NS_CLASS_AVAILABLE(10_11, NA)
 @interface iTermMetalRendererTransientState : NSObject
 @property (nonatomic, strong, readonly) __kindof iTermRenderConfiguration *configuration;
 @property (nonatomic, strong) id<MTLBuffer> vertexBuffer;
-@property (nonatomic, strong) id<MTLBuffer> verticalGuideVertexBuffer;
 @property (nonatomic, readonly) iTermMetalBufferPoolContext *poolContext;
 @property (nonatomic, weak) iTermMetalDebugInfo *debugInfo;
 @property (nonatomic, strong) NSImage *renderedOutputForDebugging;

--- a/sources/Metal/Renderers/iTermCursorGuideRenderer.h
+++ b/sources/Metal/Renderers/iTermCursorGuideRenderer.h
@@ -1,17 +1,18 @@
 #import <Foundation/Foundation.h>
 
 #import "iTermMetalCellRenderer.h"
+#import "VT100GridTypes.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface iTermCursorGuideRendererTransientState : iTermMetalCellRendererTransientState
-// set to -1 if cursor's row is not currently visible.
-- (void)setRow:(int)row;
+- (void)setCursorCoord:(VT100GridCoord)coord;
 @end
 
 @interface iTermCursorGuideRenderer : NSObject<iTermMetalCellRenderer>
 
-@property (nonatomic) BOOL enabled;
+@property (nonatomic) BOOL horizontalEnabled;
+@property (nonatomic) BOOL verticalEnabled;
 
 - (nullable instancetype)initWithDevice:(id<MTLDevice>)device NS_DESIGNATED_INITIALIZER;
 - (instancetype)init NS_UNAVAILABLE;

--- a/sources/Metal/Renderers/iTermCursorGuideRenderer.h
+++ b/sources/Metal/Renderers/iTermCursorGuideRenderer.h
@@ -6,7 +6,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface iTermCursorGuideRendererTransientState : iTermMetalCellRendererTransientState
-- (void)setCursorCoord:(VT100GridCoord)coord within:(VT100GridSize)bounds;
+- (void)setCursorCoord:(VT100GridCoord)coord;
 @end
 
 @interface iTermCursorGuideRenderer : NSObject<iTermMetalCellRenderer>

--- a/sources/Metal/Renderers/iTermCursorGuideRenderer.h
+++ b/sources/Metal/Renderers/iTermCursorGuideRenderer.h
@@ -12,6 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface iTermCursorGuideRenderer : NSObject<iTermMetalCellRenderer>
 
 @property (nonatomic) BOOL enabled;
+@property (nonatomic) BOOL venabled;
 
 - (nullable instancetype)initWithDevice:(id<MTLDevice>)device NS_DESIGNATED_INITIALIZER;
 - (instancetype)init NS_UNAVAILABLE;

--- a/sources/Metal/Renderers/iTermCursorGuideRenderer.h
+++ b/sources/Metal/Renderers/iTermCursorGuideRenderer.h
@@ -1,12 +1,12 @@
 #import <Foundation/Foundation.h>
 
 #import "iTermMetalCellRenderer.h"
+#import "VT100GridTypes.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface iTermCursorGuideRendererTransientState : iTermMetalCellRendererTransientState
-// set to -1 if cursor's row is not currently visible.
-- (void)setRow:(int)row;
+- (void)setCursorCoord:(VT100GridCoord)coord within:(VT100GridSize)bounds;
 @end
 
 @interface iTermCursorGuideRenderer : NSObject<iTermMetalCellRenderer>

--- a/sources/Metal/Renderers/iTermCursorGuideRenderer.h
+++ b/sources/Metal/Renderers/iTermCursorGuideRenderer.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface iTermCursorGuideRenderer : NSObject<iTermMetalCellRenderer>
 
-@property (nonatomic) BOOL enabled;
+@property (nonatomic) BOOL horizontalEnabled;
 @property (nonatomic) BOOL verticalEnabled;
 
 - (nullable instancetype)initWithDevice:(id<MTLDevice>)device NS_DESIGNATED_INITIALIZER;

--- a/sources/Metal/Renderers/iTermCursorGuideRenderer.h
+++ b/sources/Metal/Renderers/iTermCursorGuideRenderer.h
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface iTermCursorGuideRenderer : NSObject<iTermMetalCellRenderer>
 
 @property (nonatomic) BOOL enabled;
-@property (nonatomic) BOOL venabled;
+@property (nonatomic) BOOL verticalEnabled;
 
 - (nullable instancetype)initWithDevice:(id<MTLDevice>)device NS_DESIGNATED_INITIALIZER;
 - (instancetype)init NS_UNAVAILABLE;

--- a/sources/Metal/Renderers/iTermCursorGuideRenderer.m
+++ b/sources/Metal/Renderers/iTermCursorGuideRenderer.m
@@ -98,7 +98,7 @@
 
 - (nullable __kindof iTermMetalRendererTransientState *)createTransientStateForCellConfiguration:(iTermCellRenderConfiguration *)configuration
                                                                                    commandBuffer:(id<MTLCommandBuffer>)commandBuffer {
-    if (!_enabled) {
+    if (!_horizontalEnabled && !_verticalEnabled) {
         return nil;
     }
     __kindof iTermMetalCellRendererTransientState * _Nonnull transientState =
@@ -131,7 +131,7 @@
     }
 
     [tState initializeVerticesWithPool:_cellRenderer.verticesPool];
-    if (tState.row >= 0 && self.enabled) {
+    if (tState.row >= 0 && self.horizontalEnabled) {
         [_cellRenderer drawWithTransientState:tState
                                 renderEncoder:frameData.renderEncoder
                              numberOfVertices:6

--- a/sources/Metal/Renderers/iTermCursorGuideRenderer.m
+++ b/sources/Metal/Renderers/iTermCursorGuideRenderer.m
@@ -193,7 +193,7 @@
                                 vertexBuffers:@{ @(iTermVertexInputIndexVertices): tState.lowerVertexBuffer }
                               fragmentBuffers:@{}
                                      textures:@{ @(iTermTextureIndexPrimary): tState.verticalTexture } ];
-    } else if (tState.row >= 0 && self.horizontalEnabled && !self.verticalEnabled) {
+    } else if (tState.row >= 0 && self.horizontalEnabled) {
         [tState initializeVerticesWithPool:_cellRenderer.verticesPool horizontal:TRUE vertical:FALSE];
         [_cellRenderer drawWithTransientState:tState
                                 renderEncoder:frameData.renderEncoder
@@ -202,7 +202,7 @@
                                 vertexBuffers:@{ @(iTermVertexInputIndexVertices): tState.horizontalVertexBuffer }
                               fragmentBuffers:@{}
                                      textures:@{ @(iTermTextureIndexPrimary): tState.horizontalTexture } ];
-    } else if (tState.column >= 0 && !self.horizontalEnabled && self.verticalEnabled) {
+    } else if (tState.column >= 0 && self.verticalEnabled) {
         [tState initializeVerticesWithPool:_cellRenderer.verticesPool horizontal:FALSE vertical:TRUE];
         [_cellRenderer drawWithTransientState:tState
                                 renderEncoder:frameData.renderEncoder

--- a/sources/Metal/Renderers/iTermCursorGuideRenderer.m
+++ b/sources/Metal/Renderers/iTermCursorGuideRenderer.m
@@ -1,17 +1,23 @@
 #import "iTermCursorGuideRenderer.h"
 
 @interface iTermCursorGuideRendererTransientState()
-@property (nonatomic, strong) id<MTLTexture> horizontalTexture, verticalTexture;
+@property (nonatomic, strong) id<MTLTexture> horizontalTexture;
+@property (nonatomic, strong) id<MTLTexture> verticalTexture;
 @property (nonatomic) int row;
 @property (nonatomic) int column;
-@property (nonatomic) id<MTLBuffer> horizontalVertexBuffer, verticalVertexBuffer, upperVertexBuffer, lowerVertexBuffer;
+@property (nonatomic) id<MTLBuffer> horizontalVertexBuffer;
+@property (nonatomic) id<MTLBuffer> verticalVertexBuffer;
+@property (nonatomic) id<MTLBuffer> upperVertexBuffer;
+@property (nonatomic) id<MTLBuffer> lowerVertexBuffer;
 @end
 
 @implementation iTermCursorGuideRendererTransientState {
     int _row;
     int _column;
-    id<MTLBuffer> _horizontalVertexBuffer, _verticalVertexBuffer;
-    id<MTLBuffer> _upperVertexBuffer, _lowerVertexBuffer;
+    id<MTLBuffer> _horizontalVertexBuffer;
+    id<MTLBuffer> _verticalVertexBuffer;
+    id<MTLBuffer> _upperVertexBuffer;
+    id<MTLBuffer> _lowerVertexBuffer;
 }
 
 - (id<MTLBuffer>)tessellateRect:(CGRect)rect withTexture:(CGRect)textureRect withPool:(iTermMetalBufferPool *)verticesPool {
@@ -43,6 +49,7 @@
 - (void)initializeVerticesWithPool:(iTermMetalBufferPool *)verticesPool
                         horizontal:(BOOL)horizontal
                           vertical:(BOOL)vertical {
+    assert(horizontal || vertical);
     CGSize cellSize = self.cellConfiguration.cellSize;
     VT100GridSize gridSize = self.cellConfiguration.gridSize;
 
@@ -90,7 +97,8 @@
 
 @implementation iTermCursorGuideRenderer {
     iTermMetalCellRenderer *_cellRenderer;
-    id<MTLTexture> _horizontalTexture, _verticalTexture;
+    id<MTLTexture> _horizontalTexture;
+    id<MTLTexture> _verticalTexture;
     NSColor *_color;
     CGSize _lastCellSize;
 }
@@ -156,7 +164,7 @@
     }
 
     if (tState.row >= 0 && tState.column >= 0 && self.horizontalEnabled && self.verticalEnabled) {
-        [tState initializeVerticesWithPool:_cellRenderer.verticesPool horizontal:TRUE vertical:TRUE];
+        [tState initializeVerticesWithPool:_cellRenderer.verticesPool horizontal:YES vertical:YES];
         [_cellRenderer drawWithTransientState:tState
                                 renderEncoder:frameData.renderEncoder
                              numberOfVertices:6
@@ -179,7 +187,7 @@
                               fragmentBuffers:@{}
                                      textures:@{ @(iTermTextureIndexPrimary): tState.verticalTexture } ];
     } else if (tState.row >= 0 && self.horizontalEnabled) {
-        [tState initializeVerticesWithPool:_cellRenderer.verticesPool horizontal:TRUE vertical:FALSE];
+        [tState initializeVerticesWithPool:_cellRenderer.verticesPool horizontal:YES vertical:NO];
         [_cellRenderer drawWithTransientState:tState
                                 renderEncoder:frameData.renderEncoder
                              numberOfVertices:6
@@ -188,7 +196,7 @@
                               fragmentBuffers:@{}
                                      textures:@{ @(iTermTextureIndexPrimary): tState.horizontalTexture } ];
     } else if (tState.column >= 0 && self.verticalEnabled) {
-        [tState initializeVerticesWithPool:_cellRenderer.verticesPool horizontal:FALSE vertical:TRUE];
+        [tState initializeVerticesWithPool:_cellRenderer.verticesPool horizontal:NO vertical:YES];
         [_cellRenderer drawWithTransientState:tState
                                 renderEncoder:frameData.renderEncoder
                              numberOfVertices:6

--- a/sources/Metal/Renderers/iTermCursorGuideRenderer.m
+++ b/sources/Metal/Renderers/iTermCursorGuideRenderer.m
@@ -141,7 +141,7 @@
                                      textures:@{ @(iTermTextureIndexPrimary): tState.texture } ];
     }
 
-    if (tState.col >= 0 && self.enabled) {
+    if (tState.col >= 0 && self.venabled) {
         [_cellRenderer drawWithTransientState:tState
                                 renderEncoder:frameData.renderEncoder
                              numberOfVertices:6

--- a/sources/Metal/Renderers/iTermCursorGuideRenderer.m
+++ b/sources/Metal/Renderers/iTermCursorGuideRenderer.m
@@ -1,14 +1,17 @@
 #import "iTermCursorGuideRenderer.h"
 
 @interface iTermCursorGuideRendererTransientState()
-@property (nonatomic, strong) id<MTLTexture> texture;
+@property (nonatomic, strong) id<MTLTexture> horizontalTexture, verticalTexture;
 @property (nonatomic) int row;
 @property (nonatomic) int column;
+@property (nonatomic) id<MTLBuffer> horizontalVertexBuffer, verticalVertexBuffer, upperVertexBuffer, lowerVertexBuffer;
 @end
 
 @implementation iTermCursorGuideRendererTransientState {
     int _row;
     int _column;
+    id<MTLBuffer> _horizontalVertexBuffer, _verticalVertexBuffer;
+    id<MTLBuffer> _upperVertexBuffer, _lowerVertexBuffer;
 }
 
 - (void)setCursorCoord:(VT100GridCoord)coord within:(VT100GridSize)bounds {
@@ -16,45 +19,78 @@
     _column = (0 <= coord.x && coord.x < bounds.width)  ? coord.x : -1;
 }
 
-- (void)initializeVerticesWithPool:(iTermMetalBufferPool *)verticesPool {
+- (void)initializeVerticesWithPool:(iTermMetalBufferPool *)verticesPool
+                        horizontal:(BOOL)horizontal
+                          vertical:(BOOL)vertical {
     CGSize cellSize = self.cellConfiguration.cellSize;
     VT100GridSize gridSize = self.cellConfiguration.gridSize;
 
-    const CGRect quad = CGRectMake(self.margins.left,
-                                   self.margins.top + (gridSize.height - self.row - 1) * cellSize.height,
-                                   cellSize.width * gridSize.width,
-                                   cellSize.height);
     const CGRect textureFrame = CGRectMake(0, 0, 1, 1);
-    const iTermVertex vertices[] = {
-        // Pixel Positions                              Texture Coordinates
-        { { CGRectGetMaxX(quad), CGRectGetMinY(quad) }, { CGRectGetMaxX(textureFrame), CGRectGetMinY(textureFrame) } },
-        { { CGRectGetMinX(quad), CGRectGetMinY(quad) }, { CGRectGetMinX(textureFrame), CGRectGetMinY(textureFrame) } },
-        { { CGRectGetMinX(quad), CGRectGetMaxY(quad) }, { CGRectGetMinX(textureFrame), CGRectGetMaxY(textureFrame) } },
 
-        { { CGRectGetMaxX(quad), CGRectGetMinY(quad) }, { CGRectGetMaxX(textureFrame), CGRectGetMinY(textureFrame) } },
-        { { CGRectGetMinX(quad), CGRectGetMaxY(quad) }, { CGRectGetMinX(textureFrame), CGRectGetMaxY(textureFrame) } },
-        { { CGRectGetMaxX(quad), CGRectGetMaxY(quad) }, { CGRectGetMaxX(textureFrame), CGRectGetMaxY(textureFrame) } },
-    };
-    self.vertexBuffer = [verticesPool requestBufferFromContext:self.poolContext
-                                                     withBytes:vertices
-                                                checkIfChanged:YES];
+    CGFloat viewMinX = self.margins.left, viewMinY = self.margins.top;
+    CGFloat viewMaxX = viewMinX + cellSize.width*gridSize.width, viewMaxY = viewMinY + cellSize.height*gridSize.height;
 
-    const CGRect verticalGuideQuad = CGRectMake(self.margins.left + self.column * cellSize.width,
-                                                self.margins.top,
-                                                cellSize.width,
-                                                cellSize.height * gridSize.height);
-    const iTermVertex verticalGuideVertices[] = {
-        { { CGRectGetMaxX(verticalGuideQuad), CGRectGetMinY(verticalGuideQuad) }, { CGRectGetMaxX(textureFrame), CGRectGetMinY(textureFrame) } },
-        { { CGRectGetMinX(verticalGuideQuad), CGRectGetMinY(verticalGuideQuad) }, { CGRectGetMinX(textureFrame), CGRectGetMinY(textureFrame) } },
-        { { CGRectGetMinX(verticalGuideQuad), CGRectGetMaxY(verticalGuideQuad) }, { CGRectGetMinX(textureFrame), CGRectGetMaxY(textureFrame) } },
+    CGFloat cursorMinX = self.margins.left + self.column * cellSize.width, cursorMinY = self.margins.top + (gridSize.height - self.row - 1) * cellSize.height;
+    CGFloat cursorMaxX = cursorMinX + cellSize.width, cursorMaxY = cursorMinY + cellSize.height;
 
-        { { CGRectGetMaxX(verticalGuideQuad), CGRectGetMinY(verticalGuideQuad) }, { CGRectGetMaxX(textureFrame), CGRectGetMinY(textureFrame) } },
-        { { CGRectGetMinX(verticalGuideQuad), CGRectGetMaxY(verticalGuideQuad) }, { CGRectGetMinX(textureFrame), CGRectGetMaxY(textureFrame) } },
-        { { CGRectGetMaxX(verticalGuideQuad), CGRectGetMaxY(verticalGuideQuad) }, { CGRectGetMaxX(textureFrame), CGRectGetMaxY(textureFrame) } },
-    };
-    self.verticalGuideVertexBuffer = [verticesPool requestBufferFromContext:self.poolContext
-                                                                  withBytes:verticalGuideVertices
-                                                             checkIfChanged:YES];
+    if (horizontal) {
+        const iTermVertex vertices[] = {
+            // Pixel Positions                              Texture Coordinates
+            { { viewMaxX, cursorMinY }, { CGRectGetMaxX(textureFrame), CGRectGetMinY(textureFrame) } },
+            { { viewMinX, cursorMinY }, { CGRectGetMinX(textureFrame), CGRectGetMinY(textureFrame) } },
+            { { viewMinX, cursorMaxY }, { CGRectGetMinX(textureFrame), CGRectGetMaxY(textureFrame) } },
+
+            { { viewMaxX, cursorMinY }, { CGRectGetMaxX(textureFrame), CGRectGetMinY(textureFrame) } },
+            { { viewMinX, cursorMaxY }, { CGRectGetMinX(textureFrame), CGRectGetMaxY(textureFrame) } },
+            { { viewMaxX, cursorMaxY }, { CGRectGetMaxX(textureFrame), CGRectGetMaxY(textureFrame) } },
+        };
+        self.horizontalVertexBuffer = [verticesPool requestBufferFromContext:self.poolContext
+                                                                   withBytes:vertices
+                                                              checkIfChanged:YES];
+    }
+
+    if (horizontal && vertical) {
+        const iTermVertex lowerVertices[] = {
+            // Pixel Positions                              Texture Coordinates
+            { { cursorMaxX, viewMinY },   { CGRectGetMaxX(textureFrame), CGRectGetMinY(textureFrame) } },
+            { { cursorMinX, viewMinY },   { CGRectGetMinX(textureFrame), CGRectGetMinY(textureFrame) } },
+            { { cursorMinX, cursorMinY }, { CGRectGetMinX(textureFrame), CGRectGetMaxY(textureFrame) } },
+
+            { { cursorMaxX, viewMinY },   { CGRectGetMaxX(textureFrame), CGRectGetMinY(textureFrame) } },
+            { { cursorMinX, cursorMinY }, { CGRectGetMinX(textureFrame), CGRectGetMaxY(textureFrame) } },
+            { { cursorMaxX, cursorMinY }, { CGRectGetMaxX(textureFrame), CGRectGetMaxY(textureFrame) } },
+        };
+        self.lowerVertexBuffer = [verticesPool requestBufferFromContext:self.poolContext
+                                                              withBytes:lowerVertices
+                                                         checkIfChanged:YES];
+        const iTermVertex upperVertices[] = {
+            // Pixel Positions                              Texture Coordinates
+            { { cursorMaxX, cursorMaxY }, { CGRectGetMaxX(textureFrame), CGRectGetMinY(textureFrame) } },
+            { { cursorMinX, cursorMaxY }, { CGRectGetMinX(textureFrame), CGRectGetMinY(textureFrame) } },
+            { { cursorMinX, viewMaxY },   { CGRectGetMinX(textureFrame), CGRectGetMaxY(textureFrame) } },
+
+            { { cursorMaxX, cursorMaxY }, { CGRectGetMaxX(textureFrame), CGRectGetMinY(textureFrame) } },
+            { { cursorMinX, viewMaxY },   { CGRectGetMinX(textureFrame), CGRectGetMaxY(textureFrame) } },
+            { { cursorMaxX, viewMaxY },   { CGRectGetMaxX(textureFrame), CGRectGetMaxY(textureFrame) } },
+        };
+        self.upperVertexBuffer = [verticesPool requestBufferFromContext:self.poolContext
+                                                              withBytes:upperVertices
+                                                         checkIfChanged:YES];
+    } else if (vertical) {
+        const iTermVertex vertices[] = {
+            // Pixel Positions                              Texture Coordinates
+            { { cursorMaxX, viewMinY }, { CGRectGetMaxX(textureFrame), CGRectGetMinY(textureFrame) } },
+            { { cursorMinX, viewMinY }, { CGRectGetMinX(textureFrame), CGRectGetMinY(textureFrame) } },
+            { { cursorMinX, viewMaxY }, { CGRectGetMinX(textureFrame), CGRectGetMaxY(textureFrame) } },
+
+            { { cursorMaxX, viewMinY }, { CGRectGetMaxX(textureFrame), CGRectGetMinY(textureFrame) } },
+            { { cursorMinX, viewMaxY }, { CGRectGetMinX(textureFrame), CGRectGetMaxY(textureFrame) } },
+            { { cursorMaxX, viewMaxY }, { CGRectGetMaxX(textureFrame), CGRectGetMaxY(textureFrame) } },
+        };
+        self.verticalVertexBuffer = [verticesPool requestBufferFromContext:self.poolContext
+                                                                 withBytes:vertices
+                                                            checkIfChanged:YES];
+    }
 }
 
 - (void)writeDebugInfoToFolder:(NSURL *)folder {
@@ -69,7 +105,7 @@
 
 @implementation iTermCursorGuideRenderer {
     iTermMetalCellRenderer *_cellRenderer;
-    id<MTLTexture> _texture;
+    id<MTLTexture> _horizontalTexture, _verticalTexture;
     NSColor *_color;
     CGSize _lastCellSize;
 }
@@ -110,10 +146,14 @@
 
 - (void)initializeTransientState:(iTermCursorGuideRendererTransientState *)tState {
     if (!CGSizeEqualToSize(tState.cellConfiguration.cellSize, _lastCellSize)) {
-        _texture = [self newCursorGuideTextureWithTransientState:tState];
+        _horizontalTexture = [self newCursorGuideTextureWithTransientState:tState
+                                                              isHorizontal:YES];
+        _verticalTexture   = [self newCursorGuideTextureWithTransientState:tState
+                                                              isHorizontal:NO];
         _lastCellSize = tState.cellConfiguration.cellSize;
     }
-    tState.texture = _texture;
+    tState.horizontalTexture = _horizontalTexture;
+    tState.verticalTexture   = _verticalTexture;
 }
 
 - (void)setColor:(NSColor *)color {
@@ -126,37 +166,59 @@
 - (void)drawWithFrameData:(iTermMetalFrameData *)frameData
            transientState:(__kindof iTermMetalCellRendererTransientState *)transientState {
     iTermCursorGuideRendererTransientState *tState = transientState;
-    if (tState.row < 0 || tState.column < 0) {
+    if (tState.row < 0 && tState.column < 0) {
         return;
     }
 
-    [tState initializeVerticesWithPool:_cellRenderer.verticesPool];
-    if (tState.row >= 0 && self.horizontalEnabled) {
+    if (tState.row >= 0 && tState.column >= 0 && self.horizontalEnabled && self.verticalEnabled) {
+        [tState initializeVerticesWithPool:_cellRenderer.verticesPool horizontal:TRUE vertical:TRUE];
         [_cellRenderer drawWithTransientState:tState
                                 renderEncoder:frameData.renderEncoder
                              numberOfVertices:6
                                  numberOfPIUs:0
-                                vertexBuffers:@{ @(iTermVertexInputIndexVertices): tState.vertexBuffer }
+                                vertexBuffers:@{ @(iTermVertexInputIndexVertices): tState.horizontalVertexBuffer }
                               fragmentBuffers:@{}
-                                     textures:@{ @(iTermTextureIndexPrimary): tState.texture } ];
-    }
-
-    if (tState.column >= 0 && self.verticalEnabled) {
+                                     textures:@{ @(iTermTextureIndexPrimary): tState.horizontalTexture } ];
         [_cellRenderer drawWithTransientState:tState
                                 renderEncoder:frameData.renderEncoder
                              numberOfVertices:6
                                  numberOfPIUs:0
-                                vertexBuffers:@{ @(iTermVertexInputIndexVertices): tState.verticalGuideVertexBuffer }
+                                vertexBuffers:@{ @(iTermVertexInputIndexVertices): tState.upperVertexBuffer }
                               fragmentBuffers:@{}
-                                     textures:@{ @(iTermTextureIndexPrimary): tState.texture } ];
+                                     textures:@{ @(iTermTextureIndexPrimary): tState.verticalTexture } ];
+        [_cellRenderer drawWithTransientState:tState
+                                renderEncoder:frameData.renderEncoder
+                             numberOfVertices:6
+                                 numberOfPIUs:0
+                                vertexBuffers:@{ @(iTermVertexInputIndexVertices): tState.lowerVertexBuffer }
+                              fragmentBuffers:@{}
+                                     textures:@{ @(iTermTextureIndexPrimary): tState.verticalTexture } ];
+    } else if (tState.row >= 0 && self.horizontalEnabled) {
+        [tState initializeVerticesWithPool:_cellRenderer.verticesPool horizontal:TRUE vertical:FALSE];
+        [_cellRenderer drawWithTransientState:tState
+                                renderEncoder:frameData.renderEncoder
+                             numberOfVertices:6
+                                 numberOfPIUs:0
+                                vertexBuffers:@{ @(iTermVertexInputIndexVertices): tState.horizontalVertexBuffer }
+                              fragmentBuffers:@{}
+                                     textures:@{ @(iTermTextureIndexPrimary): tState.horizontalTexture } ];
+    } else if (tState.column >= 0 && self.verticalEnabled) {
+        [tState initializeVerticesWithPool:_cellRenderer.verticesPool horizontal:FALSE vertical:TRUE];
+        [_cellRenderer drawWithTransientState:tState
+                                renderEncoder:frameData.renderEncoder
+                             numberOfVertices:6
+                                 numberOfPIUs:0
+                                vertexBuffers:@{ @(iTermVertexInputIndexVertices): tState.verticalVertexBuffer }
+                              fragmentBuffers:@{}
+                                     textures:@{ @(iTermTextureIndexPrimary): tState.verticalTexture } ];
     }
 }
 
 #pragma mark - Private
 
-- (id<MTLTexture>)newCursorGuideTextureWithTransientState:(iTermCursorGuideRendererTransientState *)tState {
+- (id<MTLTexture>)newCursorGuideTextureWithTransientState:(iTermCursorGuideRendererTransientState *)tState
+                                             isHorizontal:(BOOL)isHorizontal {
     NSImage *image = [[NSImage alloc] initWithSize:tState.cellConfiguration.cellSize];
-
     [image lockFocus];
     {
         [_color set];
@@ -166,11 +228,19 @@
                                  tState.cellConfiguration.cellSize.height);
         NSRectFillUsingOperation(rect, NSCompositingOperationSourceOver);
 
-        rect.size.height = tState.cellConfiguration.scale;
-        NSRectFillUsingOperation(rect, NSCompositingOperationSourceOver);
+        if (isHorizontal) {
+            rect.size.height = tState.cellConfiguration.scale;
+            NSRectFillUsingOperation(rect, NSCompositingOperationSourceOver);
 
-        rect.origin.y += tState.cellConfiguration.cellSize.height - tState.cellConfiguration.scale;
-        NSRectFillUsingOperation(rect, NSCompositingOperationSourceOver);
+            rect.origin.y += tState.cellConfiguration.cellSize.height - tState.cellConfiguration.scale;
+            NSRectFillUsingOperation(rect, NSCompositingOperationSourceOver);
+        } else {
+            rect.size.width = tState.cellConfiguration.scale;
+            NSRectFillUsingOperation(rect, NSCompositingOperationSourceOver);
+
+            rect.origin.x += tState.cellConfiguration.cellSize.width - tState.cellConfiguration.scale;
+            NSRectFillUsingOperation(rect, NSCompositingOperationSourceOver);
+        }
     }
     [image unlockFocus];
 

--- a/sources/Metal/Renderers/iTermCursorGuideRenderer.m
+++ b/sources/Metal/Renderers/iTermCursorGuideRenderer.m
@@ -3,17 +3,17 @@
 @interface iTermCursorGuideRendererTransientState()
 @property (nonatomic, strong) id<MTLTexture> texture;
 @property (nonatomic) int row;
-@property (nonatomic) int col;
+@property (nonatomic) int column;
 @end
 
 @implementation iTermCursorGuideRendererTransientState {
     int _row;
-    int _col;
+    int _column;
 }
 
 - (void)setCursorCoord:(VT100GridCoord)coord within:(VT100GridSize)bounds {
     _row = (0 <= coord.y && coord.y < bounds.height) ? coord.y : -1;
-    _col = (0 <= coord.x && coord.x < bounds.width)  ? coord.x : -1;
+    _column = (0 <= coord.x && coord.x < bounds.width)  ? coord.x : -1;
 }
 
 - (void)initializeVerticesWithPool:(iTermMetalBufferPool *)verticesPool {
@@ -39,22 +39,22 @@
                                                      withBytes:vertices
                                                 checkIfChanged:YES];
 
-    const CGRect vQuad = CGRectMake(self.margins.left + self.col * cellSize.width,
-                                    self.margins.top,
-                                    cellSize.width,
-                                    cellSize.height * gridSize.height);
-    const iTermVertex vvertices[] = {
-        { { CGRectGetMaxX(vQuad), CGRectGetMinY(vQuad) }, { CGRectGetMaxX(textureFrame), CGRectGetMinY(textureFrame) } },
-        { { CGRectGetMinX(vQuad), CGRectGetMinY(vQuad) }, { CGRectGetMinX(textureFrame), CGRectGetMinY(textureFrame) } },
-        { { CGRectGetMinX(vQuad), CGRectGetMaxY(vQuad) }, { CGRectGetMinX(textureFrame), CGRectGetMaxY(textureFrame) } },
+    const CGRect verticalGuideQuad = CGRectMake(self.margins.left + self.column * cellSize.width,
+                                                self.margins.top,
+                                                cellSize.width,
+                                                cellSize.height * gridSize.height);
+    const iTermVertex verticalGuideVertices[] = {
+        { { CGRectGetMaxX(verticalGuideQuad), CGRectGetMinY(verticalGuideQuad) }, { CGRectGetMaxX(textureFrame), CGRectGetMinY(textureFrame) } },
+        { { CGRectGetMinX(verticalGuideQuad), CGRectGetMinY(verticalGuideQuad) }, { CGRectGetMinX(textureFrame), CGRectGetMinY(textureFrame) } },
+        { { CGRectGetMinX(verticalGuideQuad), CGRectGetMaxY(verticalGuideQuad) }, { CGRectGetMinX(textureFrame), CGRectGetMaxY(textureFrame) } },
 
-        { { CGRectGetMaxX(vQuad), CGRectGetMinY(vQuad) }, { CGRectGetMaxX(textureFrame), CGRectGetMinY(textureFrame) } },
-        { { CGRectGetMinX(vQuad), CGRectGetMaxY(vQuad) }, { CGRectGetMinX(textureFrame), CGRectGetMaxY(textureFrame) } },
-        { { CGRectGetMaxX(vQuad), CGRectGetMaxY(vQuad) }, { CGRectGetMaxX(textureFrame), CGRectGetMaxY(textureFrame) } },
+        { { CGRectGetMaxX(verticalGuideQuad), CGRectGetMinY(verticalGuideQuad) }, { CGRectGetMaxX(textureFrame), CGRectGetMinY(textureFrame) } },
+        { { CGRectGetMinX(verticalGuideQuad), CGRectGetMaxY(verticalGuideQuad) }, { CGRectGetMinX(textureFrame), CGRectGetMaxY(textureFrame) } },
+        { { CGRectGetMaxX(verticalGuideQuad), CGRectGetMaxY(verticalGuideQuad) }, { CGRectGetMaxX(textureFrame), CGRectGetMaxY(textureFrame) } },
     };
-    self.vvertexBuffer = [verticesPool requestBufferFromContext:self.poolContext
-                                                      withBytes:vvertices
-                                                 checkIfChanged:YES];
+    self.verticalGuideVertexBuffer = [verticesPool requestBufferFromContext:self.poolContext
+                                                                  withBytes:verticalGuideVertices
+                                                             checkIfChanged:YES];
 }
 
 - (void)writeDebugInfoToFolder:(NSURL *)folder {
@@ -126,7 +126,7 @@
 - (void)drawWithFrameData:(iTermMetalFrameData *)frameData
            transientState:(__kindof iTermMetalCellRendererTransientState *)transientState {
     iTermCursorGuideRendererTransientState *tState = transientState;
-    if (tState.row < 0 || tState.col < 0) {
+    if (tState.row < 0 || tState.column < 0) {
         return;
     }
 
@@ -141,12 +141,12 @@
                                      textures:@{ @(iTermTextureIndexPrimary): tState.texture } ];
     }
 
-    if (tState.col >= 0 && self.venabled) {
+    if (tState.column >= 0 && self.verticalEnabled) {
         [_cellRenderer drawWithTransientState:tState
                                 renderEncoder:frameData.renderEncoder
                              numberOfVertices:6
                                  numberOfPIUs:0
-                                vertexBuffers:@{ @(iTermVertexInputIndexVertices): tState.vvertexBuffer }
+                                vertexBuffers:@{ @(iTermVertexInputIndexVertices): tState.verticalGuideVertexBuffer }
                               fragmentBuffers:@{}
                                      textures:@{ @(iTermTextureIndexPrimary): tState.texture } ];
     }

--- a/sources/Metal/Renderers/iTermCursorGuideRenderer.m
+++ b/sources/Metal/Renderers/iTermCursorGuideRenderer.m
@@ -14,7 +14,8 @@
     id<MTLBuffer> _upperVertexBuffer, _lowerVertexBuffer;
 }
 
-- (void)setCursorCoord:(VT100GridCoord)coord within:(VT100GridSize)bounds {
+- (void)setCursorCoord:(VT100GridCoord)coord {
+    VT100GridSize bounds = self.cellConfiguration.gridSize;
     _row = (0 <= coord.y && coord.y < bounds.height) ? coord.y : -1;
     _column = (0 <= coord.x && coord.x < bounds.width)  ? coord.x : -1;
 }

--- a/sources/Metal/Renderers/iTermCursorGuideRenderer.m
+++ b/sources/Metal/Renderers/iTermCursorGuideRenderer.m
@@ -40,26 +40,6 @@
                                    checkIfChanged:YES];
 }
 
-- (id<MTLBuffer>)tessellateRect:(CGRect)rect withTexture:(CGRect)textureRect withPool:(iTermMetalBufferPool *)verticesPool {
-    // Tesselates an axis-aligned rectangle into a sequence of vertices
-    // representing two adjacent triangles that share the diagonal of the
-    // rectangle:
-    //  top-right, top-left, bottom-left, top-right, bottom-left, bottom-right
-    const iTermVertex vertices[] = {
-        // Pixel Positions                              Texture Coordinates
-        { { CGRectGetMaxX(rect), CGRectGetMinY(rect) }, { CGRectGetMaxX(textureRect), CGRectGetMinY(textureRect) } },
-        { { CGRectGetMinX(rect), CGRectGetMinY(rect) }, { CGRectGetMinX(textureRect), CGRectGetMinY(textureRect) } },
-        { { CGRectGetMinX(rect), CGRectGetMaxY(rect) }, { CGRectGetMinX(textureRect), CGRectGetMaxY(textureRect) } },
-
-        { { CGRectGetMaxX(rect), CGRectGetMinY(rect) }, { CGRectGetMaxX(textureRect), CGRectGetMinY(textureRect) } },
-        { { CGRectGetMinX(rect), CGRectGetMaxY(rect) }, { CGRectGetMinX(textureRect), CGRectGetMaxY(textureRect) } },
-        { { CGRectGetMaxX(rect), CGRectGetMaxY(rect) }, { CGRectGetMaxX(textureRect), CGRectGetMaxY(textureRect) } },
-    };
-    return [verticesPool requestBufferFromContext:self.poolContext
-                                        withBytes:vertices
-                                   checkIfChanged:YES];
-}
-
 - (void)setCursorCoord:(VT100GridCoord)coord {
     VT100GridSize bounds = self.cellConfiguration.gridSize;
     _row = (0 <= coord.y && coord.y < bounds.height) ? coord.y : -1;

--- a/sources/Metal/Renderers/iTermCursorGuideRenderer.m
+++ b/sources/Metal/Renderers/iTermCursorGuideRenderer.m
@@ -1,40 +1,108 @@
 #import "iTermCursorGuideRenderer.h"
 
 @interface iTermCursorGuideRendererTransientState()
-@property (nonatomic, strong) id<MTLTexture> texture;
+@property (nonatomic, strong) id<MTLTexture> horizontalTexture;
+@property (nonatomic, strong) id<MTLTexture> verticalTexture;
 @property (nonatomic) int row;
+@property (nonatomic) int column;
+@property (nonatomic) id<MTLBuffer> horizontalVertexBuffer;
+@property (nonatomic) id<MTLBuffer> verticalVertexBuffer;
+@property (nonatomic) id<MTLBuffer> upperVertexBuffer;
+@property (nonatomic) id<MTLBuffer> lowerVertexBuffer;
 @end
 
 @implementation iTermCursorGuideRendererTransientState {
     int _row;
+    int _column;
+    id<MTLBuffer> _horizontalVertexBuffer;
+    id<MTLBuffer> _verticalVertexBuffer;
+    id<MTLBuffer> _upperVertexBuffer;
+    id<MTLBuffer> _lowerVertexBuffer;
 }
 
-- (void)setRow:(int)row {
-    _row = row;
+- (id<MTLBuffer>)tessellateRect:(CGRect)rect withTexture:(CGRect)textureRect withPool:(iTermMetalBufferPool *)verticesPool {
+    // Tesselates an axis-aligned rectangle into a sequence of vertices
+    // representing two adjacent triangles that share the diagonal of the
+    // rectangle:
+    //  top-right, top-left, bottom-left, top-right, bottom-left, bottom-right
+    const iTermVertex vertices[] = {
+        // Pixel Positions                              Texture Coordinates
+        { { CGRectGetMaxX(rect), CGRectGetMinY(rect) }, { CGRectGetMaxX(textureRect), CGRectGetMinY(textureRect) } },
+        { { CGRectGetMinX(rect), CGRectGetMinY(rect) }, { CGRectGetMinX(textureRect), CGRectGetMinY(textureRect) } },
+        { { CGRectGetMinX(rect), CGRectGetMaxY(rect) }, { CGRectGetMinX(textureRect), CGRectGetMaxY(textureRect) } },
+
+        { { CGRectGetMaxX(rect), CGRectGetMinY(rect) }, { CGRectGetMaxX(textureRect), CGRectGetMinY(textureRect) } },
+        { { CGRectGetMinX(rect), CGRectGetMaxY(rect) }, { CGRectGetMinX(textureRect), CGRectGetMaxY(textureRect) } },
+        { { CGRectGetMaxX(rect), CGRectGetMaxY(rect) }, { CGRectGetMaxX(textureRect), CGRectGetMaxY(textureRect) } },
+    };
+    return [verticesPool requestBufferFromContext:self.poolContext
+                                        withBytes:vertices
+                                   checkIfChanged:YES];
 }
 
-- (void)initializeVerticesWithPool:(iTermMetalBufferPool *)verticesPool {
+- (id<MTLBuffer>)tessellateRect:(CGRect)rect withTexture:(CGRect)textureRect withPool:(iTermMetalBufferPool *)verticesPool {
+    // Tesselates an axis-aligned rectangle into a sequence of vertices
+    // representing two adjacent triangles that share the diagonal of the
+    // rectangle:
+    //  top-right, top-left, bottom-left, top-right, bottom-left, bottom-right
+    const iTermVertex vertices[] = {
+        // Pixel Positions                              Texture Coordinates
+        { { CGRectGetMaxX(rect), CGRectGetMinY(rect) }, { CGRectGetMaxX(textureRect), CGRectGetMinY(textureRect) } },
+        { { CGRectGetMinX(rect), CGRectGetMinY(rect) }, { CGRectGetMinX(textureRect), CGRectGetMinY(textureRect) } },
+        { { CGRectGetMinX(rect), CGRectGetMaxY(rect) }, { CGRectGetMinX(textureRect), CGRectGetMaxY(textureRect) } },
+
+        { { CGRectGetMaxX(rect), CGRectGetMinY(rect) }, { CGRectGetMaxX(textureRect), CGRectGetMinY(textureRect) } },
+        { { CGRectGetMinX(rect), CGRectGetMaxY(rect) }, { CGRectGetMinX(textureRect), CGRectGetMaxY(textureRect) } },
+        { { CGRectGetMaxX(rect), CGRectGetMaxY(rect) }, { CGRectGetMaxX(textureRect), CGRectGetMaxY(textureRect) } },
+    };
+    return [verticesPool requestBufferFromContext:self.poolContext
+                                        withBytes:vertices
+                                   checkIfChanged:YES];
+}
+
+- (void)setCursorCoord:(VT100GridCoord)coord {
+    VT100GridSize bounds = self.cellConfiguration.gridSize;
+    _row = (0 <= coord.y && coord.y < bounds.height) ? coord.y : -1;
+    _column = (0 <= coord.x && coord.x < bounds.width)  ? coord.x : -1;
+}
+
+- (void)initializeVerticesWithPool:(iTermMetalBufferPool *)verticesPool
+                        horizontal:(BOOL)horizontal
+                          vertical:(BOOL)vertical {
+    assert(horizontal || vertical);
     CGSize cellSize = self.cellConfiguration.cellSize;
     VT100GridSize gridSize = self.cellConfiguration.gridSize;
 
-    const CGRect quad = CGRectMake(self.margins.left,
-                                   self.margins.top + (gridSize.height - self.row - 1) * cellSize.height,
-                                   cellSize.width * gridSize.width,
-                                   cellSize.height);
     const CGRect textureFrame = CGRectMake(0, 0, 1, 1);
-    const iTermVertex vertices[] = {
-        // Pixel Positions                              Texture Coordinates
-        { { CGRectGetMaxX(quad), CGRectGetMinY(quad) }, { CGRectGetMaxX(textureFrame), CGRectGetMinY(textureFrame) } },
-        { { CGRectGetMinX(quad), CGRectGetMinY(quad) }, { CGRectGetMinX(textureFrame), CGRectGetMinY(textureFrame) } },
-        { { CGRectGetMinX(quad), CGRectGetMaxY(quad) }, { CGRectGetMinX(textureFrame), CGRectGetMaxY(textureFrame) } },
 
-        { { CGRectGetMaxX(quad), CGRectGetMinY(quad) }, { CGRectGetMaxX(textureFrame), CGRectGetMinY(textureFrame) } },
-        { { CGRectGetMinX(quad), CGRectGetMaxY(quad) }, { CGRectGetMinX(textureFrame), CGRectGetMaxY(textureFrame) } },
-        { { CGRectGetMaxX(quad), CGRectGetMaxY(quad) }, { CGRectGetMaxX(textureFrame), CGRectGetMaxY(textureFrame) } },
-    };
-    self.vertexBuffer = [verticesPool requestBufferFromContext:self.poolContext
-                                                     withBytes:vertices
-                                                checkIfChanged:YES];
+    CGFloat viewMinX = self.margins.left, viewMinY = self.margins.top;
+    CGFloat viewMaxX = viewMinX + cellSize.width*gridSize.width, viewMaxY = viewMinY + cellSize.height*gridSize.height;
+
+    CGFloat cursorMinX = self.margins.left + self.column * cellSize.width, cursorMinY = self.margins.top + (gridSize.height - self.row - 1) * cellSize.height;
+    CGFloat cursorMaxY = cursorMinY + cellSize.height;
+
+    if (horizontal) {
+        self.horizontalVertexBuffer = [self tessellateRect:CGRectMake(viewMinX, cursorMinY,
+                                                                     viewMaxX - viewMinX, cellSize.height)
+                                              withTexture:textureFrame
+                                                 withPool:verticesPool];
+    }
+
+    if (horizontal && vertical) {
+        self.lowerVertexBuffer = [self tessellateRect:CGRectMake(cursorMinX, viewMinY,
+                                                                cellSize.width, cursorMinY - viewMinY)
+                                         withTexture:textureFrame
+                                            withPool:verticesPool];
+        self.upperVertexBuffer = [self tessellateRect:CGRectMake(cursorMinX, cursorMaxY,
+                                                                cellSize.width, viewMaxY - cursorMaxY)
+                                         withTexture:textureFrame
+                                            withPool:verticesPool];
+    } else if (vertical) {
+        self.verticalVertexBuffer = [self tessellateRect:CGRectMake(cursorMinX, viewMinY,
+                                                                   cellSize.width, viewMaxY - viewMinY)
+                                            withTexture:textureFrame
+                                               withPool:verticesPool];
+    }
 }
 
 - (void)writeDebugInfoToFolder:(NSURL *)folder {
@@ -49,7 +117,8 @@
 
 @implementation iTermCursorGuideRenderer {
     iTermMetalCellRenderer *_cellRenderer;
-    id<MTLTexture> _texture;
+    id<MTLTexture> _horizontalTexture;
+    id<MTLTexture> _verticalTexture;
     NSColor *_color;
     CGSize _lastCellSize;
 }
@@ -78,7 +147,7 @@
 
 - (nullable __kindof iTermMetalRendererTransientState *)createTransientStateForCellConfiguration:(iTermCellRenderConfiguration *)configuration
                                                                                    commandBuffer:(id<MTLCommandBuffer>)commandBuffer {
-    if (!_enabled) {
+    if (!_horizontalEnabled && !_verticalEnabled) {
         return nil;
     }
     __kindof iTermMetalCellRendererTransientState * _Nonnull transientState =
@@ -90,10 +159,14 @@
 
 - (void)initializeTransientState:(iTermCursorGuideRendererTransientState *)tState {
     if (!CGSizeEqualToSize(tState.cellConfiguration.cellSize, _lastCellSize)) {
-        _texture = [self newCursorGuideTextureWithTransientState:tState];
+        _horizontalTexture = [self newCursorGuideTextureWithTransientState:tState
+                                                              isHorizontal:YES];
+        _verticalTexture   = [self newCursorGuideTextureWithTransientState:tState
+                                                              isHorizontal:NO];
         _lastCellSize = tState.cellConfiguration.cellSize;
     }
-    tState.texture = _texture;
+    tState.horizontalTexture = _horizontalTexture;
+    tState.verticalTexture   = _verticalTexture;
 }
 
 - (void)setColor:(NSColor *)color {
@@ -106,26 +179,59 @@
 - (void)drawWithFrameData:(iTermMetalFrameData *)frameData
            transientState:(__kindof iTermMetalCellRendererTransientState *)transientState {
     iTermCursorGuideRendererTransientState *tState = transientState;
-    if (tState.row < 0) {
-        // Cursor is offscreen. We set it to -1 to signal this.
+    if (tState.row < 0 && tState.column < 0) {
         return;
     }
 
-    [tState initializeVerticesWithPool:_cellRenderer.verticesPool];
-    [_cellRenderer drawWithTransientState:tState
-                            renderEncoder:frameData.renderEncoder
-                         numberOfVertices:6
-                             numberOfPIUs:0
-                            vertexBuffers:@{ @(iTermVertexInputIndexVertices): tState.vertexBuffer }
-                          fragmentBuffers:@{}
-                                 textures:@{ @(iTermTextureIndexPrimary): tState.texture } ];
+    if (tState.row >= 0 && tState.column >= 0 && self.horizontalEnabled && self.verticalEnabled) {
+        [tState initializeVerticesWithPool:_cellRenderer.verticesPool horizontal:YES vertical:YES];
+        [_cellRenderer drawWithTransientState:tState
+                                renderEncoder:frameData.renderEncoder
+                             numberOfVertices:6
+                                 numberOfPIUs:0
+                                vertexBuffers:@{ @(iTermVertexInputIndexVertices): tState.horizontalVertexBuffer }
+                              fragmentBuffers:@{}
+                                     textures:@{ @(iTermTextureIndexPrimary): tState.horizontalTexture } ];
+        [_cellRenderer drawWithTransientState:tState
+                                renderEncoder:frameData.renderEncoder
+                             numberOfVertices:6
+                                 numberOfPIUs:0
+                                vertexBuffers:@{ @(iTermVertexInputIndexVertices): tState.upperVertexBuffer }
+                              fragmentBuffers:@{}
+                                     textures:@{ @(iTermTextureIndexPrimary): tState.verticalTexture } ];
+        [_cellRenderer drawWithTransientState:tState
+                                renderEncoder:frameData.renderEncoder
+                             numberOfVertices:6
+                                 numberOfPIUs:0
+                                vertexBuffers:@{ @(iTermVertexInputIndexVertices): tState.lowerVertexBuffer }
+                              fragmentBuffers:@{}
+                                     textures:@{ @(iTermTextureIndexPrimary): tState.verticalTexture } ];
+    } else if (tState.row >= 0 && self.horizontalEnabled) {
+        [tState initializeVerticesWithPool:_cellRenderer.verticesPool horizontal:YES vertical:NO];
+        [_cellRenderer drawWithTransientState:tState
+                                renderEncoder:frameData.renderEncoder
+                             numberOfVertices:6
+                                 numberOfPIUs:0
+                                vertexBuffers:@{ @(iTermVertexInputIndexVertices): tState.horizontalVertexBuffer }
+                              fragmentBuffers:@{}
+                                     textures:@{ @(iTermTextureIndexPrimary): tState.horizontalTexture } ];
+    } else if (tState.column >= 0 && self.verticalEnabled) {
+        [tState initializeVerticesWithPool:_cellRenderer.verticesPool horizontal:NO vertical:YES];
+        [_cellRenderer drawWithTransientState:tState
+                                renderEncoder:frameData.renderEncoder
+                             numberOfVertices:6
+                                 numberOfPIUs:0
+                                vertexBuffers:@{ @(iTermVertexInputIndexVertices): tState.verticalVertexBuffer }
+                              fragmentBuffers:@{}
+                                     textures:@{ @(iTermTextureIndexPrimary): tState.verticalTexture } ];
+    }
 }
 
 #pragma mark - Private
 
-- (id<MTLTexture>)newCursorGuideTextureWithTransientState:(iTermCursorGuideRendererTransientState *)tState {
+- (id<MTLTexture>)newCursorGuideTextureWithTransientState:(iTermCursorGuideRendererTransientState *)tState
+                                             isHorizontal:(BOOL)isHorizontal {
     NSImage *image = [[NSImage alloc] initWithSize:tState.cellConfiguration.cellSize];
-
     [image lockFocus];
     {
         [_color set];
@@ -135,11 +241,19 @@
                                  tState.cellConfiguration.cellSize.height);
         NSRectFillUsingOperation(rect, NSCompositingOperationSourceOver);
 
-        rect.size.height = tState.cellConfiguration.scale;
-        NSRectFillUsingOperation(rect, NSCompositingOperationSourceOver);
+        if (isHorizontal) {
+            rect.size.height = tState.cellConfiguration.scale;
+            NSRectFillUsingOperation(rect, NSCompositingOperationSourceOver);
 
-        rect.origin.y += tState.cellConfiguration.cellSize.height - tState.cellConfiguration.scale;
-        NSRectFillUsingOperation(rect, NSCompositingOperationSourceOver);
+            rect.origin.y += tState.cellConfiguration.cellSize.height - tState.cellConfiguration.scale;
+            NSRectFillUsingOperation(rect, NSCompositingOperationSourceOver);
+        } else {
+            rect.size.width = tState.cellConfiguration.scale;
+            NSRectFillUsingOperation(rect, NSCompositingOperationSourceOver);
+
+            rect.origin.x += tState.cellConfiguration.cellSize.width - tState.cellConfiguration.scale;
+            NSRectFillUsingOperation(rect, NSCompositingOperationSourceOver);
+        }
     }
     [image unlockFocus];
 

--- a/sources/Metal/Renderers/iTermCursorGuideRenderer.m
+++ b/sources/Metal/Renderers/iTermCursorGuideRenderer.m
@@ -14,7 +14,28 @@
     id<MTLBuffer> _upperVertexBuffer, _lowerVertexBuffer;
 }
 
-- (void)setCursorCoord:(VT100GridCoord)coord within:(VT100GridSize)bounds {
+- (id<MTLBuffer>)tessellateRect:(CGRect)rect withTexture:(CGRect)textureRect withPool:(iTermMetalBufferPool *)verticesPool {
+    // Tesselates an axis-aligned rectangle into a sequence of vertices
+    // representing two adjacent triangles that share the diagonal of the
+    // rectangle:
+    //  top-right, top-left, bottom-left, top-right, bottom-left, bottom-right
+    const iTermVertex vertices[] = {
+        // Pixel Positions                              Texture Coordinates
+        { { CGRectGetMaxX(rect), CGRectGetMinY(rect) }, { CGRectGetMaxX(textureRect), CGRectGetMinY(textureRect) } },
+        { { CGRectGetMinX(rect), CGRectGetMinY(rect) }, { CGRectGetMinX(textureRect), CGRectGetMinY(textureRect) } },
+        { { CGRectGetMinX(rect), CGRectGetMaxY(rect) }, { CGRectGetMinX(textureRect), CGRectGetMaxY(textureRect) } },
+
+        { { CGRectGetMaxX(rect), CGRectGetMinY(rect) }, { CGRectGetMaxX(textureRect), CGRectGetMinY(textureRect) } },
+        { { CGRectGetMinX(rect), CGRectGetMaxY(rect) }, { CGRectGetMinX(textureRect), CGRectGetMaxY(textureRect) } },
+        { { CGRectGetMaxX(rect), CGRectGetMaxY(rect) }, { CGRectGetMaxX(textureRect), CGRectGetMaxY(textureRect) } },
+    };
+    return [verticesPool requestBufferFromContext:self.poolContext
+                                        withBytes:vertices
+                                   checkIfChanged:YES];
+}
+
+- (void)setCursorCoord:(VT100GridCoord)coord {
+    VT100GridSize bounds = self.cellConfiguration.gridSize;
     _row = (0 <= coord.y && coord.y < bounds.height) ? coord.y : -1;
     _column = (0 <= coord.x && coord.x < bounds.width)  ? coord.x : -1;
 }
@@ -31,65 +52,29 @@
     CGFloat viewMaxX = viewMinX + cellSize.width*gridSize.width, viewMaxY = viewMinY + cellSize.height*gridSize.height;
 
     CGFloat cursorMinX = self.margins.left + self.column * cellSize.width, cursorMinY = self.margins.top + (gridSize.height - self.row - 1) * cellSize.height;
-    CGFloat cursorMaxX = cursorMinX + cellSize.width, cursorMaxY = cursorMinY + cellSize.height;
+    CGFloat cursorMaxY = cursorMinY + cellSize.height;
 
     if (horizontal) {
-        const iTermVertex vertices[] = {
-            // Pixel Positions                              Texture Coordinates
-            { { viewMaxX, cursorMinY }, { CGRectGetMaxX(textureFrame), CGRectGetMinY(textureFrame) } },
-            { { viewMinX, cursorMinY }, { CGRectGetMinX(textureFrame), CGRectGetMinY(textureFrame) } },
-            { { viewMinX, cursorMaxY }, { CGRectGetMinX(textureFrame), CGRectGetMaxY(textureFrame) } },
-
-            { { viewMaxX, cursorMinY }, { CGRectGetMaxX(textureFrame), CGRectGetMinY(textureFrame) } },
-            { { viewMinX, cursorMaxY }, { CGRectGetMinX(textureFrame), CGRectGetMaxY(textureFrame) } },
-            { { viewMaxX, cursorMaxY }, { CGRectGetMaxX(textureFrame), CGRectGetMaxY(textureFrame) } },
-        };
-        self.horizontalVertexBuffer = [verticesPool requestBufferFromContext:self.poolContext
-                                                                   withBytes:vertices
-                                                              checkIfChanged:YES];
+        self.horizontalVertexBuffer = [self tessellateRect:CGRectMake(viewMinX, cursorMinY,
+                                                                     viewMaxX - viewMinX, cellSize.height)
+                                              withTexture:textureFrame
+                                                 withPool:verticesPool];
     }
 
     if (horizontal && vertical) {
-        const iTermVertex lowerVertices[] = {
-            // Pixel Positions                              Texture Coordinates
-            { { cursorMaxX, viewMinY },   { CGRectGetMaxX(textureFrame), CGRectGetMinY(textureFrame) } },
-            { { cursorMinX, viewMinY },   { CGRectGetMinX(textureFrame), CGRectGetMinY(textureFrame) } },
-            { { cursorMinX, cursorMinY }, { CGRectGetMinX(textureFrame), CGRectGetMaxY(textureFrame) } },
-
-            { { cursorMaxX, viewMinY },   { CGRectGetMaxX(textureFrame), CGRectGetMinY(textureFrame) } },
-            { { cursorMinX, cursorMinY }, { CGRectGetMinX(textureFrame), CGRectGetMaxY(textureFrame) } },
-            { { cursorMaxX, cursorMinY }, { CGRectGetMaxX(textureFrame), CGRectGetMaxY(textureFrame) } },
-        };
-        self.lowerVertexBuffer = [verticesPool requestBufferFromContext:self.poolContext
-                                                              withBytes:lowerVertices
-                                                         checkIfChanged:YES];
-        const iTermVertex upperVertices[] = {
-            // Pixel Positions                              Texture Coordinates
-            { { cursorMaxX, cursorMaxY }, { CGRectGetMaxX(textureFrame), CGRectGetMinY(textureFrame) } },
-            { { cursorMinX, cursorMaxY }, { CGRectGetMinX(textureFrame), CGRectGetMinY(textureFrame) } },
-            { { cursorMinX, viewMaxY },   { CGRectGetMinX(textureFrame), CGRectGetMaxY(textureFrame) } },
-
-            { { cursorMaxX, cursorMaxY }, { CGRectGetMaxX(textureFrame), CGRectGetMinY(textureFrame) } },
-            { { cursorMinX, viewMaxY },   { CGRectGetMinX(textureFrame), CGRectGetMaxY(textureFrame) } },
-            { { cursorMaxX, viewMaxY },   { CGRectGetMaxX(textureFrame), CGRectGetMaxY(textureFrame) } },
-        };
-        self.upperVertexBuffer = [verticesPool requestBufferFromContext:self.poolContext
-                                                              withBytes:upperVertices
-                                                         checkIfChanged:YES];
+        self.lowerVertexBuffer = [self tessellateRect:CGRectMake(cursorMinX, viewMinY,
+                                                                cellSize.width, cursorMinY - viewMinY)
+                                         withTexture:textureFrame
+                                            withPool:verticesPool];
+        self.upperVertexBuffer = [self tessellateRect:CGRectMake(cursorMinX, cursorMaxY,
+                                                                cellSize.width, viewMaxY - cursorMaxY)
+                                         withTexture:textureFrame
+                                            withPool:verticesPool];
     } else if (vertical) {
-        const iTermVertex vertices[] = {
-            // Pixel Positions                              Texture Coordinates
-            { { cursorMaxX, viewMinY }, { CGRectGetMaxX(textureFrame), CGRectGetMinY(textureFrame) } },
-            { { cursorMinX, viewMinY }, { CGRectGetMinX(textureFrame), CGRectGetMinY(textureFrame) } },
-            { { cursorMinX, viewMaxY }, { CGRectGetMinX(textureFrame), CGRectGetMaxY(textureFrame) } },
-
-            { { cursorMaxX, viewMinY }, { CGRectGetMaxX(textureFrame), CGRectGetMinY(textureFrame) } },
-            { { cursorMinX, viewMaxY }, { CGRectGetMinX(textureFrame), CGRectGetMaxY(textureFrame) } },
-            { { cursorMaxX, viewMaxY }, { CGRectGetMaxX(textureFrame), CGRectGetMaxY(textureFrame) } },
-        };
-        self.verticalVertexBuffer = [verticesPool requestBufferFromContext:self.poolContext
-                                                                 withBytes:vertices
-                                                            checkIfChanged:YES];
+        self.verticalVertexBuffer = [self tessellateRect:CGRectMake(cursorMinX, viewMinY,
+                                                                   cellSize.width, viewMaxY - viewMinY)
+                                            withTexture:textureFrame
+                                               withPool:verticesPool];
     }
 }
 

--- a/sources/Metal/iTermMetalDriver.h
+++ b/sources/Metal/iTermMetalDriver.h
@@ -60,7 +60,8 @@ NS_CLASS_AVAILABLE(10_11, NA)
 @property (nonatomic, nullable, readonly) iTermMetalIMEInfo *imeInfo;
 @property (nonatomic, readonly) BOOL showBroadcastStripes;
 @property (nonatomic, readonly) NSColor *cursorGuideColor;
-@property (nonatomic, readonly) BOOL cursorGuideEnabled;
+@property (nonatomic, readonly) BOOL cursorHorizontalGuideEnabled;
+@property (nonatomic, readonly) BOOL cursorVerticalGuideEnabled;
 @property (nonatomic, readonly) vector_float4 fullScreenFlashColor;
 @property (nonatomic, readonly) BOOL timestampsEnabled;
 @property (nonatomic, readonly) NSColor *timestampsBackgroundColor;

--- a/sources/Metal/iTermMetalDriver.h
+++ b/sources/Metal/iTermMetalDriver.h
@@ -61,7 +61,7 @@ NS_CLASS_AVAILABLE(10_11, NA)
 @property (nonatomic, readonly) BOOL showBroadcastStripes;
 @property (nonatomic, readonly) NSColor *cursorGuideColor;
 @property (nonatomic, readonly) BOOL cursorGuideEnabled;
-@property (nonatomic, readonly) BOOL cursorVGuideEnabled;
+@property (nonatomic, readonly) BOOL cursorVerticalGuideEnabled;
 @property (nonatomic, readonly) vector_float4 fullScreenFlashColor;
 @property (nonatomic, readonly) BOOL timestampsEnabled;
 @property (nonatomic, readonly) NSColor *timestampsBackgroundColor;

--- a/sources/Metal/iTermMetalDriver.h
+++ b/sources/Metal/iTermMetalDriver.h
@@ -61,6 +61,7 @@ NS_CLASS_AVAILABLE(10_11, NA)
 @property (nonatomic, readonly) BOOL showBroadcastStripes;
 @property (nonatomic, readonly) NSColor *cursorGuideColor;
 @property (nonatomic, readonly) BOOL cursorGuideEnabled;
+@property (nonatomic, readonly) BOOL cursorVGuideEnabled;
 @property (nonatomic, readonly) vector_float4 fullScreenFlashColor;
 @property (nonatomic, readonly) BOOL timestampsEnabled;
 @property (nonatomic, readonly) NSColor *timestampsBackgroundColor;

--- a/sources/Metal/iTermMetalDriver.h
+++ b/sources/Metal/iTermMetalDriver.h
@@ -60,7 +60,7 @@ NS_CLASS_AVAILABLE(10_11, NA)
 @property (nonatomic, nullable, readonly) iTermMetalIMEInfo *imeInfo;
 @property (nonatomic, readonly) BOOL showBroadcastStripes;
 @property (nonatomic, readonly) NSColor *cursorGuideColor;
-@property (nonatomic, readonly) BOOL cursorGuideEnabled;
+@property (nonatomic, readonly) BOOL cursorHorizontalGuideEnabled;
 @property (nonatomic, readonly) BOOL cursorVerticalGuideEnabled;
 @property (nonatomic, readonly) vector_float4 fullScreenFlashColor;
 @property (nonatomic, readonly) BOOL timestampsEnabled;

--- a/sources/Metal/iTermMetalDriver.m
+++ b/sources/Metal/iTermMetalDriver.m
@@ -1219,13 +1219,8 @@ cellSizeWithoutSpacing:(CGSize)cellSizeWithoutSpacing
 
 - (void)populateCursorGuideRendererTransientStateWithFrameData:(iTermMetalFrameData *)frameData {
     iTermCursorGuideRendererTransientState *tState = [frameData transientStateForRenderer:_cursorGuideRenderer];
-    iTermMetalCursorInfo *cursorInfo = frameData.perFrameState.metalDriverCursorInfo;
-    if (cursorInfo.coord.y >= 0 &&
-        cursorInfo.coord.y < frameData.gridSize.height) {
-        [tState setRow:frameData.perFrameState.metalDriverCursorInfo.coord.y];
-    } else {
-        [tState setRow:-1];
-    }
+    VT100GridCoord coord = frameData.perFrameState.metalDriverCursorInfo.coord;
+    [tState setCursorCoord:coord within:frameData.gridSize];
 }
 
 - (void)populateTimestampsRendererTransientStateWithFrameData:(iTermMetalFrameData *)frameData {

--- a/sources/Metal/iTermMetalDriver.m
+++ b/sources/Metal/iTermMetalDriver.m
@@ -1222,7 +1222,7 @@ cellSizeWithoutSpacing:(CGSize)cellSizeWithoutSpacing
 - (void)populateCursorGuideRendererTransientStateWithFrameData:(iTermMetalFrameData *)frameData {
     iTermCursorGuideRendererTransientState *tState = [frameData transientStateForRenderer:_cursorGuideRenderer];
     VT100GridCoord coord = frameData.perFrameState.metalDriverCursorInfo.coord;
-    [tState setCursorCoord:coord within:frameData.gridSize];
+    [tState setCursorCoord:coord];
 }
 
 - (void)populateTimestampsRendererTransientStateWithFrameData:(iTermMetalFrameData *)frameData {

--- a/sources/Metal/iTermMetalDriver.m
+++ b/sources/Metal/iTermMetalDriver.m
@@ -644,7 +644,8 @@ cellSizeWithoutSpacing:(CGSize)cellSizeWithoutSpacing
     if (!_broadcastStripesRenderer.rendererDisabled && frameData.perFrameState.showBroadcastStripes) {
         return YES;
     }
-    if (!_cursorGuideRenderer.rendererDisabled && frameData.perFrameState.cursorGuideEnabled) {
+    if (!_cursorGuideRenderer.rendererDisabled && (frameData.perFrameState.cursorGuideEnabled
+                                                   || frameData.perFrameState.cursorVGuideEnabled)) {
         return YES;
     }
 
@@ -970,6 +971,7 @@ cellSizeWithoutSpacing:(CGSize)cellSizeWithoutSpacing
     }
     [_cursorGuideRenderer setColor:frameData.perFrameState.cursorGuideColor];
     _cursorGuideRenderer.enabled = frameData.perFrameState.cursorGuideEnabled;
+    _cursorGuideRenderer.venabled = frameData.perFrameState.cursorVGuideEnabled;
 }
 
 - (void)updateTimestampsRendererForFrameData:(iTermMetalFrameData *)frameData {

--- a/sources/Metal/iTermMetalDriver.m
+++ b/sources/Metal/iTermMetalDriver.m
@@ -644,7 +644,7 @@ cellSizeWithoutSpacing:(CGSize)cellSizeWithoutSpacing
     if (!_broadcastStripesRenderer.rendererDisabled && frameData.perFrameState.showBroadcastStripes) {
         return YES;
     }
-    if (!_cursorGuideRenderer.rendererDisabled && (frameData.perFrameState.cursorGuideEnabled ||
+    if (!_cursorGuideRenderer.rendererDisabled && (frameData.perFrameState.cursorHorizontalGuideEnabled ||
                                                    frameData.perFrameState.cursorVerticalGuideEnabled)) {
         return YES;
     }
@@ -970,7 +970,7 @@ cellSizeWithoutSpacing:(CGSize)cellSizeWithoutSpacing
         return;
     }
     [_cursorGuideRenderer setColor:frameData.perFrameState.cursorGuideColor];
-    _cursorGuideRenderer.enabled = frameData.perFrameState.cursorGuideEnabled;
+    _cursorGuideRenderer.horizontalEnabled = frameData.perFrameState.cursorHorizontalGuideEnabled;
     _cursorGuideRenderer.verticalEnabled = frameData.perFrameState.cursorVerticalGuideEnabled;
 }
 

--- a/sources/Metal/iTermMetalDriver.m
+++ b/sources/Metal/iTermMetalDriver.m
@@ -644,8 +644,8 @@ cellSizeWithoutSpacing:(CGSize)cellSizeWithoutSpacing
     if (!_broadcastStripesRenderer.rendererDisabled && frameData.perFrameState.showBroadcastStripes) {
         return YES;
     }
-    if (!_cursorGuideRenderer.rendererDisabled && (frameData.perFrameState.cursorGuideEnabled
-                                                   || frameData.perFrameState.cursorVGuideEnabled)) {
+    if (!_cursorGuideRenderer.rendererDisabled && (frameData.perFrameState.cursorGuideEnabled ||
+                                                   frameData.perFrameState.cursorVerticalGuideEnabled)) {
         return YES;
     }
 
@@ -971,7 +971,7 @@ cellSizeWithoutSpacing:(CGSize)cellSizeWithoutSpacing
     }
     [_cursorGuideRenderer setColor:frameData.perFrameState.cursorGuideColor];
     _cursorGuideRenderer.enabled = frameData.perFrameState.cursorGuideEnabled;
-    _cursorGuideRenderer.venabled = frameData.perFrameState.cursorVGuideEnabled;
+    _cursorGuideRenderer.verticalEnabled = frameData.perFrameState.cursorVerticalGuideEnabled;
 }
 
 - (void)updateTimestampsRendererForFrameData:(iTermMetalFrameData *)frameData {

--- a/sources/Metal/iTermMetalDriver.m
+++ b/sources/Metal/iTermMetalDriver.m
@@ -644,7 +644,8 @@ cellSizeWithoutSpacing:(CGSize)cellSizeWithoutSpacing
     if (!_broadcastStripesRenderer.rendererDisabled && frameData.perFrameState.showBroadcastStripes) {
         return YES;
     }
-    if (!_cursorGuideRenderer.rendererDisabled && frameData.perFrameState.cursorGuideEnabled) {
+    if (!_cursorGuideRenderer.rendererDisabled && (frameData.perFrameState.cursorHorizontalGuideEnabled ||
+                                                   frameData.perFrameState.cursorVerticalGuideEnabled)) {
         return YES;
     }
 
@@ -969,7 +970,8 @@ cellSizeWithoutSpacing:(CGSize)cellSizeWithoutSpacing
         return;
     }
     [_cursorGuideRenderer setColor:frameData.perFrameState.cursorGuideColor];
-    _cursorGuideRenderer.enabled = frameData.perFrameState.cursorGuideEnabled;
+    _cursorGuideRenderer.horizontalEnabled = frameData.perFrameState.cursorHorizontalGuideEnabled;
+    _cursorGuideRenderer.verticalEnabled = frameData.perFrameState.cursorVerticalGuideEnabled;
 }
 
 - (void)updateTimestampsRendererForFrameData:(iTermMetalFrameData *)frameData {
@@ -1219,13 +1221,8 @@ cellSizeWithoutSpacing:(CGSize)cellSizeWithoutSpacing
 
 - (void)populateCursorGuideRendererTransientStateWithFrameData:(iTermMetalFrameData *)frameData {
     iTermCursorGuideRendererTransientState *tState = [frameData transientStateForRenderer:_cursorGuideRenderer];
-    iTermMetalCursorInfo *cursorInfo = frameData.perFrameState.metalDriverCursorInfo;
-    if (cursorInfo.coord.y >= 0 &&
-        cursorInfo.coord.y < frameData.gridSize.height) {
-        [tState setRow:frameData.perFrameState.metalDriverCursorInfo.coord.y];
-    } else {
-        [tState setRow:-1];
-    }
+    VT100GridCoord coord = frameData.perFrameState.metalDriverCursorInfo.coord;
+    [tState setCursorCoord:coord];
 }
 
 - (void)populateTimestampsRendererTransientStateWithFrameData:(iTermMetalFrameData *)frameData {

--- a/sources/PTYSession.h
+++ b/sources/PTYSession.h
@@ -422,6 +422,7 @@ typedef enum {
 @property(nonatomic, readonly) BOOL hasSelection;
 
 @property(nonatomic, assign) BOOL highlightCursorLine;
+@property(nonatomic, assign) BOOL highlightCursorColumn;
 
 // Used to help remember total ordering on views while one is maximized
 @property(nonatomic, assign) NSPoint savedRootRelativeOrigin;

--- a/sources/PTYSession.h
+++ b/sources/PTYSession.h
@@ -422,6 +422,7 @@ typedef enum {
 @property(nonatomic, readonly) BOOL hasSelection;
 
 @property(nonatomic, assign) BOOL highlightCursorLine;
+@property(nonatomic, assign) BOOL highlightCursorCol;
 
 // Used to help remember total ordering on views while one is maximized
 @property(nonatomic, assign) NSPoint savedRootRelativeOrigin;

--- a/sources/PTYSession.h
+++ b/sources/PTYSession.h
@@ -422,7 +422,7 @@ typedef enum {
 @property(nonatomic, readonly) BOOL hasSelection;
 
 @property(nonatomic, assign) BOOL highlightCursorLine;
-@property(nonatomic, assign) BOOL highlightCursorCol;
+@property(nonatomic, assign) BOOL highlightCursorColumn;
 
 // Used to help remember total ordering on views while one is maximized
 @property(nonatomic, assign) NSPoint savedRootRelativeOrigin;

--- a/sources/PTYSession.m
+++ b/sources/PTYSession.m
@@ -207,6 +207,7 @@ static NSString *const SESSION_ARRANGEMENT_COMMANDS = @"Commands";  // Array of 
 static NSString *const SESSION_ARRANGEMENT_DIRECTORIES = @"Directories";  // Array of strings
 static NSString *const SESSION_ARRANGEMENT_HOSTS = @"Hosts";  // Array of VT100RemoteHost
 static NSString *const SESSION_ARRANGEMENT_CURSOR_GUIDE = @"Cursor Guide";  // BOOL
+static NSString *const SESSION_ARRANGEMENT_VCURSOR_GUIDE = @"Vertical Cursor Guide";  // BOOL
 static NSString *const SESSION_ARRANGEMENT_LAST_DIRECTORY = @"Last Directory";  // NSString
 static NSString *const SESSION_ARRANGEMENT_LAST_DIRECTORY_IS_UNSUITABLE_FOR_OLD_PWD = @"Last Directory Is Remote";  // BOOL
 static NSString *const SESSION_ARRANGEMENT_SELECTION = @"Selection";  // Dictionary for iTermSelection.
@@ -1184,6 +1185,9 @@ ITERM_WEAKLY_REFERENCEABLE
         }
         if (arrangement[SESSION_ARRANGEMENT_CURSOR_GUIDE]) {
             aSession.textview.highlightCursorLine = [arrangement[SESSION_ARRANGEMENT_CURSOR_GUIDE] boolValue];
+        }
+        if (arrangement[SESSION_ARRANGEMENT_VCURSOR_GUIDE]) {
+            aSession.textview.highlightCursorLine = [arrangement[SESSION_ARRANGEMENT_VCURSOR_GUIDE] boolValue];
         }
         aSession->_lastMark = [aSession.screen.lastMark retain];
         aSession.lastRemoteHost = aSession.screen.lastRemoteHost;
@@ -3473,6 +3477,8 @@ ITERM_WEAKLY_REFERENCEABLE
     }
     _textview.highlightCursorLine = [iTermProfilePreferences boolForKey:KEY_USE_CURSOR_GUIDE
                                                               inProfile:_profile];
+    _textview.highlightCursorCol = [iTermProfilePreferences boolForKey:KEY_USE_VERT_CURSOR_GUIDE
+                                                             inProfile:_profile];
 }
 
 - (NSColor *)tabColorInProfile:(NSDictionary *)profile
@@ -3655,6 +3661,8 @@ ITERM_WEAKLY_REFERENCEABLE
     if (!_cursorGuideSettingHasChanged) {
         _textview.highlightCursorLine = [iTermProfilePreferences boolForKey:KEY_USE_CURSOR_GUIDE
                                                                   inProfile:aDict];
+        _textview.highlightCursorCol = [iTermProfilePreferences boolForKey:KEY_USE_VERT_CURSOR_GUIDE
+                                                                 inProfile:aDict];
     }
 
     for (i = 0; i < 16; i++) {
@@ -4381,6 +4389,7 @@ ITERM_WEAKLY_REFERENCEABLE
             [NSDictionary dictionaryWithGridCoordRange:range];
         result[SESSION_ARRANGEMENT_ALERT_ON_NEXT_MARK] = @(_alertOnNextMark);
         result[SESSION_ARRANGEMENT_CURSOR_GUIDE] = @(_textview.highlightCursorLine);
+        result[SESSION_ARRANGEMENT_VCURSOR_GUIDE] = @(_textview.highlightCursorCol);
         if (self.lastDirectory) {
             result[SESSION_ARRANGEMENT_LAST_DIRECTORY] = self.lastDirectory;
             result[SESSION_ARRANGEMENT_LAST_DIRECTORY_IS_UNSUITABLE_FOR_OLD_PWD] = @(self.lastDirectoryIsUnsuitableForOldPWD);
@@ -8388,6 +8397,8 @@ scrollToFirstResult:(BOOL)scrollToFirstResult {
     _cursorGuideSettingHasChanged = NO;
     _textview.highlightCursorLine = [iTermProfilePreferences boolForKey:KEY_USE_CURSOR_GUIDE
                                                               inProfile:_profile];
+    _textview.highlightCursorCol = [iTermProfilePreferences boolForKey:KEY_USE_VERT_CURSOR_GUIDE
+                                                             inProfile:_profile];
     [_textview setNeedsDisplay:YES];
     _screen.trackCursorLineMovement = NO;
 }
@@ -8658,6 +8669,28 @@ scrollToFirstResult:(BOOL)scrollToFirstResult {
 
 - (BOOL)highlightCursorLine {
     return _textview.highlightCursorLine;
+}
+
+- (void)screenCursorDidMoveToCol:(int)col {
+    if (_textview.cursorVisible) {
+        [_textview setNeedsDisplayOnCol:col];
+    }
+}
+
+- (void)screenSetHighlightCursorCol:(BOOL)highlight {
+    _cursorGuideSettingHasChanged = YES;
+    self.highlightCursorCol = highlight;
+}
+
+- (void)setHighlightCursorCol:(BOOL)highlight {
+    _cursorGuideSettingHasChanged = YES;
+    _textview.highlightCursorCol = highlight;
+    [_textview setNeedsDisplay:YES];
+    _screen.trackCursorColMovement = highlight;
+}
+
+- (BOOL)highlightCursorCol {
+    return _textview.highlightCursorCol;
 }
 
 - (BOOL)screenHasView {

--- a/sources/PTYSession.m
+++ b/sources/PTYSession.m
@@ -2374,6 +2374,7 @@ ITERM_WEAKLY_REFERENCEABLE
 
 - (void)handleKeyPressInCopyMode:(NSEvent *)event {
     [self.textview setNeedsDisplayOnLine:_copyModeState.coord.y];
+    [self.textview setNeedsDisplayOnCol:_copyModeState.coord.x];
     BOOL wasSelecting = _copyModeState.selecting;
     NSString *string = event.charactersIgnoringModifiers;
     unichar code = [string length] > 0 ? [string characterAtIndex:0] : 0;
@@ -2525,6 +2526,7 @@ ITERM_WEAKLY_REFERENCEABLE
             [_textview scrollLineNumberRangeIntoView:VT100GridRangeMake(_copyModeState.coord.y, 1)];
         }
         [self.textview setNeedsDisplayOnLine:_copyModeState.coord.y];
+        [self.textview setNeedsDisplayOnCol:_copyModeState.coord.x];
     }
 }
 

--- a/sources/PTYSession.m
+++ b/sources/PTYSession.m
@@ -1187,7 +1187,7 @@ ITERM_WEAKLY_REFERENCEABLE
             aSession.textview.highlightCursorLine = [arrangement[SESSION_ARRANGEMENT_CURSOR_GUIDE] boolValue];
         }
         if (arrangement[SESSION_ARRANGEMENT_VERTICAL_CURSOR_GUIDE]) {
-            aSession.textview.highlightCursorLine = [arrangement[SESSION_ARRANGEMENT_VERTICAL_CURSOR_GUIDE] boolValue];
+            aSession.textview.highlightCursorColumn = [arrangement[SESSION_ARRANGEMENT_VERTICAL_CURSOR_GUIDE] boolValue];
         }
         aSession->_lastMark = [aSession.screen.lastMark retain];
         aSession.lastRemoteHost = aSession.screen.lastRemoteHost;

--- a/sources/PTYSession.m
+++ b/sources/PTYSession.m
@@ -1177,7 +1177,7 @@ ITERM_WEAKLY_REFERENCEABLE
             aSession.textview.highlightCursorLine = [arrangement[SESSION_ARRANGEMENT_CURSOR_GUIDE] boolValue];
         }
         if (arrangement[SESSION_ARRANGEMENT_VERTICAL_CURSOR_GUIDE]) {
-            aSession.textview.highlightCursorLine = [arrangement[SESSION_ARRANGEMENT_VERTICAL_CURSOR_GUIDE] boolValue];
+            aSession.textview.highlightCursorColumn = [arrangement[SESSION_ARRANGEMENT_VERTICAL_CURSOR_GUIDE] boolValue];
         }
         aSession->_lastMark = [aSession.screen.lastMark retain];
         aSession.lastRemoteHost = aSession.screen.lastRemoteHost;

--- a/sources/PTYSession.m
+++ b/sources/PTYSession.m
@@ -2345,6 +2345,7 @@ ITERM_WEAKLY_REFERENCEABLE
     [self writeTaskImpl:string encoding:encoding forceEncoding:forceEncoding canBroadcast:NO];
 }
 
+#if 0
 - (void)handleKeyPressInCopyMode:(NSEvent *)event {
     [self.textview setNeedsDisplayOnLine:_copyModeState.coord.y];
     [self.textview setNeedsDisplayOnColumn:_copyModeState.coord.x];
@@ -2502,6 +2503,7 @@ ITERM_WEAKLY_REFERENCEABLE
         [self.textview setNeedsDisplayOnColumn:_copyModeState.coord.x];
     }
 }
+#endif
 
 - (void)handleKeypressInTmuxGateway:(NSEvent *)event {
     const unichar unicode = [event.characters length] > 0 ? [event.characters characterAtIndex:0] : 0;

--- a/sources/PTYSession.m
+++ b/sources/PTYSession.m
@@ -2364,6 +2364,7 @@ ITERM_WEAKLY_REFERENCEABLE
 
 - (void)handleKeyPressInCopyMode:(NSEvent *)event {
     [self.textview setNeedsDisplayOnLine:_copyModeState.coord.y];
+    [self.textview setNeedsDisplayOnCol:_copyModeState.coord.x];
     BOOL wasSelecting = _copyModeState.selecting;
     NSString *string = event.charactersIgnoringModifiers;
     unichar code = [string length] > 0 ? [string characterAtIndex:0] : 0;
@@ -2515,6 +2516,7 @@ ITERM_WEAKLY_REFERENCEABLE
             [_textview scrollLineNumberRangeIntoView:VT100GridRangeMake(_copyModeState.coord.y, 1)];
         }
         [self.textview setNeedsDisplayOnLine:_copyModeState.coord.y];
+        [self.textview setNeedsDisplayOnCol:_copyModeState.coord.x];
     }
 }
 

--- a/sources/PTYSession.m
+++ b/sources/PTYSession.m
@@ -8313,6 +8313,7 @@ scrollToFirstResult:(BOOL)scrollToFirstResult {
                                                              inProfile:_profile];
     [_textview setNeedsDisplay:YES];
     _screen.trackCursorLineMovement = NO;
+    _screen.trackCursorColMovement = NO;
 }
 
 - (void)screenDidAppendStringToCurrentLine:(NSString *)string {

--- a/sources/PTYSession.m
+++ b/sources/PTYSession.m
@@ -208,6 +208,7 @@ static NSString *const SESSION_ARRANGEMENT_COMMANDS = @"Commands";  // Array of 
 static NSString *const SESSION_ARRANGEMENT_DIRECTORIES = @"Directories";  // Array of strings
 static NSString *const SESSION_ARRANGEMENT_HOSTS = @"Hosts";  // Array of VT100RemoteHost
 static NSString *const SESSION_ARRANGEMENT_CURSOR_GUIDE = @"Cursor Guide";  // BOOL
+static NSString *const SESSION_ARRANGEMENT_VERTICAL_CURSOR_GUIDE = @"Vertical Cursor Guide";  // BOOL
 static NSString *const SESSION_ARRANGEMENT_LAST_DIRECTORY = @"Last Directory";  // NSString
 static NSString *const SESSION_ARRANGEMENT_LAST_DIRECTORY_IS_UNSUITABLE_FOR_OLD_PWD = @"Last Directory Is Remote";  // BOOL
 static NSString *const SESSION_ARRANGEMENT_SELECTION = @"Selection";  // Dictionary for iTermSelection.
@@ -1157,6 +1158,9 @@ ITERM_WEAKLY_REFERENCEABLE
         }
         if (arrangement[SESSION_ARRANGEMENT_CURSOR_GUIDE]) {
             aSession.textview.highlightCursorLine = [arrangement[SESSION_ARRANGEMENT_CURSOR_GUIDE] boolValue];
+        }
+        if (arrangement[SESSION_ARRANGEMENT_VERTICAL_CURSOR_GUIDE]) {
+            aSession.textview.highlightCursorColumn = [arrangement[SESSION_ARRANGEMENT_VERTICAL_CURSOR_GUIDE] boolValue];
         }
         aSession->_lastMark = [aSession.screen.lastMark retain];
         aSession.lastRemoteHost = aSession.screen.lastRemoteHost;
@@ -2341,6 +2345,164 @@ ITERM_WEAKLY_REFERENCEABLE
     [self writeTaskImpl:string encoding:encoding forceEncoding:forceEncoding canBroadcast:NO];
 }
 
+- (void)handleKeyPressInCopyMode:(NSEvent *)event {
+    [self.textview setNeedsDisplayOnLine:_copyModeState.coord.y];
+    [self.textview setNeedsDisplayOnColumn:_copyModeState.coord.x];
+    BOOL wasSelecting = _copyModeState.selecting;
+    NSString *string = event.charactersIgnoringModifiers;
+    unichar code = [string length] > 0 ? [string characterAtIndex:0] : 0;
+    NSUInteger mask = (NSEventModifierFlagOption | NSEventModifierFlagControl | NSEventModifierFlagCommand);
+    BOOL moved = NO;
+    if ((event.modifierFlags & mask) == NSEventModifierFlagControl) {
+        switch (code) {
+            case 'b':  // ^B
+                moved = [_copyModeState pageUp];
+                break;
+            case 'f': // ^F
+                moved = [_copyModeState pageDown];
+                break;
+            case ' ':
+                _copyModeState.selecting = !_copyModeState.selecting;
+                _copyModeState.mode = kiTermSelectionModeCharacter;
+                break;
+            case 'c':
+                self.copyMode = NO;
+                break;
+            case 'g':
+                self.copyMode = NO;
+                break;
+            case 'k':
+                [_textview copySelectionAccordingToUserPreferences];
+                self.copyMode = NO;
+                break;
+            case 'v':
+                _copyModeState.selecting = !_copyModeState.selecting;
+                _copyModeState.mode = kiTermSelectionModeBox;
+                break;
+        }
+    } else if ((event.modifierFlags & mask) == NSEventModifierFlagOption) {
+        switch (code) {
+            case 'b':
+            case NSLeftArrowFunctionKey:
+                moved = [_copyModeState moveBackwardWord];
+                break;
+
+            case 'f':
+            case NSRightArrowFunctionKey:
+                moved = [_copyModeState moveForwardWord];
+                break;
+            case 'm':
+                moved = [_copyModeState moveToStartOfIndentation];
+                break;
+        }
+    } else if ((event.modifierFlags & mask) == 0) {
+        switch (code) {
+            case NSPageUpFunctionKey:
+                moved = [_copyModeState pageUp];
+                break;
+            case NSPageDownFunctionKey:
+                moved = [_copyModeState pageDown];
+                break;
+            case '\t':
+                if (event.modifierFlags & NSEventModifierFlagShift) {
+                    moved = [_copyModeState moveBackwardWord];
+                } else {
+                    moved = [_copyModeState moveForwardWord];
+                }
+                break;
+            case '\n':
+            case '\r':
+                moved = [_copyModeState moveToStartOfNextLine];
+                break;
+            case 27:
+            case 'q':
+                self.copyMode = NO;
+                _copyModeState.selecting = NO;
+                moved = YES;
+                break;
+            case ' ':
+            case 'v':
+                _copyModeState.selecting = !_copyModeState.selecting;
+                _copyModeState.mode = kiTermSelectionModeCharacter;
+                break;
+            case 'b':
+                moved = [_copyModeState moveBackwardWord];
+                break;
+            case '0':
+                moved = [_copyModeState moveToStartOfLine];
+                break;
+            case 'H':
+                moved = [_copyModeState moveToTopOfVisibleArea];
+                break;
+            case 'G':
+                moved = [_copyModeState moveToEnd];
+                break;
+            case 'L':
+                moved = [_copyModeState moveToBottomOfVisibleArea];
+                break;
+            case 'M':
+                moved = [_copyModeState moveToMiddleOfVisibleArea];
+                break;
+            case 'V':
+                _copyModeState.selecting = !_copyModeState.selecting;
+                _copyModeState.mode = kiTermSelectionModeLine;
+                break;
+            case 'g':
+                moved = [_copyModeState moveToStart];
+                break;
+            case 'h':
+            case NSLeftArrowFunctionKey:
+                moved = [_copyModeState moveLeft];
+                break;
+            case 'j':
+            case NSDownArrowFunctionKey:
+                moved = [_copyModeState moveDown];
+                break;
+            case 'k':
+            case NSUpArrowFunctionKey:
+                moved = [_copyModeState moveUp];
+                break;
+            case 'l':
+            case NSRightArrowFunctionKey:
+                moved = [_copyModeState moveRight];
+                break;
+            case 'o':
+                [_copyModeState swap];
+                moved = YES;
+                break;
+            case 'w':
+                moved = [_copyModeState moveForwardWord];
+                break;
+            case 'y':
+                [_textview copySelectionAccordingToUserPreferences];
+                self.copyMode = NO;
+                break;
+            case '/':
+                [self showFindPanel];
+                break;
+            case '[':
+                moved = [_copyModeState previousMark];
+                break;
+            case ']':
+                moved = [_copyModeState nextMark];
+                break;
+            case '^':
+                moved = [_copyModeState moveToStartOfIndentation];
+                break;
+            case '$':
+                moved = [_copyModeState moveToEndOfLine];
+                break;
+        }
+    }
+    if (moved || (_copyModeState.selecting != wasSelecting)) {
+        if (self.copyMode) {
+            [_textview scrollLineNumberRangeIntoView:VT100GridRangeMake(_copyModeState.coord.y, 1)];
+        }
+        [self.textview setNeedsDisplayOnLine:_copyModeState.coord.y];
+        [self.textview setNeedsDisplayOnColumn:_copyModeState.coord.x];
+    }
+}
+
 - (void)handleKeypressInTmuxGateway:(NSEvent *)event {
     const unichar unicode = [event.characters length] > 0 ? [event.characters characterAtIndex:0] : 0;
     [self handleCharacterPressedInTmuxGateway:unicode];
@@ -3290,6 +3452,8 @@ ITERM_WEAKLY_REFERENCEABLE
     }
     _textview.highlightCursorLine = [iTermProfilePreferences boolForKey:KEY_USE_CURSOR_GUIDE
                                                               inProfile:_profile];
+    _textview.highlightCursorColumn = [iTermProfilePreferences boolForKey:KEY_USE_VERTICAL_CURSOR_GUIDE
+                                                             inProfile:_profile];
 }
 
 - (NSColor *)tabColorInProfile:(NSDictionary *)profile
@@ -3472,6 +3636,8 @@ ITERM_WEAKLY_REFERENCEABLE
     if (!_cursorGuideSettingHasChanged) {
         _textview.highlightCursorLine = [iTermProfilePreferences boolForKey:KEY_USE_CURSOR_GUIDE
                                                                   inProfile:aDict];
+        _textview.highlightCursorColumn = [iTermProfilePreferences boolForKey:KEY_USE_VERTICAL_CURSOR_GUIDE
+                                                                 inProfile:aDict];
     }
 
     for (i = 0; i < 16; i++) {
@@ -4198,6 +4364,7 @@ ITERM_WEAKLY_REFERENCEABLE
             [NSDictionary dictionaryWithGridCoordRange:range];
         result[SESSION_ARRANGEMENT_ALERT_ON_NEXT_MARK] = @(_alertOnNextMark);
         result[SESSION_ARRANGEMENT_CURSOR_GUIDE] = @(_textview.highlightCursorLine);
+        result[SESSION_ARRANGEMENT_VERTICAL_CURSOR_GUIDE] = @(_textview.highlightCursorColumn);
         if (self.lastDirectory) {
             result[SESSION_ARRANGEMENT_LAST_DIRECTORY] = self.lastDirectory;
             result[SESSION_ARRANGEMENT_LAST_DIRECTORY_IS_UNSUITABLE_FOR_OLD_PWD] = @(self.lastDirectoryIsUnsuitableForOldPWD);
@@ -8211,8 +8378,11 @@ scrollToFirstResult:(BOOL)scrollToFirstResult {
     _cursorGuideSettingHasChanged = NO;
     _textview.highlightCursorLine = [iTermProfilePreferences boolForKey:KEY_USE_CURSOR_GUIDE
                                                               inProfile:_profile];
+    _textview.highlightCursorColumn = [iTermProfilePreferences boolForKey:KEY_USE_VERTICAL_CURSOR_GUIDE
+                                                                inProfile:_profile];
     [_textview setNeedsDisplay:YES];
     _screen.trackCursorLineMovement = NO;
+    _screen.trackCursorColumnMovement = NO;
 }
 
 - (void)screenDidAppendStringToCurrentLine:(NSString *)string {
@@ -8481,6 +8651,28 @@ scrollToFirstResult:(BOOL)scrollToFirstResult {
 
 - (BOOL)highlightCursorLine {
     return _textview.highlightCursorLine;
+}
+
+- (void)screenCursorDidMoveToColumn:(int)column {
+    if (_textview.cursorVisible) {
+        [_textview setNeedsDisplayOnColumn:column];
+    }
+}
+
+- (void)screenSetHighlightCursorColumn:(BOOL)highlight {
+    _cursorGuideSettingHasChanged = YES;
+    self.highlightCursorColumn = highlight;
+}
+
+- (void)setHighlightCursorColumn:(BOOL)highlight {
+    _cursorGuideSettingHasChanged = YES;
+    _textview.highlightCursorColumn = highlight;
+    [_textview setNeedsDisplay:YES];
+    _screen.trackCursorColumnMovement = highlight;
+}
+
+- (BOOL)highlightCursorColumn {
+    return _textview.highlightCursorColumn;
 }
 
 - (BOOL)screenHasView {

--- a/sources/PTYSession.m
+++ b/sources/PTYSession.m
@@ -207,7 +207,7 @@ static NSString *const SESSION_ARRANGEMENT_COMMANDS = @"Commands";  // Array of 
 static NSString *const SESSION_ARRANGEMENT_DIRECTORIES = @"Directories";  // Array of strings
 static NSString *const SESSION_ARRANGEMENT_HOSTS = @"Hosts";  // Array of VT100RemoteHost
 static NSString *const SESSION_ARRANGEMENT_CURSOR_GUIDE = @"Cursor Guide";  // BOOL
-static NSString *const SESSION_ARRANGEMENT_VCURSOR_GUIDE = @"Vertical Cursor Guide";  // BOOL
+static NSString *const SESSION_ARRANGEMENT_VERTICAL_CURSOR_GUIDE = @"Vertical Cursor Guide";  // BOOL
 static NSString *const SESSION_ARRANGEMENT_LAST_DIRECTORY = @"Last Directory";  // NSString
 static NSString *const SESSION_ARRANGEMENT_LAST_DIRECTORY_IS_UNSUITABLE_FOR_OLD_PWD = @"Last Directory Is Remote";  // BOOL
 static NSString *const SESSION_ARRANGEMENT_SELECTION = @"Selection";  // Dictionary for iTermSelection.
@@ -1186,8 +1186,8 @@ ITERM_WEAKLY_REFERENCEABLE
         if (arrangement[SESSION_ARRANGEMENT_CURSOR_GUIDE]) {
             aSession.textview.highlightCursorLine = [arrangement[SESSION_ARRANGEMENT_CURSOR_GUIDE] boolValue];
         }
-        if (arrangement[SESSION_ARRANGEMENT_VCURSOR_GUIDE]) {
-            aSession.textview.highlightCursorLine = [arrangement[SESSION_ARRANGEMENT_VCURSOR_GUIDE] boolValue];
+        if (arrangement[SESSION_ARRANGEMENT_VERTICAL_CURSOR_GUIDE]) {
+            aSession.textview.highlightCursorLine = [arrangement[SESSION_ARRANGEMENT_VERTICAL_CURSOR_GUIDE] boolValue];
         }
         aSession->_lastMark = [aSession.screen.lastMark retain];
         aSession.lastRemoteHost = aSession.screen.lastRemoteHost;
@@ -2374,7 +2374,7 @@ ITERM_WEAKLY_REFERENCEABLE
 
 - (void)handleKeyPressInCopyMode:(NSEvent *)event {
     [self.textview setNeedsDisplayOnLine:_copyModeState.coord.y];
-    [self.textview setNeedsDisplayOnCol:_copyModeState.coord.x];
+    [self.textview setNeedsDisplayOnColumn:_copyModeState.coord.x];
     BOOL wasSelecting = _copyModeState.selecting;
     NSString *string = event.charactersIgnoringModifiers;
     unichar code = [string length] > 0 ? [string characterAtIndex:0] : 0;
@@ -2526,7 +2526,7 @@ ITERM_WEAKLY_REFERENCEABLE
             [_textview scrollLineNumberRangeIntoView:VT100GridRangeMake(_copyModeState.coord.y, 1)];
         }
         [self.textview setNeedsDisplayOnLine:_copyModeState.coord.y];
-        [self.textview setNeedsDisplayOnCol:_copyModeState.coord.x];
+        [self.textview setNeedsDisplayOnColumn:_copyModeState.coord.x];
     }
 }
 
@@ -3479,7 +3479,7 @@ ITERM_WEAKLY_REFERENCEABLE
     }
     _textview.highlightCursorLine = [iTermProfilePreferences boolForKey:KEY_USE_CURSOR_GUIDE
                                                               inProfile:_profile];
-    _textview.highlightCursorCol = [iTermProfilePreferences boolForKey:KEY_USE_VERT_CURSOR_GUIDE
+    _textview.highlightCursorColumn = [iTermProfilePreferences boolForKey:KEY_USE_VERTICAL_CURSOR_GUIDE
                                                              inProfile:_profile];
 }
 
@@ -3663,7 +3663,7 @@ ITERM_WEAKLY_REFERENCEABLE
     if (!_cursorGuideSettingHasChanged) {
         _textview.highlightCursorLine = [iTermProfilePreferences boolForKey:KEY_USE_CURSOR_GUIDE
                                                                   inProfile:aDict];
-        _textview.highlightCursorCol = [iTermProfilePreferences boolForKey:KEY_USE_VERT_CURSOR_GUIDE
+        _textview.highlightCursorColumn = [iTermProfilePreferences boolForKey:KEY_USE_VERTICAL_CURSOR_GUIDE
                                                                  inProfile:aDict];
     }
 
@@ -4391,7 +4391,7 @@ ITERM_WEAKLY_REFERENCEABLE
             [NSDictionary dictionaryWithGridCoordRange:range];
         result[SESSION_ARRANGEMENT_ALERT_ON_NEXT_MARK] = @(_alertOnNextMark);
         result[SESSION_ARRANGEMENT_CURSOR_GUIDE] = @(_textview.highlightCursorLine);
-        result[SESSION_ARRANGEMENT_VCURSOR_GUIDE] = @(_textview.highlightCursorCol);
+        result[SESSION_ARRANGEMENT_VERTICAL_CURSOR_GUIDE] = @(_textview.highlightCursorColumn);
         if (self.lastDirectory) {
             result[SESSION_ARRANGEMENT_LAST_DIRECTORY] = self.lastDirectory;
             result[SESSION_ARRANGEMENT_LAST_DIRECTORY_IS_UNSUITABLE_FOR_OLD_PWD] = @(self.lastDirectoryIsUnsuitableForOldPWD);
@@ -8399,10 +8399,11 @@ scrollToFirstResult:(BOOL)scrollToFirstResult {
     _cursorGuideSettingHasChanged = NO;
     _textview.highlightCursorLine = [iTermProfilePreferences boolForKey:KEY_USE_CURSOR_GUIDE
                                                               inProfile:_profile];
-    _textview.highlightCursorCol = [iTermProfilePreferences boolForKey:KEY_USE_VERT_CURSOR_GUIDE
-                                                             inProfile:_profile];
+    _textview.highlightCursorColumn = [iTermProfilePreferences boolForKey:KEY_USE_VERTICAL_CURSOR_GUIDE
+                                                                inProfile:_profile];
     [_textview setNeedsDisplay:YES];
     _screen.trackCursorLineMovement = NO;
+    _screen.trackCursorColumnMovement = NO;
 }
 
 - (void)screenDidAppendStringToCurrentLine:(NSString *)string {
@@ -8673,26 +8674,26 @@ scrollToFirstResult:(BOOL)scrollToFirstResult {
     return _textview.highlightCursorLine;
 }
 
-- (void)screenCursorDidMoveToCol:(int)col {
+- (void)screenCursorDidMoveToColumn:(int)column {
     if (_textview.cursorVisible) {
-        [_textview setNeedsDisplayOnCol:col];
+        [_textview setNeedsDisplayOnColumn:column];
     }
 }
 
-- (void)screenSetHighlightCursorCol:(BOOL)highlight {
+- (void)screenSetHighlightCursorColumn:(BOOL)highlight {
     _cursorGuideSettingHasChanged = YES;
-    self.highlightCursorCol = highlight;
+    self.highlightCursorColumn = highlight;
 }
 
-- (void)setHighlightCursorCol:(BOOL)highlight {
+- (void)setHighlightCursorColumn:(BOOL)highlight {
     _cursorGuideSettingHasChanged = YES;
-    _textview.highlightCursorCol = highlight;
+    _textview.highlightCursorColumn = highlight;
     [_textview setNeedsDisplay:YES];
-    _screen.trackCursorColMovement = highlight;
+    _screen.trackCursorColumnMovement = highlight;
 }
 
-- (BOOL)highlightCursorCol {
-    return _textview.highlightCursorCol;
+- (BOOL)highlightCursorColumn {
+    return _textview.highlightCursorColumn;
 }
 
 - (BOOL)screenHasView {

--- a/sources/PTYSession.m
+++ b/sources/PTYSession.m
@@ -205,7 +205,7 @@ static NSString *const SESSION_ARRANGEMENT_COMMANDS = @"Commands";  // Array of 
 static NSString *const SESSION_ARRANGEMENT_DIRECTORIES = @"Directories";  // Array of strings
 static NSString *const SESSION_ARRANGEMENT_HOSTS = @"Hosts";  // Array of VT100RemoteHost
 static NSString *const SESSION_ARRANGEMENT_CURSOR_GUIDE = @"Cursor Guide";  // BOOL
-static NSString *const SESSION_ARRANGEMENT_VCURSOR_GUIDE = @"Vertical Cursor Guide";  // BOOL
+static NSString *const SESSION_ARRANGEMENT_VERTICAL_CURSOR_GUIDE = @"Vertical Cursor Guide";  // BOOL
 static NSString *const SESSION_ARRANGEMENT_LAST_DIRECTORY = @"Last Directory";  // NSString
 static NSString *const SESSION_ARRANGEMENT_LAST_DIRECTORY_IS_UNSUITABLE_FOR_OLD_PWD = @"Last Directory Is Remote";  // BOOL
 static NSString *const SESSION_ARRANGEMENT_SELECTION = @"Selection";  // Dictionary for iTermSelection.
@@ -1176,8 +1176,8 @@ ITERM_WEAKLY_REFERENCEABLE
         if (arrangement[SESSION_ARRANGEMENT_CURSOR_GUIDE]) {
             aSession.textview.highlightCursorLine = [arrangement[SESSION_ARRANGEMENT_CURSOR_GUIDE] boolValue];
         }
-        if (arrangement[SESSION_ARRANGEMENT_VCURSOR_GUIDE]) {
-            aSession.textview.highlightCursorLine = [arrangement[SESSION_ARRANGEMENT_VCURSOR_GUIDE] boolValue];
+        if (arrangement[SESSION_ARRANGEMENT_VERTICAL_CURSOR_GUIDE]) {
+            aSession.textview.highlightCursorLine = [arrangement[SESSION_ARRANGEMENT_VERTICAL_CURSOR_GUIDE] boolValue];
         }
         aSession->_lastMark = [aSession.screen.lastMark retain];
         aSession.lastRemoteHost = aSession.screen.lastRemoteHost;
@@ -2364,7 +2364,7 @@ ITERM_WEAKLY_REFERENCEABLE
 
 - (void)handleKeyPressInCopyMode:(NSEvent *)event {
     [self.textview setNeedsDisplayOnLine:_copyModeState.coord.y];
-    [self.textview setNeedsDisplayOnCol:_copyModeState.coord.x];
+    [self.textview setNeedsDisplayOnColumn:_copyModeState.coord.x];
     BOOL wasSelecting = _copyModeState.selecting;
     NSString *string = event.charactersIgnoringModifiers;
     unichar code = [string length] > 0 ? [string characterAtIndex:0] : 0;
@@ -2516,7 +2516,7 @@ ITERM_WEAKLY_REFERENCEABLE
             [_textview scrollLineNumberRangeIntoView:VT100GridRangeMake(_copyModeState.coord.y, 1)];
         }
         [self.textview setNeedsDisplayOnLine:_copyModeState.coord.y];
-        [self.textview setNeedsDisplayOnCol:_copyModeState.coord.x];
+        [self.textview setNeedsDisplayOnColumn:_copyModeState.coord.x];
     }
 }
 
@@ -3469,7 +3469,7 @@ ITERM_WEAKLY_REFERENCEABLE
     }
     _textview.highlightCursorLine = [iTermProfilePreferences boolForKey:KEY_USE_CURSOR_GUIDE
                                                               inProfile:_profile];
-    _textview.highlightCursorCol = [iTermProfilePreferences boolForKey:KEY_USE_VERT_CURSOR_GUIDE
+    _textview.highlightCursorColumn = [iTermProfilePreferences boolForKey:KEY_USE_VERTICAL_CURSOR_GUIDE
                                                              inProfile:_profile];
 }
 
@@ -3653,7 +3653,7 @@ ITERM_WEAKLY_REFERENCEABLE
     if (!_cursorGuideSettingHasChanged) {
         _textview.highlightCursorLine = [iTermProfilePreferences boolForKey:KEY_USE_CURSOR_GUIDE
                                                                   inProfile:aDict];
-        _textview.highlightCursorCol = [iTermProfilePreferences boolForKey:KEY_USE_VERT_CURSOR_GUIDE
+        _textview.highlightCursorColumn = [iTermProfilePreferences boolForKey:KEY_USE_VERTICAL_CURSOR_GUIDE
                                                                  inProfile:aDict];
     }
 
@@ -4381,7 +4381,7 @@ ITERM_WEAKLY_REFERENCEABLE
             [NSDictionary dictionaryWithGridCoordRange:range];
         result[SESSION_ARRANGEMENT_ALERT_ON_NEXT_MARK] = @(_alertOnNextMark);
         result[SESSION_ARRANGEMENT_CURSOR_GUIDE] = @(_textview.highlightCursorLine);
-        result[SESSION_ARRANGEMENT_VCURSOR_GUIDE] = @(_textview.highlightCursorCol);
+        result[SESSION_ARRANGEMENT_VERTICAL_CURSOR_GUIDE] = @(_textview.highlightCursorColumn);
         if (self.lastDirectory) {
             result[SESSION_ARRANGEMENT_LAST_DIRECTORY] = self.lastDirectory;
             result[SESSION_ARRANGEMENT_LAST_DIRECTORY_IS_UNSUITABLE_FOR_OLD_PWD] = @(self.lastDirectoryIsUnsuitableForOldPWD);
@@ -8309,11 +8309,11 @@ scrollToFirstResult:(BOOL)scrollToFirstResult {
     _cursorGuideSettingHasChanged = NO;
     _textview.highlightCursorLine = [iTermProfilePreferences boolForKey:KEY_USE_CURSOR_GUIDE
                                                               inProfile:_profile];
-    _textview.highlightCursorCol = [iTermProfilePreferences boolForKey:KEY_USE_VERT_CURSOR_GUIDE
-                                                             inProfile:_profile];
+    _textview.highlightCursorColumn = [iTermProfilePreferences boolForKey:KEY_USE_VERTICAL_CURSOR_GUIDE
+                                                                inProfile:_profile];
     [_textview setNeedsDisplay:YES];
     _screen.trackCursorLineMovement = NO;
-    _screen.trackCursorColMovement = NO;
+    _screen.trackCursorColumnMovement = NO;
 }
 
 - (void)screenDidAppendStringToCurrentLine:(NSString *)string {
@@ -8584,26 +8584,26 @@ scrollToFirstResult:(BOOL)scrollToFirstResult {
     return _textview.highlightCursorLine;
 }
 
-- (void)screenCursorDidMoveToCol:(int)col {
+- (void)screenCursorDidMoveToColumn:(int)column {
     if (_textview.cursorVisible) {
-        [_textview setNeedsDisplayOnCol:col];
+        [_textview setNeedsDisplayOnColumn:column];
     }
 }
 
-- (void)screenSetHighlightCursorCol:(BOOL)highlight {
+- (void)screenSetHighlightCursorColumn:(BOOL)highlight {
     _cursorGuideSettingHasChanged = YES;
-    self.highlightCursorCol = highlight;
+    self.highlightCursorColumn = highlight;
 }
 
-- (void)setHighlightCursorCol:(BOOL)highlight {
+- (void)setHighlightCursorColumn:(BOOL)highlight {
     _cursorGuideSettingHasChanged = YES;
-    _textview.highlightCursorCol = highlight;
+    _textview.highlightCursorColumn = highlight;
     [_textview setNeedsDisplay:YES];
-    _screen.trackCursorColMovement = highlight;
+    _screen.trackCursorColumnMovement = highlight;
 }
 
-- (BOOL)highlightCursorCol {
-    return _textview.highlightCursorCol;
+- (BOOL)highlightCursorColumn {
+    return _textview.highlightCursorColumn;
 }
 
 - (BOOL)screenHasView {

--- a/sources/PTYTextView.h
+++ b/sources/PTYTextView.h
@@ -236,7 +236,7 @@ typedef NS_ENUM(NSInteger, PTYTextViewSelectionExtensionUnit) {
 @property(nonatomic, assign) BOOL highlightCursorLine;
 
 // Draw a highlight along the entire column the cursor is in.
-@property(nonatomic, assign) BOOL highlightCursorCol;
+@property(nonatomic, assign) BOOL highlightCursorColumn;
 
 // Use the non-ascii font? If not set, use the regular font for all characters.
 @property(nonatomic, assign) BOOL useNonAsciiFont;
@@ -464,7 +464,7 @@ typedef void (^PTYTextViewDrawingHookBlock)(iTermTextDrawingHelper *);
 // onscreen is blinking.
 - (BOOL)refresh;
 - (void)setNeedsDisplayOnLine:(int)line;
-- (void)setNeedsDisplayOnCol:(int)col;
+- (void)setNeedsDisplayOnColumn:(int)column;
 - (void)setCursorNeedsDisplay;
 
 // selection

--- a/sources/PTYTextView.h
+++ b/sources/PTYTextView.h
@@ -464,6 +464,7 @@ typedef void (^PTYTextViewDrawingHookBlock)(iTermTextDrawingHelper *);
 // onscreen is blinking.
 - (BOOL)refresh;
 - (void)setNeedsDisplayOnLine:(int)line;
+- (void)setNeedsDisplayOnCol:(int)col;
 
 // selection
 - (IBAction)selectAll:(id)sender;

--- a/sources/PTYTextView.h
+++ b/sources/PTYTextView.h
@@ -235,6 +235,9 @@ typedef NS_ENUM(NSInteger, PTYTextViewSelectionExtensionUnit) {
 // Draw a highlight along the entire line the cursor is on.
 @property(nonatomic, assign) BOOL highlightCursorLine;
 
+// Draw a highlight along the entire column the cursor is in.
+@property(nonatomic, assign) BOOL highlightCursorColumn;
+
 // Use the non-ascii font? If not set, use the regular font for all characters.
 @property(nonatomic, assign) BOOL useNonAsciiFont;
 
@@ -461,6 +464,7 @@ typedef void (^PTYTextViewDrawingHookBlock)(iTermTextDrawingHelper *);
 // onscreen is blinking.
 - (BOOL)refresh;
 - (void)setNeedsDisplayOnLine:(int)line;
+- (void)setNeedsDisplayOnColumn:(int)column;
 - (void)setCursorNeedsDisplay;
 
 // selection

--- a/sources/PTYTextView.h
+++ b/sources/PTYTextView.h
@@ -236,7 +236,7 @@ typedef NS_ENUM(NSInteger, PTYTextViewSelectionExtensionUnit) {
 @property(nonatomic, assign) BOOL highlightCursorLine;
 
 // Draw a highlight along the entire column the cursor is in.
-@property(nonatomic, assign) BOOL highlightCursorCol;
+@property(nonatomic, assign) BOOL highlightCursorColumn;
 
 // Use the non-ascii font? If not set, use the regular font for all characters.
 @property(nonatomic, assign) BOOL useNonAsciiFont;
@@ -464,7 +464,7 @@ typedef void (^PTYTextViewDrawingHookBlock)(iTermTextDrawingHelper *);
 // onscreen is blinking.
 - (BOOL)refresh;
 - (void)setNeedsDisplayOnLine:(int)line;
-- (void)setNeedsDisplayOnCol:(int)col;
+- (void)setNeedsDisplayOnColumn:(int)column;
 
 // selection
 - (IBAction)selectAll:(id)sender;

--- a/sources/PTYTextView.h
+++ b/sources/PTYTextView.h
@@ -235,6 +235,9 @@ typedef NS_ENUM(NSInteger, PTYTextViewSelectionExtensionUnit) {
 // Draw a highlight along the entire line the cursor is on.
 @property(nonatomic, assign) BOOL highlightCursorLine;
 
+// Draw a highlight along the entire column the cursor is in.
+@property(nonatomic, assign) BOOL highlightCursorCol;
+
 // Use the non-ascii font? If not set, use the regular font for all characters.
 @property(nonatomic, assign) BOOL useNonAsciiFont;
 

--- a/sources/PTYTextView.h
+++ b/sources/PTYTextView.h
@@ -464,6 +464,7 @@ typedef void (^PTYTextViewDrawingHookBlock)(iTermTextDrawingHelper *);
 // onscreen is blinking.
 - (BOOL)refresh;
 - (void)setNeedsDisplayOnLine:(int)line;
+- (void)setNeedsDisplayOnCol:(int)col;
 - (void)setCursorNeedsDisplay;
 
 // selection

--- a/sources/PTYTextView.m
+++ b/sources/PTYTextView.m
@@ -978,6 +978,11 @@ static const int kDragThreshold = 3;
     [self setNeedsDisplayOnLine:line inRange:VT100GridRangeMake(0, _dataSource.width)];
 }
 
+- (void)setNeedsDisplayOnCol:(int)col
+{
+    [self setNeedsDisplayOnCol:col inRange:VT100GridRangeMake(0, _dataSource.height)];
+}
+
 // Overrides an NSView method.
 - (NSRect)adjustScroll:(NSRect)proposedVisibleRect {
     proposedVisibleRect.origin.y = (int)(proposedVisibleRect.origin.y / _lineHeight + 0.5) * _lineHeight;
@@ -6406,6 +6411,24 @@ scrollToFirstResult:(BOOL)scrollToFirstResult {
 
     DLog(@"Line %d is dirty in range [%d, %d), set rect %@ dirty",
          y, x, maxX, [NSValue valueWithRect:dirtyRect]);
+    [self setNeedsDisplayInRect:dirtyRect];
+}
+
+- (void)setNeedsDisplayOnCol:(int)x inRange:(VT100GridRange)range {
+    NSRect dirtyRect;
+    const int y = range.location;
+    const int maxY = range.location + range.length;
+
+    dirtyRect.origin.y = [iTermAdvancedSettingsModel terminalMargin] + y * _lineHeight; // _charHeightWithoutSpacing;
+    dirtyRect.origin.x = x * _charWidth;
+    dirtyRect.size.height = (maxY - y) * _lineHeight; //- _charHeightWithoutSpacing;
+    dirtyRect.size.width = _charWidth;
+
+    // Expand the rect in case we're drawing a changed cell with an oversize glyph.
+    dirtyRect = [self rectWithHalo:dirtyRect];
+
+    DLog(@"Column %d is dirty in range [%d, %d), set rect %@ dirty",
+         x, y, maxY, [NSValue valueWithRect:dirtyRect]);
     [self setNeedsDisplayInRect:dirtyRect];
 }
 

--- a/sources/PTYTextView.m
+++ b/sources/PTYTextView.m
@@ -581,6 +581,14 @@ static const int kDragThreshold = 3;
     return _drawingHelper.highlightCursorLine;
 }
 
+- (void)setHighlightCursorCol:(BOOL)highlightCursorCol {
+    _drawingHelper.highlightCursorCol = highlightCursorCol;
+}
+
+- (BOOL)highlightCursorCol {
+    return _drawingHelper.highlightCursorCol;
+}
+
 - (void)setUseNonAsciiFont:(BOOL)useNonAsciiFont {
     _drawingHelper.useNonAsciiFont = useNonAsciiFont;
     _useNonAsciiFont = useNonAsciiFont;

--- a/sources/PTYTextView.m
+++ b/sources/PTYTextView.m
@@ -581,6 +581,14 @@ static const int kDragThreshold = 3;
     return _drawingHelper.highlightCursorLine;
 }
 
+- (void)setHighlightCursorColumn:(BOOL)highlightCursorColumn {
+    _drawingHelper.highlightCursorColumn = highlightCursorColumn;
+}
+
+- (BOOL)highlightCursorColumn {
+    return _drawingHelper.highlightCursorColumn;
+}
+
 - (void)setUseNonAsciiFont:(BOOL)useNonAsciiFont {
     _drawingHelper.useNonAsciiFont = useNonAsciiFont;
     _useNonAsciiFont = useNonAsciiFont;
@@ -968,6 +976,16 @@ static const int kDragThreshold = 3;
 - (void)setNeedsDisplayOnLine:(int)line
 {
     [self setNeedsDisplayOnLine:line inRange:VT100GridRangeMake(0, _dataSource.width)];
+}
+
+- (void)setNeedsDisplayOnColumn:(int)column {
+    // We can only draw whole lines, not individual characters.  Consequently
+    // a request to redraw a column should only cause an update if there is
+    // something in the column outside the row that needs an update, such as the
+    // vertical cursor guide.
+    if ([self highlightCursorColumn]) {
+        [self setNeedsDisplayOnColumn:column inRange:VT100GridRangeMake(0, _dataSource.height)];
+    }
 }
 
 // Overrides an NSView method.
@@ -6399,6 +6417,16 @@ scrollToFirstResult:(BOOL)scrollToFirstResult {
     DLog(@"Line %d is dirty in range [%d, %d), set rect %@ dirty",
          y, x, maxX, [NSValue valueWithRect:dirtyRect]);
     [self setNeedsDisplayInRect:dirtyRect];
+}
+
+- (void)setNeedsDisplayOnColumn:(int)x inRange:(VT100GridRange)range {
+    // We can only draw whole lines, not individual characters.  Consequently
+    // a request to redraw a column should only cause an update if there is
+    // something in the column outside the row that needs an update, such as the
+    // vertical cursor guide.
+    if ([self highlightCursorColumn]) {
+        [self setNeedsDisplay:YES];
+    }
 }
 
 // WARNING: Do not call this function directly. Call

--- a/sources/PTYTextView.m
+++ b/sources/PTYTextView.m
@@ -581,12 +581,12 @@ static const int kDragThreshold = 3;
     return _drawingHelper.highlightCursorLine;
 }
 
-- (void)setHighlightCursorCol:(BOOL)highlightCursorCol {
-    _drawingHelper.highlightCursorCol = highlightCursorCol;
+- (void)setHighlightCursorColumn:(BOOL)highlightCursorColumn {
+    _drawingHelper.highlightCursorColumn = highlightCursorColumn;
 }
 
-- (BOOL)highlightCursorCol {
-    return _drawingHelper.highlightCursorCol;
+- (BOOL)highlightCursorColumn {
+    return _drawingHelper.highlightCursorColumn;
 }
 
 - (void)setUseNonAsciiFont:(BOOL)useNonAsciiFont {
@@ -978,9 +978,8 @@ static const int kDragThreshold = 3;
     [self setNeedsDisplayOnLine:line inRange:VT100GridRangeMake(0, _dataSource.width)];
 }
 
-- (void)setNeedsDisplayOnCol:(int)col
-{
-    [self setNeedsDisplayOnCol:col inRange:VT100GridRangeMake(0, _dataSource.height)];
+- (void)setNeedsDisplayOnColumn:(int)column {
+    [self setNeedsDisplayOnColumn:column inRange:VT100GridRangeMake(0, _dataSource.height)];
 }
 
 // Overrides an NSView method.
@@ -6414,7 +6413,7 @@ scrollToFirstResult:(BOOL)scrollToFirstResult {
     [self setNeedsDisplayInRect:dirtyRect];
 }
 
-- (void)setNeedsDisplayOnCol:(int)x inRange:(VT100GridRange)range {
+- (void)setNeedsDisplayOnColumn:(int)x inRange:(VT100GridRange)range {
     NSRect dirtyRect;
     const int y = range.location;
     const int maxY = range.location + range.length;

--- a/sources/PTYTextView.m
+++ b/sources/PTYTextView.m
@@ -978,6 +978,11 @@ static const int kDragThreshold = 3;
     [self setNeedsDisplayOnLine:line inRange:VT100GridRangeMake(0, _dataSource.width)];
 }
 
+- (void)setNeedsDisplayOnCol:(int)col
+{
+    [self setNeedsDisplayOnCol:col inRange:VT100GridRangeMake(0, _dataSource.height)];
+}
+
 // Overrides an NSView method.
 - (NSRect)adjustScroll:(NSRect)proposedVisibleRect {
     proposedVisibleRect.origin.y = (int)(proposedVisibleRect.origin.y / _lineHeight + 0.5) * _lineHeight;
@@ -6399,6 +6404,24 @@ scrollToFirstResult:(BOOL)scrollToFirstResult {
 
     DLog(@"Line %d is dirty in range [%d, %d), set rect %@ dirty",
          y, x, maxX, [NSValue valueWithRect:dirtyRect]);
+    [self setNeedsDisplayInRect:dirtyRect];
+}
+
+- (void)setNeedsDisplayOnCol:(int)x inRange:(VT100GridRange)range {
+    NSRect dirtyRect;
+    const int y = range.location;
+    const int maxY = range.location + range.length;
+
+    dirtyRect.origin.y = [iTermAdvancedSettingsModel terminalMargin] + y * _lineHeight; // _charHeightWithoutSpacing;
+    dirtyRect.origin.x = x * _charWidth;
+    dirtyRect.size.height = (maxY - y) * _lineHeight; //- _charHeightWithoutSpacing;
+    dirtyRect.size.width = _charWidth;
+
+    // Expand the rect in case we're drawing a changed cell with an oversize glyph.
+    dirtyRect = [self rectWithHalo:dirtyRect];
+
+    DLog(@"Column %d is dirty in range [%d, %d), set rect %@ dirty",
+         x, y, maxY, [NSValue valueWithRect:dirtyRect]);
     [self setNeedsDisplayInRect:dirtyRect];
 }
 

--- a/sources/PTYTextView.m
+++ b/sources/PTYTextView.m
@@ -979,7 +979,13 @@ static const int kDragThreshold = 3;
 }
 
 - (void)setNeedsDisplayOnColumn:(int)column {
-    [self setNeedsDisplayOnColumn:column inRange:VT100GridRangeMake(0, _dataSource.height)];
+    // We can only draw whole lines, not individual characters.  Consequently
+    // a request to redraw a column should only cause an update if there is
+    // something in the column outside the row that needs an update, such as the
+    // vertical cursor guide.
+    if ([self highlightCursorColumn]) {
+        [self setNeedsDisplayOnColumn:column inRange:VT100GridRangeMake(0, _dataSource.height)];
+    }
 }
 
 // Overrides an NSView method.
@@ -6407,21 +6413,13 @@ scrollToFirstResult:(BOOL)scrollToFirstResult {
 }
 
 - (void)setNeedsDisplayOnColumn:(int)x inRange:(VT100GridRange)range {
-    NSRect dirtyRect;
-    const int y = range.location;
-    const int maxY = range.location + range.length;
-
-    dirtyRect.origin.y = [iTermAdvancedSettingsModel terminalMargin] + y * _lineHeight; // _charHeightWithoutSpacing;
-    dirtyRect.origin.x = x * _charWidth;
-    dirtyRect.size.height = (maxY - y) * _lineHeight; //- _charHeightWithoutSpacing;
-    dirtyRect.size.width = _charWidth;
-
-    // Expand the rect in case we're drawing a changed cell with an oversize glyph.
-    dirtyRect = [self rectWithHalo:dirtyRect];
-
-    DLog(@"Column %d is dirty in range [%d, %d), set rect %@ dirty",
-         x, y, maxY, [NSValue valueWithRect:dirtyRect]);
-    [self setNeedsDisplayInRect:dirtyRect];
+    // We can only draw whole lines, not individual characters.  Consequently
+    // a request to redraw a column should only cause an update if there is
+    // something in the column outside the row that needs an update, such as the
+    // vertical cursor guide.
+    if ([self highlightCursorColumn]) {
+        [self setNeedsDisplay:YES];
+    }
 }
 
 // WARNING: Do not call this function directly. Call

--- a/sources/PTYTextView.m
+++ b/sources/PTYTextView.m
@@ -581,12 +581,12 @@ static const int kDragThreshold = 3;
     return _drawingHelper.highlightCursorLine;
 }
 
-- (void)setHighlightCursorCol:(BOOL)highlightCursorCol {
-    _drawingHelper.highlightCursorCol = highlightCursorCol;
+- (void)setHighlightCursorColumn:(BOOL)highlightCursorColumn {
+    _drawingHelper.highlightCursorColumn = highlightCursorColumn;
 }
 
-- (BOOL)highlightCursorCol {
-    return _drawingHelper.highlightCursorCol;
+- (BOOL)highlightCursorColumn {
+    return _drawingHelper.highlightCursorColumn;
 }
 
 - (void)setUseNonAsciiFont:(BOOL)useNonAsciiFont {
@@ -978,9 +978,8 @@ static const int kDragThreshold = 3;
     [self setNeedsDisplayOnLine:line inRange:VT100GridRangeMake(0, _dataSource.width)];
 }
 
-- (void)setNeedsDisplayOnCol:(int)col
-{
-    [self setNeedsDisplayOnCol:col inRange:VT100GridRangeMake(0, _dataSource.height)];
+- (void)setNeedsDisplayOnColumn:(int)col {
+    [self setNeedsDisplayOnColumn:col inRange:VT100GridRangeMake(0, _dataSource.height)];
 }
 
 // Overrides an NSView method.
@@ -6407,7 +6406,7 @@ scrollToFirstResult:(BOOL)scrollToFirstResult {
     [self setNeedsDisplayInRect:dirtyRect];
 }
 
-- (void)setNeedsDisplayOnCol:(int)x inRange:(VT100GridRange)range {
+- (void)setNeedsDisplayOnColumn:(int)x inRange:(VT100GridRange)range {
     NSRect dirtyRect;
     const int y = range.location;
     const int maxY = range.location + range.length;

--- a/sources/PTYTextView.m
+++ b/sources/PTYTextView.m
@@ -978,8 +978,8 @@ static const int kDragThreshold = 3;
     [self setNeedsDisplayOnLine:line inRange:VT100GridRangeMake(0, _dataSource.width)];
 }
 
-- (void)setNeedsDisplayOnColumn:(int)col {
-    [self setNeedsDisplayOnColumn:col inRange:VT100GridRangeMake(0, _dataSource.height)];
+- (void)setNeedsDisplayOnColumn:(int)column {
+    [self setNeedsDisplayOnColumn:column inRange:VT100GridRangeMake(0, _dataSource.height)];
 }
 
 // Overrides an NSView method.

--- a/sources/ProfilesColorsPreferencesViewController.m
+++ b/sources/ProfilesColorsPreferencesViewController.m
@@ -79,6 +79,7 @@ static NSString * const kColorGalleryURL = @"https://www.iterm2.com/colorgallery
     IBOutlet NSMenu *_presetsMenu;
 
     IBOutlet NSButton *_useGuide;
+    IBOutlet NSButton *_useVGuide;
     IBOutlet CPKColorWell *_guideColor;
 
     IBOutlet NSPopUpButton *_presetsPopupButton;
@@ -201,6 +202,10 @@ static NSString * const kColorGalleryURL = @"https://www.iterm2.com/colorgallery
     [self defineControl:_useGuide
                     key:KEY_USE_CURSOR_GUIDE
             relatedView:nil
+                   type:kPreferenceInfoTypeCheckbox];
+
+    [self defineControl:_useVGuide
+                    key:KEY_USE_VERT_CURSOR_GUIDE
                    type:kPreferenceInfoTypeCheckbox];
 
     info = [self defineControl:_useBrightBold

--- a/sources/ProfilesColorsPreferencesViewController.m
+++ b/sources/ProfilesColorsPreferencesViewController.m
@@ -79,6 +79,7 @@ static NSString * const kColorGalleryURL = @"https://www.iterm2.com/colorgallery
     IBOutlet NSMenu *_presetsMenu;
 
     IBOutlet NSButton *_useGuide;
+    IBOutlet NSButton *_useVerticalGuide;
     IBOutlet CPKColorWell *_guideColor;
 
     IBOutlet NSPopUpButton *_presetsPopupButton;
@@ -200,6 +201,11 @@ static NSString * const kColorGalleryURL = @"https://www.iterm2.com/colorgallery
 
     [self defineControl:_useGuide
                     key:KEY_USE_CURSOR_GUIDE
+            relatedView:nil
+                   type:kPreferenceInfoTypeCheckbox];
+
+    [self defineControl:_useVerticalGuide
+                    key:KEY_USE_VERTICAL_CURSOR_GUIDE
             relatedView:nil
                    type:kPreferenceInfoTypeCheckbox];
 

--- a/sources/ProfilesColorsPreferencesViewController.m
+++ b/sources/ProfilesColorsPreferencesViewController.m
@@ -206,6 +206,7 @@ static NSString * const kColorGalleryURL = @"https://www.iterm2.com/colorgallery
 
     [self defineControl:_useVerticalGuide
                     key:KEY_USE_VERTICAL_CURSOR_GUIDE
+            relatedView:nil
                    type:kPreferenceInfoTypeCheckbox];
 
     info = [self defineControl:_useBrightBold

--- a/sources/ProfilesColorsPreferencesViewController.m
+++ b/sources/ProfilesColorsPreferencesViewController.m
@@ -62,7 +62,7 @@ static NSString * const kColorGalleryURL = @"https://www.iterm2.com/colorgallery
     IBOutlet NSMenu *_presetsMenu;
 
     IBOutlet NSButton *_useGuide;
-    IBOutlet NSButton *_useVGuide;
+    IBOutlet NSButton *_useVerticalGuide;
     IBOutlet CPKColorWell *_guideColor;
 
     IBOutlet NSPopUpButton *_presetsPopupButton;
@@ -172,8 +172,8 @@ static NSString * const kColorGalleryURL = @"https://www.iterm2.com/colorgallery
                     key:KEY_USE_CURSOR_GUIDE
                    type:kPreferenceInfoTypeCheckbox];
 
-    [self defineControl:_useVGuide
-                    key:KEY_USE_VERT_CURSOR_GUIDE
+    [self defineControl:_useVerticalGuide
+                    key:KEY_USE_VERTICAL_CURSOR_GUIDE
                    type:kPreferenceInfoTypeCheckbox];
 
     info = [self defineControl:_useBrightBold

--- a/sources/ProfilesColorsPreferencesViewController.m
+++ b/sources/ProfilesColorsPreferencesViewController.m
@@ -62,6 +62,7 @@ static NSString * const kColorGalleryURL = @"https://www.iterm2.com/colorgallery
     IBOutlet NSMenu *_presetsMenu;
 
     IBOutlet NSButton *_useGuide;
+    IBOutlet NSButton *_useVGuide;
     IBOutlet CPKColorWell *_guideColor;
 
     IBOutlet NSPopUpButton *_presetsPopupButton;
@@ -169,6 +170,10 @@ static NSString * const kColorGalleryURL = @"https://www.iterm2.com/colorgallery
 
     [self defineControl:_useGuide
                     key:KEY_USE_CURSOR_GUIDE
+                   type:kPreferenceInfoTypeCheckbox];
+
+    [self defineControl:_useVGuide
+                    key:KEY_USE_VERT_CURSOR_GUIDE
                    type:kPreferenceInfoTypeCheckbox];
 
     info = [self defineControl:_useBrightBold

--- a/sources/ProfilesColorsPreferencesViewController.m
+++ b/sources/ProfilesColorsPreferencesViewController.m
@@ -209,10 +209,6 @@ static NSString * const kColorGalleryURL = @"https://www.iterm2.com/colorgallery
             relatedView:nil
                    type:kPreferenceInfoTypeCheckbox];
 
-    [self defineControl:_useVerticalGuide
-                    key:KEY_USE_VERTICAL_CURSOR_GUIDE
-                   type:kPreferenceInfoTypeCheckbox];
-
     info = [self defineControl:_useBrightBold
                            key:KEY_USE_BOLD_COLOR
                    displayName:@"Custom color for bold text"

--- a/sources/ProfilesColorsPreferencesViewController.m
+++ b/sources/ProfilesColorsPreferencesViewController.m
@@ -79,7 +79,7 @@ static NSString * const kColorGalleryURL = @"https://www.iterm2.com/colorgallery
     IBOutlet NSMenu *_presetsMenu;
 
     IBOutlet NSButton *_useGuide;
-    IBOutlet NSButton *_useVGuide;
+    IBOutlet NSButton *_useVerticalGuide;
     IBOutlet CPKColorWell *_guideColor;
 
     IBOutlet NSPopUpButton *_presetsPopupButton;
@@ -204,8 +204,8 @@ static NSString * const kColorGalleryURL = @"https://www.iterm2.com/colorgallery
             relatedView:nil
                    type:kPreferenceInfoTypeCheckbox];
 
-    [self defineControl:_useVGuide
-                    key:KEY_USE_VERT_CURSOR_GUIDE
+    [self defineControl:_useVerticalGuide
+                    key:KEY_USE_VERTICAL_CURSOR_GUIDE
                    type:kPreferenceInfoTypeCheckbox];
 
     info = [self defineControl:_useBrightBold

--- a/sources/PseudoTerminal.m
+++ b/sources/PseudoTerminal.m
@@ -1782,6 +1782,11 @@ ITERM_WEAKLY_REFERENCEABLE
   session.highlightCursorLine = !session.highlightCursorLine;
 }
 
+- (IBAction)toggleVCursorGuide:(id)sender {
+    PTYSession *session = [self currentSession];
+    session.highlightCursorCol = !session.highlightCursorCol;
+}
+
 - (IBAction)toggleSelectionRespectsSoftBoundaries:(id)sender {
     iTermController *controller = [iTermController sharedInstance];
     controller.selectionRespectsSoftBoundaries = !controller.selectionRespectsSoftBoundaries;
@@ -8589,6 +8594,10 @@ static CGFloat iTermDimmingAmount(PSMTabBarControl *tabView) {
     } else if ([item action] == @selector(toggleCursorGuide:)) {
         PTYSession *session = [self currentSession];
         [item setState:session.highlightCursorLine ? NSOnState : NSOffState];
+        result = YES;
+    } else if ([item action] == @selector(toggleVCursorGuide:)) {
+        PTYSession *session = [self currentSession];
+        [item setState:session.highlightCursorCol ? NSOnState : NSOffState];
         result = YES;
     } else if ([item action] == @selector(toggleSelectionRespectsSoftBoundaries:)) {
         [item setState:[[iTermController sharedInstance] selectionRespectsSoftBoundaries] ? NSOnState : NSOffState];

--- a/sources/PseudoTerminal.m
+++ b/sources/PseudoTerminal.m
@@ -5423,7 +5423,6 @@ ITERM_WEAKLY_REFERENCEABLE
 - (NSImage *)imageFromSelectedTabView:(NSTabView *)aTabView
                           tabViewItem:(NSTabViewItem *)tabViewItem {
     NSView *tabRootView = [tabViewItem view];
-    NSRect tabFrame = [_contentView.tabBarControl frame];
 
     NSRect contentFrame;
     NSRect viewRect;

--- a/sources/PseudoTerminal.m
+++ b/sources/PseudoTerminal.m
@@ -1787,6 +1787,11 @@ ITERM_WEAKLY_REFERENCEABLE
   session.highlightCursorLine = !session.highlightCursorLine;
 }
 
+- (IBAction)toggleVCursorGuide:(id)sender {
+    PTYSession *session = [self currentSession];
+    session.highlightCursorCol = !session.highlightCursorCol;
+}
+
 - (IBAction)toggleSelectionRespectsSoftBoundaries:(id)sender {
     iTermController *controller = [iTermController sharedInstance];
     controller.selectionRespectsSoftBoundaries = !controller.selectionRespectsSoftBoundaries;
@@ -8602,6 +8607,10 @@ static CGFloat iTermDimmingAmount(PSMTabBarControl *tabView) {
     } else if ([item action] == @selector(toggleCursorGuide:)) {
         PTYSession *session = [self currentSession];
         [item setState:session.highlightCursorLine ? NSOnState : NSOffState];
+        result = YES;
+    } else if ([item action] == @selector(toggleVCursorGuide:)) {
+        PTYSession *session = [self currentSession];
+        [item setState:session.highlightCursorCol ? NSOnState : NSOffState];
         result = YES;
     } else if ([item action] == @selector(toggleSelectionRespectsSoftBoundaries:)) {
         [item setState:[[iTermController sharedInstance] selectionRespectsSoftBoundaries] ? NSOnState : NSOffState];

--- a/sources/PseudoTerminal.m
+++ b/sources/PseudoTerminal.m
@@ -1782,9 +1782,9 @@ ITERM_WEAKLY_REFERENCEABLE
   session.highlightCursorLine = !session.highlightCursorLine;
 }
 
-- (IBAction)toggleVCursorGuide:(id)sender {
+- (IBAction)toggleVerticalCursorGuide:(id)sender {
     PTYSession *session = [self currentSession];
-    session.highlightCursorCol = !session.highlightCursorCol;
+    session.highlightCursorColumn = !session.highlightCursorColumn;
 }
 
 - (IBAction)toggleSelectionRespectsSoftBoundaries:(id)sender {
@@ -8595,9 +8595,9 @@ static CGFloat iTermDimmingAmount(PSMTabBarControl *tabView) {
         PTYSession *session = [self currentSession];
         [item setState:session.highlightCursorLine ? NSOnState : NSOffState];
         result = YES;
-    } else if ([item action] == @selector(toggleVCursorGuide:)) {
+    } else if ([item action] == @selector(toggleVerticalCursorGuide:)) {
         PTYSession *session = [self currentSession];
-        [item setState:session.highlightCursorCol ? NSOnState : NSOffState];
+        [item setState:session.highlightCursorColumn ? NSOnState : NSOffState];
         result = YES;
     } else if ([item action] == @selector(toggleSelectionRespectsSoftBoundaries:)) {
         [item setState:[[iTermController sharedInstance] selectionRespectsSoftBoundaries] ? NSOnState : NSOffState];

--- a/sources/PseudoTerminal.m
+++ b/sources/PseudoTerminal.m
@@ -1787,9 +1787,9 @@ ITERM_WEAKLY_REFERENCEABLE
   session.highlightCursorLine = !session.highlightCursorLine;
 }
 
-- (IBAction)toggleVCursorGuide:(id)sender {
+- (IBAction)toggleVerticalCursorGuide:(id)sender {
     PTYSession *session = [self currentSession];
-    session.highlightCursorCol = !session.highlightCursorCol;
+    session.highlightCursorColumn = !session.highlightCursorColumn;
 }
 
 - (IBAction)toggleSelectionRespectsSoftBoundaries:(id)sender {
@@ -8608,9 +8608,9 @@ static CGFloat iTermDimmingAmount(PSMTabBarControl *tabView) {
         PTYSession *session = [self currentSession];
         [item setState:session.highlightCursorLine ? NSOnState : NSOffState];
         result = YES;
-    } else if ([item action] == @selector(toggleVCursorGuide:)) {
+    } else if ([item action] == @selector(toggleVerticalCursorGuide:)) {
         PTYSession *session = [self currentSession];
-        [item setState:session.highlightCursorCol ? NSOnState : NSOffState];
+        [item setState:session.highlightCursorColumn ? NSOnState : NSOffState];
         result = YES;
     } else if ([item action] == @selector(toggleSelectionRespectsSoftBoundaries:)) {
         [item setState:[[iTermController sharedInstance] selectionRespectsSoftBoundaries] ? NSOnState : NSOffState];

--- a/sources/PseudoTerminal.m
+++ b/sources/PseudoTerminal.m
@@ -1788,6 +1788,11 @@ ITERM_WEAKLY_REFERENCEABLE
   session.highlightCursorLine = !session.highlightCursorLine;
 }
 
+- (IBAction)toggleVerticalCursorGuide:(id)sender {
+    PTYSession *session = [self currentSession];
+    session.highlightCursorColumn = !session.highlightCursorColumn;
+}
+
 - (IBAction)toggleSelectionRespectsSoftBoundaries:(id)sender {
     iTermController *controller = [iTermController sharedInstance];
     controller.selectionRespectsSoftBoundaries = !controller.selectionRespectsSoftBoundaries;
@@ -5421,7 +5426,6 @@ ITERM_WEAKLY_REFERENCEABLE
 - (NSImage *)imageFromSelectedTabView:(NSTabView *)aTabView
                           tabViewItem:(NSTabViewItem *)tabViewItem {
     NSView *tabRootView = [tabViewItem view];
-    NSRect tabFrame = [_contentView.tabBarControl frame];
 
     NSRect contentFrame;
     NSRect viewRect;
@@ -8606,6 +8610,10 @@ static CGFloat iTermDimmingAmount(PSMTabBarControl *tabView) {
     } else if ([item action] == @selector(toggleCursorGuide:)) {
         PTYSession *session = [self currentSession];
         [item setState:session.highlightCursorLine ? NSOnState : NSOffState];
+        result = YES;
+    } else if ([item action] == @selector(toggleVerticalCursorGuide:)) {
+        PTYSession *session = [self currentSession];
+        [item setState:session.highlightCursorColumn ? NSOnState : NSOffState];
         result = YES;
     } else if ([item action] == @selector(toggleSelectionRespectsSoftBoundaries:)) {
         [item setState:[[iTermController sharedInstance] selectionRespectsSoftBoundaries] ? NSOnState : NSOffState];

--- a/sources/VT100Grid.h
+++ b/sources/VT100Grid.h
@@ -21,7 +21,7 @@
 - (iTermUnicodeNormalization)gridUnicodeNormalizationForm;
 - (void)gridCursorDidMove;
 - (void)gridCursorDidChangeLine;
-- (void)gridCursorDidChangeCol;
+- (void)gridCursorDidChangeColumn;
 @end
 
 @interface VT100Grid : NSObject<NSCopying>

--- a/sources/VT100Grid.h
+++ b/sources/VT100Grid.h
@@ -21,6 +21,7 @@
 - (iTermUnicodeNormalization)gridUnicodeNormalizationForm;
 - (void)gridCursorDidMove;
 - (void)gridCursorDidChangeLine;
+- (void)gridCursorDidChangeColumn;
 @end
 
 @interface VT100Grid : NSObject<NSCopying>

--- a/sources/VT100Grid.h
+++ b/sources/VT100Grid.h
@@ -21,6 +21,7 @@
 - (iTermUnicodeNormalization)gridUnicodeNormalizationForm;
 - (void)gridCursorDidMove;
 - (void)gridCursorDidChangeLine;
+- (void)gridCursorDidChangeCol;
 @end
 
 @interface VT100Grid : NSObject<NSCopying>

--- a/sources/VT100Grid.m
+++ b/sources/VT100Grid.m
@@ -183,6 +183,7 @@ static NSString *const kGridSizeKey = @"Size";
     int newX = MIN(size_.width, MAX(0, cursorX));
     if (newX != cursor_.x) {
         cursor_.x = newX;
+        [delegate_ gridCursorDidChangeColumn];
         [delegate_ gridCursorDidMove];
     }
 }

--- a/sources/VT100Grid.m
+++ b/sources/VT100Grid.m
@@ -183,6 +183,7 @@ static NSString *const kGridSizeKey = @"Size";
     int newX = MIN(size_.width, MAX(0, cursorX));
     if (newX != cursor_.x) {
         cursor_.x = newX;
+        [delegate_ gridCursorDidChangeCol];
         [delegate_ gridCursorDidMove];
     }
 }

--- a/sources/VT100Grid.m
+++ b/sources/VT100Grid.m
@@ -183,7 +183,7 @@ static NSString *const kGridSizeKey = @"Size";
     int newX = MIN(size_.width, MAX(0, cursorX));
     if (newX != cursor_.x) {
         cursor_.x = newX;
-        [delegate_ gridCursorDidChangeCol];
+        [delegate_ gridCursorDidChangeColumn];
         [delegate_ gridCursorDidMove];
     }
 }

--- a/sources/VT100Screen.h
+++ b/sources/VT100Screen.h
@@ -58,6 +58,7 @@ extern int kVT100ScreenMinRows;
 @property(nonatomic, assign) BOOL saveToScrollbackInAlternateScreen;
 @property(nonatomic, retain) DVR *dvr;
 @property(nonatomic, assign) BOOL trackCursorLineMovement;
+@property(nonatomic, assign) BOOL trackCursorColumnMovement;
 @property(nonatomic, assign) BOOL appendToScrollbackWithStatusBar;
 @property(nonatomic, readonly) VT100GridAbsCoordRange lastCommandOutputRange;
 @property(nonatomic, assign) iTermUnicodeNormalization normalization;

--- a/sources/VT100Screen.h
+++ b/sources/VT100Screen.h
@@ -58,6 +58,7 @@ extern int kVT100ScreenMinRows;
 @property(nonatomic, assign) BOOL saveToScrollbackInAlternateScreen;
 @property(nonatomic, retain) DVR *dvr;
 @property(nonatomic, assign) BOOL trackCursorLineMovement;
+@property(nonatomic, assign) BOOL trackCursorColMovement;
 @property(nonatomic, assign) BOOL appendToScrollbackWithStatusBar;
 @property(nonatomic, readonly) VT100GridAbsCoordRange lastCommandOutputRange;
 @property(nonatomic, assign) iTermUnicodeNormalization normalization;

--- a/sources/VT100Screen.h
+++ b/sources/VT100Screen.h
@@ -58,7 +58,7 @@ extern int kVT100ScreenMinRows;
 @property(nonatomic, assign) BOOL saveToScrollbackInAlternateScreen;
 @property(nonatomic, retain) DVR *dvr;
 @property(nonatomic, assign) BOOL trackCursorLineMovement;
-@property(nonatomic, assign) BOOL trackCursorColMovement;
+@property(nonatomic, assign) BOOL trackCursorColumnMovement;
 @property(nonatomic, assign) BOOL appendToScrollbackWithStatusBar;
 @property(nonatomic, readonly) VT100GridAbsCoordRange lastCommandOutputRange;
 @property(nonatomic, assign) iTermUnicodeNormalization normalization;

--- a/sources/VT100Screen.m
+++ b/sources/VT100Screen.m
@@ -52,6 +52,7 @@ NSString *const kScreenStateCommandStartYKey = @"Command Start Y";
 NSString *const kScreenStateNextCommandOutputStartKey = @"Output Start";
 NSString *const kScreenStateCursorVisibleKey = @"Cursor Visible";
 NSString *const kScreenStateTrackCursorLineMovementKey = @"Track Cursor Line";
+NSString *const kScreenStateTrackCursorColumnMovementKey = @"Track Cursor Column";
 NSString *const kScreenStateLastCommandOutputRangeKey = @"Last Command Output Range";
 NSString *const kScreenStateShellIntegrationInstalledKey = @"Shell Integration Installed";
 NSString *const kScreenStateLastCommandMarkKey = @"Last Command Mark";
@@ -4139,6 +4140,10 @@ basedAtAbsoluteLineNumber:(long long)absoluteLineNumber
     [delegate_ screenSetHighlightCursorLine:highlight];
 }
 
+- (void)terminalSetHighlightCursorColumn:(BOOL)highlight {
+    [delegate_ screenSetHighlightCursorColumn:highlight];
+}
+
 - (void)terminalPromptDidStart {
     [self promptDidStartAt:VT100GridAbsCoordMake(currentGrid_.cursor.x,
                                                  currentGrid_.cursor.y + self.numberOfScrollbackLines + self.totalScrollbackOverflow)];
@@ -5303,6 +5308,12 @@ static void SwapInt(int *a, int *b) {
     }
 }
 
+- (void)gridCursorDidChangeColumn {
+    if (_trackCursorColumnMovement) {
+        [delegate_ screenCursorDidMoveToColumn:currentGrid_.cursorX];
+    }
+}
+
 - (iTermUnicodeNormalization)gridUnicodeNormalizationForm {
     return _normalization;
 }
@@ -5360,6 +5371,7 @@ static void SwapInt(int *a, int *b) {
             kScreenStateNextCommandOutputStartKey: [NSDictionary dictionaryWithGridAbsCoord:_startOfRunningCommandOutput],
             kScreenStateCursorVisibleKey: @(_cursorVisible),
             kScreenStateTrackCursorLineMovementKey: @(_trackCursorLineMovement),
+            kScreenStateTrackCursorColumnMovementKey: @(_trackCursorColumnMovement),
             kScreenStateLastCommandOutputRangeKey: [NSDictionary dictionaryWithGridAbsCoordRange:_lastCommandOutputRange],
             kScreenStateShellIntegrationInstalledKey: @(_shellIntegrationInstalled),
             kScreenStateLastCommandMarkKey: _lastCommandMark.guid ?: [NSNull null],
@@ -5474,6 +5486,7 @@ static void SwapInt(int *a, int *b) {
         _startOfRunningCommandOutput = [screenState[kScreenStateNextCommandOutputStartKey] gridAbsCoord];
         _cursorVisible = [screenState[kScreenStateCursorVisibleKey] boolValue];
         _trackCursorLineMovement = [screenState[kScreenStateTrackCursorLineMovementKey] boolValue];
+        _trackCursorColumnMovement = [screenState[kScreenStateTrackCursorColumnMovementKey] boolValue];
         _lastCommandOutputRange = [screenState[kScreenStateLastCommandOutputRangeKey] gridAbsCoordRange];
         _shellIntegrationInstalled = [screenState[kScreenStateShellIntegrationInstalledKey] boolValue];
 

--- a/sources/VT100Screen.m
+++ b/sources/VT100Screen.m
@@ -52,6 +52,7 @@ NSString *const kScreenStateCommandStartYKey = @"Command Start Y";
 NSString *const kScreenStateNextCommandOutputStartKey = @"Output Start";
 NSString *const kScreenStateCursorVisibleKey = @"Cursor Visible";
 NSString *const kScreenStateTrackCursorLineMovementKey = @"Track Cursor Line";
+NSString *const kScreenStateTrackCursorColumnMovementKey = @"Track Cursor Column";
 NSString *const kScreenStateLastCommandOutputRangeKey = @"Last Command Output Range";
 NSString *const kScreenStateShellIntegrationInstalledKey = @"Shell Integration Installed";
 NSString *const kScreenStateLastCommandMarkKey = @"Last Command Mark";
@@ -4139,8 +4140,8 @@ basedAtAbsoluteLineNumber:(long long)absoluteLineNumber
     [delegate_ screenSetHighlightCursorLine:highlight];
 }
 
-- (void)terminalSetHighlightCursorCol:(BOOL)highlight {
-    [delegate_ screenSetHighlightCursorCol:highlight];
+- (void)terminalSetHighlightCursorColumn:(BOOL)highlight {
+    [delegate_ screenSetHighlightCursorColumn:highlight];
 }
 
 - (void)terminalPromptDidStart {
@@ -5307,6 +5308,12 @@ static void SwapInt(int *a, int *b) {
     }
 }
 
+- (void)gridCursorDidChangeColumn {
+    if (_trackCursorColumnMovement) {
+        [delegate_ screenCursorDidMoveToColumn:currentGrid_.cursorX];
+    }
+}
+
 - (iTermUnicodeNormalization)gridUnicodeNormalizationForm {
     return _normalization;
 }
@@ -5364,6 +5371,7 @@ static void SwapInt(int *a, int *b) {
             kScreenStateNextCommandOutputStartKey: [NSDictionary dictionaryWithGridAbsCoord:_startOfRunningCommandOutput],
             kScreenStateCursorVisibleKey: @(_cursorVisible),
             kScreenStateTrackCursorLineMovementKey: @(_trackCursorLineMovement),
+            kScreenStateTrackCursorColumnMovementKey: @(_trackCursorColumnMovement),
             kScreenStateLastCommandOutputRangeKey: [NSDictionary dictionaryWithGridAbsCoordRange:_lastCommandOutputRange],
             kScreenStateShellIntegrationInstalledKey: @(_shellIntegrationInstalled),
             kScreenStateLastCommandMarkKey: _lastCommandMark.guid ?: [NSNull null],
@@ -5478,6 +5486,7 @@ static void SwapInt(int *a, int *b) {
         _startOfRunningCommandOutput = [screenState[kScreenStateNextCommandOutputStartKey] gridAbsCoord];
         _cursorVisible = [screenState[kScreenStateCursorVisibleKey] boolValue];
         _trackCursorLineMovement = [screenState[kScreenStateTrackCursorLineMovementKey] boolValue];
+        _trackCursorColumnMovement = [screenState[kScreenStateTrackCursorColumnMovementKey] boolValue];
         _lastCommandOutputRange = [screenState[kScreenStateLastCommandOutputRangeKey] gridAbsCoordRange];
         _shellIntegrationInstalled = [screenState[kScreenStateShellIntegrationInstalledKey] boolValue];
 

--- a/sources/VT100Screen.m
+++ b/sources/VT100Screen.m
@@ -52,7 +52,7 @@ NSString *const kScreenStateCommandStartYKey = @"Command Start Y";
 NSString *const kScreenStateNextCommandOutputStartKey = @"Output Start";
 NSString *const kScreenStateCursorVisibleKey = @"Cursor Visible";
 NSString *const kScreenStateTrackCursorLineMovementKey = @"Track Cursor Line";
-NSString *const kScreenStateTrackCursorColMovementKey = @"Track Cursor Col";
+NSString *const kScreenStateTrackCursorColumnMovementKey = @"Track Cursor Column";
 NSString *const kScreenStateLastCommandOutputRangeKey = @"Last Command Output Range";
 NSString *const kScreenStateShellIntegrationInstalledKey = @"Shell Integration Installed";
 NSString *const kScreenStateLastCommandMarkKey = @"Last Command Mark";
@@ -4140,8 +4140,8 @@ basedAtAbsoluteLineNumber:(long long)absoluteLineNumber
     [delegate_ screenSetHighlightCursorLine:highlight];
 }
 
-- (void)terminalSetHighlightCursorCol:(BOOL)highlight {
-    [delegate_ screenSetHighlightCursorCol:highlight];
+- (void)terminalSetHighlightCursorColumn:(BOOL)highlight {
+    [delegate_ screenSetHighlightCursorColumn:highlight];
 }
 
 - (void)terminalPromptDidStart {
@@ -5308,9 +5308,9 @@ static void SwapInt(int *a, int *b) {
     }
 }
 
-- (void)gridCursorDidChangeCol {
-    if (_trackCursorColMovement) {
-        [delegate_ screenCursorDidMoveToCol:currentGrid_.cursorX];
+- (void)gridCursorDidChangeColumn {
+    if (_trackCursorColumnMovement) {
+        [delegate_ screenCursorDidMoveToColumn:currentGrid_.cursorX];
     }
 }
 
@@ -5371,7 +5371,7 @@ static void SwapInt(int *a, int *b) {
             kScreenStateNextCommandOutputStartKey: [NSDictionary dictionaryWithGridAbsCoord:_startOfRunningCommandOutput],
             kScreenStateCursorVisibleKey: @(_cursorVisible),
             kScreenStateTrackCursorLineMovementKey: @(_trackCursorLineMovement),
-            kScreenStateTrackCursorColMovementKey: @(_trackCursorColMovement),
+            kScreenStateTrackCursorColumnMovementKey: @(_trackCursorColumnMovement),
             kScreenStateLastCommandOutputRangeKey: [NSDictionary dictionaryWithGridAbsCoordRange:_lastCommandOutputRange],
             kScreenStateShellIntegrationInstalledKey: @(_shellIntegrationInstalled),
             kScreenStateLastCommandMarkKey: _lastCommandMark.guid ?: [NSNull null],
@@ -5486,7 +5486,7 @@ static void SwapInt(int *a, int *b) {
         _startOfRunningCommandOutput = [screenState[kScreenStateNextCommandOutputStartKey] gridAbsCoord];
         _cursorVisible = [screenState[kScreenStateCursorVisibleKey] boolValue];
         _trackCursorLineMovement = [screenState[kScreenStateTrackCursorLineMovementKey] boolValue];
-        _trackCursorColMovement = [screenState[kScreenStateTrackCursorColMovementKey] boolValue];
+        _trackCursorColumnMovement = [screenState[kScreenStateTrackCursorColumnMovementKey] boolValue];
         _lastCommandOutputRange = [screenState[kScreenStateLastCommandOutputRangeKey] gridAbsCoordRange];
         _shellIntegrationInstalled = [screenState[kScreenStateShellIntegrationInstalledKey] boolValue];
 

--- a/sources/VT100Screen.m
+++ b/sources/VT100Screen.m
@@ -4139,6 +4139,10 @@ basedAtAbsoluteLineNumber:(long long)absoluteLineNumber
     [delegate_ screenSetHighlightCursorLine:highlight];
 }
 
+- (void)terminalSetHighlightCursorCol:(BOOL)highlight {
+    [delegate_ screenSetHighlightCursorCol:highlight];
+}
+
 - (void)terminalPromptDidStart {
     [self promptDidStartAt:VT100GridAbsCoordMake(currentGrid_.cursor.x,
                                                  currentGrid_.cursor.y + self.numberOfScrollbackLines + self.totalScrollbackOverflow)];

--- a/sources/VT100Screen.m
+++ b/sources/VT100Screen.m
@@ -52,6 +52,7 @@ NSString *const kScreenStateCommandStartYKey = @"Command Start Y";
 NSString *const kScreenStateNextCommandOutputStartKey = @"Output Start";
 NSString *const kScreenStateCursorVisibleKey = @"Cursor Visible";
 NSString *const kScreenStateTrackCursorLineMovementKey = @"Track Cursor Line";
+NSString *const kScreenStateTrackCursorColMovementKey = @"Track Cursor Col";
 NSString *const kScreenStateLastCommandOutputRangeKey = @"Last Command Output Range";
 NSString *const kScreenStateShellIntegrationInstalledKey = @"Shell Integration Installed";
 NSString *const kScreenStateLastCommandMarkKey = @"Last Command Mark";
@@ -5307,6 +5308,12 @@ static void SwapInt(int *a, int *b) {
     }
 }
 
+- (void)gridCursorDidChangeCol {
+    if (_trackCursorColMovement) {
+        [delegate_ screenCursorDidMoveToCol:currentGrid_.cursorX];
+    }
+}
+
 - (iTermUnicodeNormalization)gridUnicodeNormalizationForm {
     return _normalization;
 }
@@ -5364,6 +5371,7 @@ static void SwapInt(int *a, int *b) {
             kScreenStateNextCommandOutputStartKey: [NSDictionary dictionaryWithGridAbsCoord:_startOfRunningCommandOutput],
             kScreenStateCursorVisibleKey: @(_cursorVisible),
             kScreenStateTrackCursorLineMovementKey: @(_trackCursorLineMovement),
+            kScreenStateTrackCursorColMovementKey: @(_trackCursorColMovement),
             kScreenStateLastCommandOutputRangeKey: [NSDictionary dictionaryWithGridAbsCoordRange:_lastCommandOutputRange],
             kScreenStateShellIntegrationInstalledKey: @(_shellIntegrationInstalled),
             kScreenStateLastCommandMarkKey: _lastCommandMark.guid ?: [NSNull null],
@@ -5478,6 +5486,7 @@ static void SwapInt(int *a, int *b) {
         _startOfRunningCommandOutput = [screenState[kScreenStateNextCommandOutputStartKey] gridAbsCoord];
         _cursorVisible = [screenState[kScreenStateCursorVisibleKey] boolValue];
         _trackCursorLineMovement = [screenState[kScreenStateTrackCursorLineMovementKey] boolValue];
+        _trackCursorColMovement = [screenState[kScreenStateTrackCursorColMovementKey] boolValue];
         _lastCommandOutputRange = [screenState[kScreenStateLastCommandOutputRangeKey] gridAbsCoordRange];
         _shellIntegrationInstalled = [screenState[kScreenStateShellIntegrationInstalledKey] boolValue];
 

--- a/sources/VT100ScreenDelegate.h
+++ b/sources/VT100ScreenDelegate.h
@@ -185,13 +185,13 @@
 - (void)screenSetCursorVisible:(BOOL)visible;
 
 - (void)screenSetHighlightCursorLine:(BOOL)highlight;
-- (void)screenSetHighlightCursorCol:(BOOL)highlight;
+- (void)screenSetHighlightCursorColumn:(BOOL)highlight;
 
 // Only called if the trackCursorLineMovement property is set.
 - (void)screenCursorDidMoveToLine:(int)line;
 
 // Only called if the trackCursorColMovement property is set.
-- (void)screenCursorDidMoveToCol:(int)col;
+- (void)screenCursorDidMoveToColumn:(int)col;
 
 // Returns if there is a view.
 - (BOOL)screenHasView;

--- a/sources/VT100ScreenDelegate.h
+++ b/sources/VT100ScreenDelegate.h
@@ -191,7 +191,7 @@
 - (void)screenCursorDidMoveToLine:(int)line;
 
 // Only called if the trackCursorColMovement property is set.
-- (void)screenCursorDidMoveToColumn:(int)col;
+- (void)screenCursorDidMoveToColumn:(int)column;
 
 // Returns if there is a view.
 - (BOOL)screenHasView;

--- a/sources/VT100ScreenDelegate.h
+++ b/sources/VT100ScreenDelegate.h
@@ -185,9 +185,13 @@
 - (void)screenSetCursorVisible:(BOOL)visible;
 
 - (void)screenSetHighlightCursorLine:(BOOL)highlight;
+- (void)screenSetHighlightCursorColumn:(BOOL)highlight;
 
 // Only called if the trackCursorLineMovement property is set.
 - (void)screenCursorDidMoveToLine:(int)line;
+
+// Only called if the trackCursorColMovement property is set.
+- (void)screenCursorDidMoveToColumn:(int)column;
 
 // Returns if there is a view.
 - (BOOL)screenHasView;

--- a/sources/VT100ScreenDelegate.h
+++ b/sources/VT100ScreenDelegate.h
@@ -185,6 +185,7 @@
 - (void)screenSetCursorVisible:(BOOL)visible;
 
 - (void)screenSetHighlightCursorLine:(BOOL)highlight;
+- (void)screenSetHighlightCursorCol:(BOOL)highlight;
 
 // Only called if the trackCursorLineMovement property is set.
 - (void)screenCursorDidMoveToLine:(int)line;

--- a/sources/VT100ScreenDelegate.h
+++ b/sources/VT100ScreenDelegate.h
@@ -190,6 +190,9 @@
 // Only called if the trackCursorLineMovement property is set.
 - (void)screenCursorDidMoveToLine:(int)line;
 
+// Only called if the trackCursorColMovement property is set.
+- (void)screenCursorDidMoveToCol:(int)col;
+
 // Returns if there is a view.
 - (BOOL)screenHasView;
 

--- a/sources/VT100ScreenDelegate.h
+++ b/sources/VT100ScreenDelegate.h
@@ -185,10 +185,13 @@
 - (void)screenSetCursorVisible:(BOOL)visible;
 
 - (void)screenSetHighlightCursorLine:(BOOL)highlight;
-- (void)screenSetHighlightCursorCol:(BOOL)highlight;
+- (void)screenSetHighlightCursorColumn:(BOOL)highlight;
 
 // Only called if the trackCursorLineMovement property is set.
 - (void)screenCursorDidMoveToLine:(int)line;
+
+// Only called if the trackCursorColMovement property is set.
+- (void)screenCursorDidMoveToColumn:(int)column;
 
 // Returns if there is a view.
 - (BOOL)screenHasView;

--- a/sources/VT100Terminal.m
+++ b/sources/VT100Terminal.m
@@ -2367,8 +2367,8 @@ static const int kMaxScreenRows = 4096;
         [delegate_ terminalAddNote:(NSString *)value show:NO];
     } else if ([key isEqualToString:@"HighlightCursorLine"]) {
         [delegate_ terminalSetHighlightCursorLine:value.length ? [value boolValue] : YES];
-    } else if ([key isEqualToString:@"HighlightCursorCol"]) {
-        [delegate_ terminalSetHighlightCursorCol:value.length ? [value boolValue] : YES];
+    } else if ([key isEqualToString:@"HighlightCursorColumn"]) {
+        [delegate_ terminalSetHighlightCursorColumn:value.length ? [value boolValue] : YES];
     } else if ([key isEqualToString:@"CopyToClipboard"]) {
         if ([delegate_ terminalIsTrusted]) {
             [delegate_ terminalSetPasteboard:value];

--- a/sources/VT100Terminal.m
+++ b/sources/VT100Terminal.m
@@ -2367,6 +2367,8 @@ static const int kMaxScreenRows = 4096;
         [delegate_ terminalAddNote:(NSString *)value show:NO];
     } else if ([key isEqualToString:@"HighlightCursorLine"]) {
         [delegate_ terminalSetHighlightCursorLine:value.length ? [value boolValue] : YES];
+    } else if ([key isEqualToString:@"HighlightCursorColumn"]) {
+        [delegate_ terminalSetHighlightCursorColumn:value.length ? [value boolValue] : YES];
     } else if ([key isEqualToString:@"CopyToClipboard"]) {
         if ([delegate_ terminalIsTrusted]) {
             [delegate_ terminalSetPasteboard:value];

--- a/sources/VT100Terminal.m
+++ b/sources/VT100Terminal.m
@@ -2367,6 +2367,8 @@ static const int kMaxScreenRows = 4096;
         [delegate_ terminalAddNote:(NSString *)value show:NO];
     } else if ([key isEqualToString:@"HighlightCursorLine"]) {
         [delegate_ terminalSetHighlightCursorLine:value.length ? [value boolValue] : YES];
+    } else if ([key isEqualToString:@"HighlightCursorCol"]) {
+        [delegate_ terminalSetHighlightCursorCol:value.length ? [value boolValue] : YES];
     } else if ([key isEqualToString:@"CopyToClipboard"]) {
         if ([delegate_ terminalIsTrusted]) {
             [delegate_ terminalSetPasteboard:value];

--- a/sources/VT100TerminalDelegate.h
+++ b/sources/VT100TerminalDelegate.h
@@ -366,6 +366,7 @@ typedef NS_ENUM(int, VT100TerminalColorIndex) {
 - (void)terminalSetCursorVisible:(BOOL)visible;
 
 - (void)terminalSetHighlightCursorLine:(BOOL)highlight;
+- (void)terminalSetHighlightCursorCol:(BOOL)highlight;
 
 // FinalTerm features
 - (void)terminalPromptDidStart;

--- a/sources/VT100TerminalDelegate.h
+++ b/sources/VT100TerminalDelegate.h
@@ -366,7 +366,7 @@ typedef NS_ENUM(int, VT100TerminalColorIndex) {
 - (void)terminalSetCursorVisible:(BOOL)visible;
 
 - (void)terminalSetHighlightCursorLine:(BOOL)highlight;
-- (void)terminalSetHighlightCursorCol:(BOOL)highlight;
+- (void)terminalSetHighlightCursorColumn:(BOOL)highlight;
 
 // FinalTerm features
 - (void)terminalPromptDidStart;

--- a/sources/VT100TerminalDelegate.h
+++ b/sources/VT100TerminalDelegate.h
@@ -366,6 +366,7 @@ typedef NS_ENUM(int, VT100TerminalColorIndex) {
 - (void)terminalSetCursorVisible:(BOOL)visible;
 
 - (void)terminalSetHighlightCursorLine:(BOOL)highlight;
+- (void)terminalSetHighlightCursorColumn:(BOOL)highlight;
 
 // FinalTerm features
 - (void)terminalPromptDidStart;

--- a/sources/iTermMetalPerFrameState.m
+++ b/sources/iTermMetalPerFrameState.m
@@ -582,6 +582,10 @@ ambiguousIsDoubleWidth:(BOOL)ambiguousIsDoubleWidth
     return _configuration->_cursorGuideColor && _configuration->_cursorGuideEnabled;
 }
 
+- (BOOL)cursorVGuideEnabled {
+    return _configuration->_cursorGuideColor && _configuration->_cursorVGuideEnabled;
+}
+
 - (NSColor *)cursorGuideColor {
     return _configuration->_cursorGuideColor;
 }

--- a/sources/iTermMetalPerFrameState.m
+++ b/sources/iTermMetalPerFrameState.m
@@ -578,8 +578,16 @@ ambiguousIsDoubleWidth:(BOOL)ambiguousIsDoubleWidth
     return _configuration->_fullScreenFlashColor;
 }
 
-- (BOOL)cursorGuideEnabled {
-    return _configuration->_cursorGuideColor && _configuration->_cursorGuideEnabled;
+- (BOOL)cursorHorizontalGuideEnabled {
+    return _configuration->_cursorGuideColor && _configuration->_cursorHorizontalGuideEnabled;
+}
+
+- (BOOL)cursorVerticalGuideEnabled {
+    return _configuration->_cursorGuideColor && _configuration->_cursorVerticalGuideEnabled;
+}
+
+- (BOOL)cursorVerticalGuideEnabled {
+    return _configuration->_cursorGuideColor && _configuration->_cursorVerticalGuideEnabled;
 }
 
 - (NSColor *)cursorGuideColor {

--- a/sources/iTermMetalPerFrameState.m
+++ b/sources/iTermMetalPerFrameState.m
@@ -578,8 +578,8 @@ ambiguousIsDoubleWidth:(BOOL)ambiguousIsDoubleWidth
     return _configuration->_fullScreenFlashColor;
 }
 
-- (BOOL)cursorGuideEnabled {
-    return _configuration->_cursorGuideColor && _configuration->_cursorGuideEnabled;
+- (BOOL)cursorHorizontalGuideEnabled {
+    return _configuration->_cursorGuideColor && _configuration->_cursorHorizontalGuideEnabled;
 }
 
 - (BOOL)cursorVerticalGuideEnabled {

--- a/sources/iTermMetalPerFrameState.m
+++ b/sources/iTermMetalPerFrameState.m
@@ -586,10 +586,6 @@ ambiguousIsDoubleWidth:(BOOL)ambiguousIsDoubleWidth
     return _configuration->_cursorGuideColor && _configuration->_cursorVerticalGuideEnabled;
 }
 
-- (BOOL)cursorVerticalGuideEnabled {
-    return _configuration->_cursorGuideColor && _configuration->_cursorVerticalGuideEnabled;
-}
-
 - (NSColor *)cursorGuideColor {
     return _configuration->_cursorGuideColor;
 }

--- a/sources/iTermMetalPerFrameState.m
+++ b/sources/iTermMetalPerFrameState.m
@@ -582,8 +582,8 @@ ambiguousIsDoubleWidth:(BOOL)ambiguousIsDoubleWidth
     return _configuration->_cursorGuideColor && _configuration->_cursorGuideEnabled;
 }
 
-- (BOOL)cursorVGuideEnabled {
-    return _configuration->_cursorGuideColor && _configuration->_cursorVGuideEnabled;
+- (BOOL)cursorVerticalGuideEnabled {
+    return _configuration->_cursorGuideColor && _configuration->_cursorVerticalGuideEnabled;
 }
 
 - (NSColor *)cursorGuideColor {

--- a/sources/iTermMetalPerFrameStateConfiguration.h
+++ b/sources/iTermMetalPerFrameStateConfiguration.h
@@ -62,6 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
     // Cursor
     BOOL _shouldDrawFilledInCursor;
     BOOL _cursorGuideEnabled;
+    BOOL _cursorVGuideEnabled;
 
     // Size
     VT100GridSize _gridSize;

--- a/sources/iTermMetalPerFrameStateConfiguration.h
+++ b/sources/iTermMetalPerFrameStateConfiguration.h
@@ -62,7 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
     // Cursor
     BOOL _shouldDrawFilledInCursor;
     BOOL _cursorGuideEnabled;
-    BOOL _cursorVGuideEnabled;
+    BOOL _cursorVerticalGuideEnabled;
 
     // Size
     VT100GridSize _gridSize;

--- a/sources/iTermMetalPerFrameStateConfiguration.h
+++ b/sources/iTermMetalPerFrameStateConfiguration.h
@@ -61,7 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     // Cursor
     BOOL _shouldDrawFilledInCursor;
-    BOOL _cursorGuideEnabled;
+    BOOL _cursorHorizontalGuideEnabled;
     BOOL _cursorVerticalGuideEnabled;
 
     // Size

--- a/sources/iTermMetalPerFrameStateConfiguration.h
+++ b/sources/iTermMetalPerFrameStateConfiguration.h
@@ -61,7 +61,8 @@ NS_ASSUME_NONNULL_BEGIN
 
     // Cursor
     BOOL _shouldDrawFilledInCursor;
-    BOOL _cursorGuideEnabled;
+    BOOL _cursorHorizontalGuideEnabled;
+    BOOL _cursorVerticalGuideEnabled;
 
     // Size
     VT100GridSize _gridSize;

--- a/sources/iTermMetalPerFrameStateConfiguration.m
+++ b/sources/iTermMetalPerFrameStateConfiguration.m
@@ -56,6 +56,7 @@ static vector_float4 VectorForColor(NSColor *color) {
 
     // Cursor guide
     _cursorGuideEnabled = drawingHelper.highlightCursorLine;
+    _cursorVGuideEnabled = drawingHelper.highlightCursorCol;
     _cursorGuideColor = drawingHelper.cursorGuideColor;
 
     // Background image

--- a/sources/iTermMetalPerFrameStateConfiguration.m
+++ b/sources/iTermMetalPerFrameStateConfiguration.m
@@ -56,7 +56,7 @@ static vector_float4 VectorForColor(NSColor *color) {
 
     // Cursor guide
     _cursorGuideEnabled = drawingHelper.highlightCursorLine;
-    _cursorVGuideEnabled = drawingHelper.highlightCursorCol;
+    _cursorVerticalGuideEnabled = drawingHelper.highlightCursorColumn;
     _cursorGuideColor = drawingHelper.cursorGuideColor;
 
     // Background image

--- a/sources/iTermMetalPerFrameStateConfiguration.m
+++ b/sources/iTermMetalPerFrameStateConfiguration.m
@@ -55,7 +55,7 @@ static vector_float4 VectorForColor(NSColor *color) {
     _transparencyAffectsOnlyDefaultBackgroundColor = drawingHelper.transparencyAffectsOnlyDefaultBackgroundColor;
 
     // Cursor guide
-    _cursorGuideEnabled = drawingHelper.highlightCursorLine;
+    _cursorHorizontalGuideEnabled = drawingHelper.highlightCursorLine;
     _cursorVerticalGuideEnabled = drawingHelper.highlightCursorColumn;
     _cursorGuideColor = drawingHelper.cursorGuideColor;
 

--- a/sources/iTermMetalPerFrameStateConfiguration.m
+++ b/sources/iTermMetalPerFrameStateConfiguration.m
@@ -55,7 +55,8 @@ static vector_float4 VectorForColor(NSColor *color) {
     _transparencyAffectsOnlyDefaultBackgroundColor = drawingHelper.transparencyAffectsOnlyDefaultBackgroundColor;
 
     // Cursor guide
-    _cursorGuideEnabled = drawingHelper.highlightCursorLine;
+    _cursorHorizontalGuideEnabled = drawingHelper.highlightCursorLine;
+    _cursorVerticalGuideEnabled = drawingHelper.highlightCursorColumn;
     _cursorGuideColor = drawingHelper.cursorGuideColor;
 
     // Background image

--- a/sources/iTermProfilePreferences.m
+++ b/sources/iTermProfilePreferences.m
@@ -184,7 +184,7 @@ NSString *const kProfilePreferenceInitialDirectoryAdvancedValue = @"Advanced";
                         KEY_CURSOR_GUIDE_COLOR, KEY_BADGE_COLOR, KEY_TAB_COLOR,
                         KEY_UNDERLINE_COLOR ];
 
-    NSArray *number = @[ KEY_USE_CURSOR_GUIDE, KEY_USE_TAB_COLOR, KEY_USE_UNDERLINE_COLOR,
+    NSArray *number = @[ KEY_USE_CURSOR_GUIDE, KEY_USE_VERTICAL_CURSOR_GUIDE, KEY_USE_TAB_COLOR, KEY_USE_UNDERLINE_COLOR,
                          KEY_SMART_CURSOR_COLOR, KEY_MINIMUM_CONTRAST, KEY_CURSOR_BOOST,
                          KEY_CURSOR_TYPE, KEY_BLINKING_CURSOR, KEY_USE_BOLD_FONT, KEY_THIN_STROKES,
                          KEY_ASCII_LIGATURES, KEY_NON_ASCII_LIGATURES, KEY_USE_BOLD_COLOR,
@@ -268,6 +268,7 @@ NSString *const kProfilePreferenceInitialDirectoryAdvancedValue = @"Advanced";
                   KEY_CURSOR_GUIDE_COLOR:  [[NSColor colorWithCalibratedRed:0.650 green:0.910 blue:1.000 alpha:0.25] dictionaryValue],
                   KEY_BADGE_COLOR:         [[NSColor colorWithCalibratedRed:1.0 green:0.000 blue:0.000 alpha:0.5] dictionaryValue],
                   KEY_USE_CURSOR_GUIDE: @NO,
+                  KEY_USE_VERTICAL_CURSOR_GUIDE: @NO,
                   KEY_TAB_COLOR: [NSNull null],
                   KEY_USE_TAB_COLOR: @NO,
                   KEY_UNDERLINE_COLOR: [NSNull null],

--- a/sources/iTermProfilePreferences.m
+++ b/sources/iTermProfilePreferences.m
@@ -184,7 +184,7 @@ NSString *const kProfilePreferenceInitialDirectoryAdvancedValue = @"Advanced";
                         KEY_CURSOR_GUIDE_COLOR, KEY_BADGE_COLOR, KEY_TAB_COLOR,
                         KEY_UNDERLINE_COLOR ];
 
-    NSArray *number = @[ KEY_USE_CURSOR_GUIDE, KEY_USE_VERT_CURSOR_GUIDE, KEY_USE_TAB_COLOR, KEY_USE_UNDERLINE_COLOR,
+    NSArray *number = @[ KEY_USE_CURSOR_GUIDE, KEY_USE_VERTICAL_CURSOR_GUIDE, KEY_USE_TAB_COLOR, KEY_USE_UNDERLINE_COLOR,
                          KEY_SMART_CURSOR_COLOR, KEY_MINIMUM_CONTRAST, KEY_CURSOR_BOOST,
                          KEY_CURSOR_TYPE, KEY_BLINKING_CURSOR, KEY_USE_BOLD_FONT, KEY_THIN_STROKES,
                          KEY_ASCII_LIGATURES, KEY_NON_ASCII_LIGATURES, KEY_USE_BOLD_COLOR,
@@ -268,7 +268,7 @@ NSString *const kProfilePreferenceInitialDirectoryAdvancedValue = @"Advanced";
                   KEY_CURSOR_GUIDE_COLOR:  [[NSColor colorWithCalibratedRed:0.650 green:0.910 blue:1.000 alpha:0.25] dictionaryValue],
                   KEY_BADGE_COLOR:         [[NSColor colorWithCalibratedRed:1.0 green:0.000 blue:0.000 alpha:0.5] dictionaryValue],
                   KEY_USE_CURSOR_GUIDE: @NO,
-                  KEY_USE_VERT_CURSOR_GUIDE: @NO,
+                  KEY_USE_VERTICAL_CURSOR_GUIDE: @NO,
                   KEY_TAB_COLOR: [NSNull null],
                   KEY_USE_TAB_COLOR: @NO,
                   KEY_UNDERLINE_COLOR: [NSNull null],

--- a/sources/iTermProfilePreferences.m
+++ b/sources/iTermProfilePreferences.m
@@ -184,7 +184,7 @@ NSString *const kProfilePreferenceInitialDirectoryAdvancedValue = @"Advanced";
                         KEY_CURSOR_GUIDE_COLOR, KEY_BADGE_COLOR, KEY_TAB_COLOR,
                         KEY_UNDERLINE_COLOR ];
 
-    NSArray *number = @[ KEY_USE_CURSOR_GUIDE, KEY_USE_TAB_COLOR, KEY_USE_UNDERLINE_COLOR,
+    NSArray *number = @[ KEY_USE_CURSOR_GUIDE, KEY_USE_VERT_CURSOR_GUIDE, KEY_USE_TAB_COLOR, KEY_USE_UNDERLINE_COLOR,
                          KEY_SMART_CURSOR_COLOR, KEY_MINIMUM_CONTRAST, KEY_CURSOR_BOOST,
                          KEY_CURSOR_TYPE, KEY_BLINKING_CURSOR, KEY_USE_BOLD_FONT, KEY_THIN_STROKES,
                          KEY_ASCII_LIGATURES, KEY_NON_ASCII_LIGATURES, KEY_USE_BOLD_COLOR,
@@ -268,6 +268,7 @@ NSString *const kProfilePreferenceInitialDirectoryAdvancedValue = @"Advanced";
                   KEY_CURSOR_GUIDE_COLOR:  [[NSColor colorWithCalibratedRed:0.650 green:0.910 blue:1.000 alpha:0.25] dictionaryValue],
                   KEY_BADGE_COLOR:         [[NSColor colorWithCalibratedRed:1.0 green:0.000 blue:0.000 alpha:0.5] dictionaryValue],
                   KEY_USE_CURSOR_GUIDE: @NO,
+                  KEY_USE_VERT_CURSOR_GUIDE: @NO,
                   KEY_TAB_COLOR: [NSNull null],
                   KEY_USE_TAB_COLOR: @NO,
                   KEY_UNDERLINE_COLOR: [NSNull null],

--- a/sources/iTermTextDrawingHelper.h
+++ b/sources/iTermTextDrawingHelper.h
@@ -180,6 +180,9 @@ BOOL CheckFindMatchAtIndex(NSData *findMatches, int index);
 // Should the cursor guide be shown?
 @property(nonatomic, assign) BOOL highlightCursorLine;
 
+// Should the vertical cursor guide be shown?
+@property(nonatomic, assign) BOOL highlightCursorCol;
+
 // Minimum contrast level, 0-1.
 @property(nonatomic, assign) double minimumContrast;
 

--- a/sources/iTermTextDrawingHelper.h
+++ b/sources/iTermTextDrawingHelper.h
@@ -181,7 +181,7 @@ BOOL CheckFindMatchAtIndex(NSData *findMatches, int index);
 @property(nonatomic, assign) BOOL highlightCursorLine;
 
 // Should the vertical cursor guide be shown?
-@property(nonatomic, assign) BOOL highlightCursorCol;
+@property(nonatomic, assign) BOOL highlightCursorColumn;
 
 // Minimum contrast level, 0-1.
 @property(nonatomic, assign) double minimumContrast;

--- a/sources/iTermTextDrawingHelper.h
+++ b/sources/iTermTextDrawingHelper.h
@@ -180,6 +180,9 @@ BOOL CheckFindMatchAtIndex(NSData *findMatches, int index);
 // Should the cursor guide be shown?
 @property(nonatomic, assign) BOOL highlightCursorLine;
 
+// Should the vertical cursor guide be shown?
+@property(nonatomic, assign) BOOL highlightCursorColumn;
+
 // Minimum contrast level, 0-1.
 @property(nonatomic, assign) double minimumContrast;
 

--- a/sources/iTermTextDrawingHelper.m
+++ b/sources/iTermTextDrawingHelper.m
@@ -653,6 +653,18 @@ typedef struct iTermTextColorContext {
                                                     coordRange.end.x - coordRange.start.x)
                                       y:y];
     }
+
+    // Highlight cursor column if the cursor is in this column and it's on.
+    int cursorCol = _cursorCoord.x;
+    const BOOL drawVCursorGuide = (self.highlightCursorCol &&
+                                   cursorCol >= coordRange.start.x &&
+                                   cursorCol < coordRange.end.x);
+    if (drawVCursorGuide) {
+        CGFloat x = cursorCol * _cellSize.width;
+        [self drawCursorGuideForRows:NSMakeRange(coordRange.start.y,
+                                                 coordRange.end.y - coordRange.start.y)
+                                   x:x];
+    }
 }
 
 - (void)drawCursorGuideForColumns:(NSRange)range y:(CGFloat)yOrigin {
@@ -671,6 +683,26 @@ typedef struct iTermTextColorContext {
     NSRectFillUsingOperation(rect, NSCompositingOperationSourceOver);
 
     rect.origin.y += _cellSize.height - 1;
+    NSRectFillUsingOperation(rect, NSCompositingOperationSourceOver);
+}
+
+- (void)drawCursorGuideForRows:(NSRange)range x:(CGFloat)xOrigin {
+    if (!_cursorVisible) {
+        return;
+    }
+    [_cursorGuideColor set];
+    NSPoint textOrigin = NSMakePoint(xOrigin + [iTermAdvancedSettingsModel terminalMargin],
+                                     [iTermAdvancedSettingsModel terminalMargin] + range.location * _cellSize.height);
+    NSRect rect = NSMakeRect(textOrigin.x,
+                             textOrigin.y,
+                             _cellSize.width,
+                             range.length * _cellSize.height);
+    NSRectFillUsingOperation(rect, NSCompositingOperationSourceOver);
+
+    rect.size.width = 1;
+    NSRectFillUsingOperation(rect, NSCompositingOperationSourceOver);
+
+    rect.origin.x += _cellSize.width - 1;
     NSRectFillUsingOperation(rect, NSCompositingOperationSourceOver);
 }
 

--- a/sources/iTermTextDrawingHelper.m
+++ b/sources/iTermTextDrawingHelper.m
@@ -644,14 +644,73 @@ typedef struct iTermTextColorContext {
 
     // Highlight cursor line if the cursor is on this line and it's on.
     int cursorLine = _cursorCoord.y + _numberOfScrollbackLines;
-    const BOOL drawCursorGuide = (self.highlightCursorLine &&
-                                  cursorLine >= coordRange.start.y &&
-                                  cursorLine < coordRange.end.y);
-    if (drawCursorGuide) {
+    int cursorColumn = _cursorCoord.x;
+    const BOOL drawHorizontalCursorGuide = (self.highlightCursorLine &&
+                                            cursorLine >= coordRange.start.y &&
+                                            cursorLine < coordRange.end.y);
+    const BOOL drawVerticalCursorGuide = (self.highlightCursorColumn &&
+                                          cursorColumn >= coordRange.start.x &&
+                                          cursorColumn < coordRange.end.x);
+
+    if (drawHorizontalCursorGuide && !drawVerticalCursorGuide) {
         CGFloat y = cursorLine * _cellSize.height;
         [self drawCursorGuideForColumns:NSMakeRange(coordRange.start.x,
                                                     coordRange.end.x - coordRange.start.x)
                                       y:y];
+    } else if (!drawHorizontalCursorGuide && drawVerticalCursorGuide) {
+        CGFloat x = cursorColumn * _cellSize.width;
+        [self drawCursorGuideForRows:NSMakeRange(coordRange.start.y,
+                                                 coordRange.end.y - coordRange.start.y)
+                                   x:x];
+        [self.delegate setNeedsDisplay:YES];
+    } else if (drawHorizontalCursorGuide && drawVerticalCursorGuide) {
+        CGFloat x = cursorColumn * _cellSize.width;
+        CGFloat y = cursorLine * _cellSize.height;
+        [self drawCursorGuideForColumns:NSMakeRange(coordRange.start.x,
+                                                    coordRange.end.x - coordRange.start.x)
+                                      y:y];
+        [self drawCursorGuideForRows:NSMakeRange(coordRange.start.y,
+                                                 cursorLine - coordRange.start.y)
+                                   x:x];
+        [self drawCursorGuideForRows:NSMakeRange(cursorLine + 1,
+                                                 coordRange.end.y - _cursorCoord.y)
+                                   x:x];
+        [self.delegate setNeedsDisplay:YES];
+    }
+
+    // Highlight cursor column if the cursor is in this column and it's on.
+    int cursorColumn = _cursorCoord.x;
+    const BOOL drawHorizontalCursorGuide = (self.highlightCursorLine &&
+                                            cursorLine >= coordRange.start.y &&
+                                            cursorLine < coordRange.end.y);
+    const BOOL drawVerticalCursorGuide = (self.highlightCursorColumn &&
+                                          cursorColumn >= coordRange.start.x &&
+                                          cursorColumn < coordRange.end.x);
+
+    if (drawHorizontalCursorGuide && !drawVerticalCursorGuide) {
+        CGFloat y = cursorLine * _cellSize.height;
+        [self drawCursorGuideForColumns:NSMakeRange(coordRange.start.x,
+                                                    coordRange.end.x - coordRange.start.x)
+                                      y:y];
+    } else if (!drawHorizontalCursorGuide && drawVerticalCursorGuide) {
+        CGFloat x = cursorColumn * _cellSize.width;
+        [self drawCursorGuideForRows:NSMakeRange(coordRange.start.y,
+                                                 coordRange.end.y - coordRange.start.y)
+                                   x:x];
+        [self.delegate setNeedsDisplay:YES];
+    } else if (drawHorizontalCursorGuide && drawVerticalCursorGuide) {
+        CGFloat x = cursorColumn * _cellSize.width;
+        CGFloat y = cursorLine * _cellSize.height;
+        [self drawCursorGuideForColumns:NSMakeRange(coordRange.start.x,
+                                                    coordRange.end.x - coordRange.start.x)
+                                      y:y];
+        [self drawCursorGuideForRows:NSMakeRange(coordRange.start.y,
+                                                 cursorLine - coordRange.start.y)
+                                   x:x];
+        [self drawCursorGuideForRows:NSMakeRange(cursorLine + 1,
+                                                 coordRange.end.y - _cursorCoord.y)
+                                   x:x];
+        [self.delegate setNeedsDisplay:YES];
     }
 }
 
@@ -671,6 +730,26 @@ typedef struct iTermTextColorContext {
     NSRectFillUsingOperation(rect, NSCompositingOperationSourceOver);
 
     rect.origin.y += _cellSize.height - 1;
+    NSRectFillUsingOperation(rect, NSCompositingOperationSourceOver);
+}
+
+- (void)drawCursorGuideForRows:(NSRange)range x:(CGFloat)xOrigin {
+    if (!_cursorVisible) {
+        return;
+    }
+    [_cursorGuideColor set];
+    NSPoint textOrigin = NSMakePoint(xOrigin + [iTermAdvancedSettingsModel terminalMargin],
+                                     range.location * _cellSize.height);
+    NSRect rect = NSMakeRect(textOrigin.x,
+                             textOrigin.y,
+                             _cellSize.width,
+                             range.length * _cellSize.height);
+    NSRectFillUsingOperation(rect, NSCompositingOperationSourceOver);
+
+    rect.size.width = 1;
+    NSRectFillUsingOperation(rect, NSCompositingOperationSourceOver);
+
+    rect.origin.x += _cellSize.width - 1;
     NSRectFillUsingOperation(rect, NSCompositingOperationSourceOver);
 }
 

--- a/sources/iTermTextDrawingHelper.m
+++ b/sources/iTermTextDrawingHelper.m
@@ -655,12 +655,12 @@ typedef struct iTermTextColorContext {
     }
 
     // Highlight cursor column if the cursor is in this column and it's on.
-    int cursorCol = _cursorCoord.x;
-    const BOOL drawVCursorGuide = (self.highlightCursorCol &&
-                                   cursorCol >= coordRange.start.x &&
-                                   cursorCol < coordRange.end.x);
-    if (drawVCursorGuide) {
-        CGFloat x = cursorCol * _cellSize.width;
+    int cursorColumn = _cursorCoord.x;
+    const BOOL drawVerticalCursorGuide = (self.highlightCursorColumn &&
+                                          cursorColumn >= coordRange.start.x &&
+                                          cursorColumn < coordRange.end.x);
+    if (drawVerticalCursorGuide) {
+        CGFloat x = cursorColumn * _cellSize.width;
         [self drawCursorGuideForRows:NSMakeRange(coordRange.start.y,
                                                  coordRange.end.y - coordRange.start.y)
                                    x:x];

--- a/sources/iTermTextDrawingHelper.m
+++ b/sources/iTermTextDrawingHelper.m
@@ -679,14 +679,6 @@ typedef struct iTermTextColorContext {
     }
 
     // Highlight cursor column if the cursor is in this column and it's on.
-    int cursorColumn = _cursorCoord.x;
-    const BOOL drawHorizontalCursorGuide = (self.highlightCursorLine &&
-                                            cursorLine >= coordRange.start.y &&
-                                            cursorLine < coordRange.end.y);
-    const BOOL drawVerticalCursorGuide = (self.highlightCursorColumn &&
-                                          cursorColumn >= coordRange.start.x &&
-                                          cursorColumn < coordRange.end.x);
-
     if (drawHorizontalCursorGuide && !drawVerticalCursorGuide) {
         CGFloat y = cursorLine * _cellSize.height;
         [self drawCursorGuideForColumns:NSMakeRange(coordRange.start.x,


### PR DESCRIPTION
Requesting a pull to gnachman:master from ahelsley:vertical-cursor-guide

Changes:

51d1fedcd (Andrew Helsley, 7 minutes ago)
   Fill out cursor column tracking API.

ed11a8e23 (Andrew Helsley, 8 minutes ago)
   Render a vertical cursor guide in the software rendered view (known issue:
   only renders on the 3 lines centered on the cursor).

6827cb36e (Andrew Helsley, 13 minutes ago)
   Separate control over the vertical cursor guide from the horizontal
   guide.

68e3d2e87 (Andrew Helsley, 28 minutes ago)
   Render a vertical guide over the column the cursor is in (Metal View
   implementation).