### PR TITLE
Make options for reporting clicks and for reporting mouse wheel events independent of each other

### DIFF
--- a/Interfaces/PreferencePanel.xib
+++ b/Interfaces/PreferencePanel.xib
@@ -3612,7 +3612,7 @@ DQ
                     </connections>
                 </button>
                 <button id="EMG-WL-JwE">
-                    <rect key="frame" x="45" y="273" width="215" height="18"/>
+                    <rect key="frame" x="20" y="273" width="215" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Report mouse wheel events" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="DCM-jj-J4m">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>

--- a/sources/PTYTextView.m
+++ b/sources/PTYTextView.m
@@ -6041,7 +6041,7 @@ scrollToFirstResult:(BOOL)scrollToFirstResult {
         return NO;
     }
     if (event.type == NSEventTypeScrollWheel) {
-        return ([self xtermMouseReporting] && [self xtermMouseReportingAllowMouseWheel]);
+        return ([self xtermMouseReportingAllowMouseWheel]);
     } else {
         PTYTextView* frontTextView = [[iTermController sharedInstance] frontTextView];
         return (frontTextView == self && [self xtermMouseReporting]);

--- a/sources/ProfilesTerminalPreferencesViewController.m
+++ b/sources/ProfilesTerminalPreferencesViewController.m
@@ -114,17 +114,10 @@
             relatedView:_answerBackStringLabel
                    type:kPreferenceInfoTypeStringTextField];
 
-    info = [self defineControl:_xtermMouseReporting
-                           key:KEY_XTERM_MOUSE_REPORTING
-                   relatedView:nil
-                          type:kPreferenceInfoTypeCheckbox];
-    info.observer = ^() {
-        __strong __typeof(weakSelf) strongSelf = weakSelf;
-        if (!strongSelf) {
-            return;
-        }
-        [strongSelf->_xtermMouseReportingAllowMouseWheel setEnabled:[strongSelf boolForKey:KEY_XTERM_MOUSE_REPORTING]];
-    };
+    [self defineControl:_xtermMouseReporting
+                    key:KEY_XTERM_MOUSE_REPORTING
+            relatedView:nil
+                   type:kPreferenceInfoTypeCheckbox];
 
     [self defineControl:_xtermMouseReportingAllowMouseWheel
                     key:KEY_XTERM_MOUSE_REPORTING_ALLOW_MOUSE_WHEEL


### PR DESCRIPTION
I want iTerm to report mouse wheel events, so that I can use scrollback in tmux. However, tmux's handling of mouse clicks is much worse than in iTerm, so I don't want clicks to be reported. This patch makes reporting clicks and reporting mouse wheel events independent of each other, which should be useful to other users of tmux.