### PR TITLE
Don't release the system bold font

### DIFF
--- a/sources/ToolDirectoriesView.m
+++ b/sources/ToolDirectoriesView.m
@@ -138,7 +138,6 @@ static const CGFloat kHelpMargin = 5;
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     [tableView_ release];
     [scrollView_ release];
-    [boldFont_ release];
     [super dealloc];
 }
 


### PR DESCRIPTION
This fixes a crash on macOS Catalina.