### PR TITLE
iterm2_git_poll.sh tweaks

### DIFF
--- a/sources/iterm2_git_poll.sh
+++ b/sources/iterm2_git_poll.sh
@@ -1,26 +1,23 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
-GIT_BINARY=/usr/bin/git
+GIT_BINARY=$(command -v git)
 
 xcode() {
     # Check if git is broken because it can't find Xcode. A special charm of macOS for you.
-    OUTPUT=$("$GIT_BINARY" --version 2>& 1)
-    grep "xcrun: error" <<< "$OUTPUT" > /dev/null 2>& 1
-    if (($?)); then
+    local output=$("${GIT_BINARY}" --version 2>&1)
+    # if there's no error, then return nothing
+    if ! grep -q "xcrun: error" <<< "${output}"; then
         echo ""
         return
     fi
-    tr '\n' '\t' <<< "$OUTPUT"
+    tr '\n' '\t' <<< "${output}"
 }
 
 dirty() {
     # Outputs "dirty" or "clean"
-    OUTPUT=$("$GIT_BINARY" status --porcelain --ignore-submodules -unormal 2>/dev/null)
-    if (($?)); then
-        echo "clean"
-        return
-    fi
-    if [ -z "$OUTPUT" ]; then
+    local output=$("${GIT_BINARY}" status --porcelain --ignore-submodules -unormal 2>/dev/null)
+    # if we get a non-zero exit code, or the output is empty, then we consider it "clean"
+    if [ $? -ne 0 ] || [ -z "${output}" ]; then
         echo "clean"
     else
         echo "dirty"
@@ -28,47 +25,49 @@ dirty() {
 }
 
 counts() {
-    OUTPUT=$("$GIT_BINARY" rev-list --left-right --count HEAD...@'{u}' 2>/dev/null)
-    if (($?)); then
+    local output=$("${GIT_BINARY}" rev-list --left-right --count HEAD...@'{u}' 2>/dev/null)
+    if [ $? -ge 1 ]; then
         echo "error"
-        return
+    else
+        echo "${output}"
     fi
-    echo "$OUTPUT"
 }
 
 branch() {
-    OUTPUT=$("$GIT_BINARY" symbolic-ref -q --short HEAD 2>/dev/null || git rev-parse --short HEAD)
-    if (($?)); then
-        return
+    local output=$("${GIT_BINARY}" symbolic-ref -q --short HEAD 2>/dev/null || git rev-parse --short HEAD)
+    if [ $? -eq 0 ]; then
+        echo "${output}"
     fi
-    echo "$OUTPUT"
 }
 
 git_poll () {
-    DIRECTORY="$1"
-    cd "$DIRECTORY"
-    XCODE=$(xcode)
-    DIRTY=$(dirty)
-    COUNTS=$(counts)
-    PUSH_COUNT=$(cut -f1 <<< "$COUNTS")
-    PULL_COUNT=$(cut -f2 <<< "$COUNTS")
-    BRANCH=$(branch)
-    cd /
+    local previous_path=$(pwd) 
+    # make sure to replace ~ with home, if it's in the path. Users
+    # might be using triggers to "Report Directory", which could pick up 
+    # a path with a '~' (representing the user's home) in it
+    local directory="${1/\~/${HOME}}" 
+    cd "${directory}"
+
+    local xcode=$(xcode)
+    local branch=$(branch)
+    local dirty=$(dirty) 
+    local push_count pull_count
+    read push_count pull_count <<< "$(counts)"
+    
+    cd "${previous_path}"
 
     echo "--BEGIN--"
-    echo "XCODE: $XCODE"
-    echo "DIRECTORY: $DIRECTORY"
-    echo "DIRTY: $DIRTY"
-    echo "PUSH: $PUSH_COUNT"
-    echo "PULL: $PULL_COUNT"
-    echo "BRANCH: $BRANCH"
+    echo "XCODE: ${xcode}"
+    echo "DIRECTORY: ${directory}"
+    echo "DIRTY: ${dirty}"
+    echo "PUSH: ${push_count}"
+    echo "PULL: ${pull_count}"
+    echo "BRANCH: ${branch}"
     echo "--END--"
     echo ""
 }
 
 
-while read line
-do
+while read line; do
     git_poll "$line"
 done
-


### PR DESCRIPTION
* use `/usr/bin/env sh` for the shebang to allow a user's environment to dictate which `sh` is run
* use locals to avoid leaking function variables
* use lowercase names for locals
* convert `~` in the received directory path to the user's `$HOME` directory
* use the more portable and clearer `test` conditional by using `[ ... ]` notation instead of the arithmetic expression `(( ... ))`
* use `command` to locate the `git` binary