### PR TITLE
[Py] Fix type annotations for Size and Point

### DIFF
--- a/api/library/python/iterm2/iterm2/util.py
+++ b/api/library/python/iterm2/iterm2/util.py
@@ -9,7 +9,7 @@ class Size:
 
   Can be used where api_pb2.Size is accepted."""
 
-  def __init__(self, width: float, height: float):
+  def __init__(self, width: int, height: int):
     """Constructs a new size.
 
     :param width: A nonnegative number giving the width.
@@ -19,19 +19,19 @@ class Size:
     self.__height = height
 
   @property
-  def width(self) -> float:
+  def width(self) -> int:
     return self.__width
 
   @width.setter
-  def width(self, value: float):
+  def width(self, value: int):
     self.__width = value
 
   @property
-  def height(self) -> float:
+  def height(self) -> int:
     return self.__height
 
   @height.setter
-  def height(self, value: float):
+  def height(self, value: int):
     self.__height = value
 
   @property
@@ -67,7 +67,7 @@ class Point:
 
   Can be used where api_pb2.Point is accepted."""
 
-  def __init__(self, x: float, y: float):
+  def __init__(self, x: int, y: int):
     """Constructs a new point.
 
     :param x: A number giving the X coordinate.
@@ -84,19 +84,19 @@ class Point:
       return Point(proto.x, proto.y)
 
   @property
-  def x(self) -> float:
+  def x(self) -> int:
     return self.__x
 
   @x.setter
-  def x(self, value: float):
+  def x(self, value: int):
     self.__x = value
 
   @property
-  def y(self) -> float:
+  def y(self) -> int:
     return self.__y
 
   @y.setter
-  def y(self, value: float):
+  def y(self, value: int):
     self.__y = value
 
   @property


### PR DESCRIPTION
**Why**:
Python type annotations is wrong for Size and Point.

Traceback:
```
8/24, 11:23:59.003 AM: Traceback (most recent call last):
8/24, 11:23:59.003 AM:   File "/Users/dmitryvasilishin/Library/ApplicationSupport/iTerm2/Scripts/iterm2-kube/iterm2env/versions/3.7.2/lib/python3.7/site-packages/iterm2/registration.py", line 23, in generic_handle_rpc
8/24, 11:23:59.003 AM:     result = await coro(**params)
8/24, 11:23:59.003 AM:   File "/Users/dmitryvasilishin/Library/ApplicationSupport/iTerm2/Scripts/iterm2-kube/iterm2env/versions/3.7.2/lib/python3.7/site-packages/iterm2/statusbar.py", line 262, in handle_rpc
8/24, 11:23:59.003 AM:     await onclick(session_id)
8/24, 11:23:59.003 AM:   File "/Users/dmitryvasilishin/Library/ApplicationSupport/iTerm2/Scripts/iterm2-kube/iterm2-kube/iterm2-kube.py", line 86, in onclick
8/24, 11:23:59.003 AM:     res = await selection.async_get_string(connection, session_id, 5)
8/24, 11:23:59.003 AM:   File "/Users/dmitryvasilishin/Library/ApplicationSupport/iTerm2/Scripts/iterm2-kube/iterm2env/versions/3.7.2/lib/python3.7/site-packages/iterm2/selection.py", line 151, in async_get_string
8/24, 11:23:59.003 AM:     return await self.__subSelections[0].async_get_string(connection, session_id)
8/24, 11:23:59.003 AM:   File "/Users/dmitryvasilishin/Library/ApplicationSupport/iTerm2/Scripts/iterm2-kube/iterm2env/versions/3.7.2/lib/python3.7/site-packages/iterm2/selection.py", line 74, in async_get_string
8/24, 11:23:59.003 AM:     self.__windowedCoordRange)
8/24, 11:23:59.003 AM:   File "/Users/dmitryvasilishin/Library/ApplicationSupport/iTerm2/Scripts/iterm2-kube/iterm2env/versions/3.7.2/lib/python3.7/site-packages/iterm2/rpc.py", line 166, in async_get_screen_contents
8/24, 11:23:59.003 AM:     windowed_coord_range.proto)
8/24, 11:23:59.003 AM:   File "/Users/dmitryvasilishin/Library/ApplicationSupport/iTerm2/Scripts/iterm2-kube/iterm2env/versions/3.7.2/lib/python3.7/site-packages/iterm2/util.py", line 342, in proto
8/24, 11:23:59.003 AM:     p.coord_range.CopyFrom(self.coordRange.proto)
8/24, 11:23:59.003 AM:   File "/Users/dmitryvasilishin/Library/ApplicationSupport/iTerm2/Scripts/iterm2-kube/iterm2env/versions/3.7.2/lib/python3.7/site-packages/iterm2/util.py", line 269, in proto
8/24, 11:23:59.003 AM:     p.start.CopyFrom(self.start.proto)
8/24, 11:23:59.003 AM:   File "/Users/dmitryvasilishin/Library/ApplicationSupport/iTerm2/Scripts/iterm2-kube/iterm2env/versions/3.7.2/lib/python3.7/site-packages/iterm2/util.py", line 120, in proto
8/24, 11:23:59.003 AM:     p.x = self.x
8/24, 11:23:59.003 AM: TypeError: 100.0 has type float, but expected one of: int, long
```

pb2 descriptors:
```python
_SIZE = _descriptor.Descriptor(
  name='Size',
  full_name='iterm2.Size',
  filename=None,
  file=DESCRIPTOR,
  containing_type=None,
  fields=[
    _descriptor.FieldDescriptor(
      name='width', full_name='iterm2.Size.width', index=0,
      number=1, type=5, cpp_type=1, label=1,
      has_default_value=False, default_value=0,
      message_type=None, enum_type=None, containing_type=None,
      is_extension=False, extension_scope=None,
      options=None),
    _descriptor.FieldDescriptor(
      name='height', full_name='iterm2.Size.height', index=1,
      number=2, type=5, cpp_type=1, label=1,
      has_default_value=False, default_value=0,
      message_type=None, enum_type=None, containing_type=None,
      is_extension=False, extension_scope=None,
      options=None),
  ],
  extensions=[
  ],
  nested_types=[],
  enum_types=[
  ],
  options=None,
  is_extendable=False,
  syntax='proto2',
  extension_ranges=[],
  oneofs=[
  ],
  serialized_start=22227,
  serialized_end=22264,
)


_POINT = _descriptor.Descriptor(
  name='Point',
  full_name='iterm2.Point',
  filename=None,
  file=DESCRIPTOR,
  containing_type=None,
  fields=[
    _descriptor.FieldDescriptor(
      name='x', full_name='iterm2.Point.x', index=0,
      number=1, type=5, cpp_type=1, label=1,
      has_default_value=False, default_value=0,
      message_type=None, enum_type=None, containing_type=None,
      is_extension=False, extension_scope=None,
      options=None),
    _descriptor.FieldDescriptor(
      name='y', full_name='iterm2.Point.y', index=1,
      number=2, type=5, cpp_type=1, label=1,
      has_default_value=False, default_value=0,
      message_type=None, enum_type=None, containing_type=None,
      is_extension=False, extension_scope=None,
      options=None),
  ],
  extensions=[
  ],
  nested_types=[],
  enum_types=[
  ],
  options=None,
  is_extendable=False,
  syntax='proto2',
  extension_ranges=[],
  oneofs=[
  ],
  serialized_start=22266,
  serialized_end=22295,
)
```

pb2 types:
```python
TYPE_INT32 = 5
CPPTYPE_INT32 = 1
```

**What**:
Change `float` type annotations on `int`