### PR TITLE
Allow moving tmux windows between sessions by holding option/command

### DIFF
--- a/sources/TmuxController.h
+++ b/sources/TmuxController.h
@@ -163,6 +163,9 @@ extern NSString *const kTmuxControllerDidFetchSetTitlesStringOption;
 - (void)linkWindowId:(int)windowId
            inSession:(NSString *)sessionName
            toSession:(NSString *)targetSession;
+- (void)moveWindowId:(int)windowId
+           inSession:(NSString *)sessionName
+           toSession:(NSString *)targetSession;
 
 - (void)renameSession:(NSString *)oldName to:(NSString *)newName;
 - (void)killSession:(NSString *)sessionName;

--- a/sources/TmuxController.m
+++ b/sources/TmuxController.m
@@ -1422,6 +1422,15 @@ static NSDictionary *iTermTmuxControllerDefaultFontOverridesFromProfile(Profile 
          responseSelector:nil];
 }
 
+- (void)moveWindowId:(int)windowId
+           inSession:(NSString *)sessionName
+           toSession:(NSString *)targetSession {
+    [gateway_ sendCommand:[NSString stringWithFormat:@"move-window -s \"%@:@%d\" -t \"%@:+\"",
+                           sessionName, windowId, targetSession]
+           responseTarget:nil
+         responseSelector:nil];
+}
+
 // Find a position for any key in panes and remove all entries with keys in panes.
 - (NSValue *)positionForWindowWithPanes:(NSArray *)panes
 {

--- a/sources/TmuxDashboardController.m
+++ b/sources/TmuxDashboardController.m
@@ -190,6 +190,15 @@
                               toSession:targetSession];
 }
 
+- (void)moveWindowId:(int)windowId
+           inSession:(NSString *)sessionName
+           toSession:(NSString *)targetSession
+{
+    [[self tmuxController] moveWindowId:windowId
+                              inSession:sessionName
+                              toSession:targetSession];
+}
+
 #pragma mark TmuxWindowsTableProtocol
 
 - (void)reloadWindows

--- a/sources/TmuxSessionsTable.h
+++ b/sources/TmuxSessionsTable.h
@@ -21,6 +21,9 @@
 - (void)linkWindowId:(int)windowId
            inSession:(NSString *)sessionName
            toSession:(NSString *)targetSession;
+- (void)moveWindowId:(int)windowId
+           inSession:(NSString *)sessionName
+           toSession:(NSString *)targetSession;
 - (void)detach;
 
 @end

--- a/sources/TmuxSessionsTable.m
+++ b/sources/TmuxSessionsTable.m
@@ -164,7 +164,7 @@ extern NSString *kWindowPasteboardType;
     NSString *targetSession = [model_ objectAtIndex:row];
     for (NSArray *tuple in draggedItems) {
         NSNumber *windowId = [tuple objectAtIndex:1];
-        if( info.draggingSourceOperationMask & NSDragOperationLink ) {
+        if (info.draggingSourceOperationMask & NSDragOperationLink) {
             [delegate_ linkWindowId:[windowId intValue]
                           inSession:sessionName
                           toSession:targetSession];
@@ -183,7 +183,7 @@ extern NSString *kWindowPasteboardType;
        proposedDropOperation:(NSTableViewDropOperation)operation
 {
     if (operation == NSTableViewDropOn) {
-        if( info.draggingSourceOperationMask & NSDragOperationLink ) {
+        if (info.draggingSourceOperationMask & NSDragOperationLink) {
             return NSDragOperationLink;
         } else {
             return NSDragOperationMove;

--- a/sources/TmuxSessionsTable.m
+++ b/sources/TmuxSessionsTable.m
@@ -164,9 +164,15 @@ extern NSString *kWindowPasteboardType;
     NSString *targetSession = [model_ objectAtIndex:row];
     for (NSArray *tuple in draggedItems) {
         NSNumber *windowId = [tuple objectAtIndex:1];
-        [delegate_ linkWindowId:[windowId intValue]
-                      inSession:sessionName
-                      toSession:targetSession];
+        if( info.draggingSourceOperationMask & NSDragOperationLink ) {
+            [delegate_ linkWindowId:[windowId intValue]
+                          inSession:sessionName
+                          toSession:targetSession];
+        } else {
+            [delegate_ moveWindowId:[windowId intValue]
+                          inSession:sessionName
+                          toSession:targetSession];
+        }
     }
     return YES;
 }
@@ -177,7 +183,11 @@ extern NSString *kWindowPasteboardType;
        proposedDropOperation:(NSTableViewDropOperation)operation
 {
     if (operation == NSTableViewDropOn) {
-        return NSDragOperationLink;
+        if( info.draggingSourceOperationMask & NSDragOperationLink ) {
+            return NSDragOperationLink;
+        } else {
+            return NSDragOperationMove;
+        }
     } else {
         return NSDragOperationNone;
     }


### PR DESCRIPTION
The tmux dashboard allows linking windows between different sessions
via drag-and-drop. This change modifies that behaviour, such that if
option or cmd are pressed during the drag, the window will be moved
instead of linked.