### PR TITLE
Option to escape strings with quotes instead of backslashes

### DIFF
--- a/sources/NSStringITerm.m
+++ b/sources/NSStringITerm.m
@@ -2198,28 +2198,21 @@ static TECObjectRef CreateTECConverterForUTF8Variants(TextEncodingVariant varian
 - (void)escapeShellCharactersIncludingNewlines:(BOOL)includingNewlines {
     if ([iTermAdvancedSettingsModel escapeWithQuotes]) {
         // Only need to escape single quote and backslash in a single-quoted string
-        NSString* charsToEscape = @"\\'";
-        NSString* charsToSearch = [NSString shellEscapableCharacters];
+        NSMutableString *charsToEscape = [@"\\'" mutableCopy];
+        NSMutableCharacterSet *charsToSearch = [NSMutableCharacterSet characterSetWithCharactersInString:[NSString shellEscapableCharacters]];
         if (includingNewlines) {
-            charsToEscape = [charsToEscape stringByAppendingString:@"\r\n"];
-            charsToSearch = [charsToSearch stringByAppendingString:@"\r\n"];
+            [charsToEscape appendString:@"\r\n"];
+            [charsToSearch addCharactersInString:@"\r\n"];
         }
-        bool didEscape = false;
-        for (int i = 0; i < [charsToSearch length]; i ++) {
-            if ([self containsString:[charsToSearch substringWithRange:NSMakeRange(i, 1)]]) {
-                didEscape = true;
-                break;
-            }
-        }
-        if (didEscape) {
+        if ([self rangeOfCharacterFromSet:charsToSearch].location != NSNotFound) {
             [self escapeCharacters:charsToEscape];
             [self insertString:@"'" atIndex:0];
             [self appendString:@"'"];
         }
     } else {
-        NSString* charsToEscape = [NSString shellEscapableCharacters];
+        NSMutableString *charsToEscape = [[NSString shellEscapableCharacters] mutableCopy];
         if (includingNewlines) {
-            charsToEscape = [charsToEscape stringByAppendingString:@"\r\n"];
+            [charsToEscape appendString:@"\r\n"];
         }
         [self escapeCharacters:charsToEscape];
     }
@@ -2228,8 +2221,8 @@ static TECObjectRef CreateTECConverterForUTF8Variants(TextEncodingVariant varian
 
 - (void)escapeCharacters:(NSString *)charsToEscape {
     for (int i = 0; i < [charsToEscape length]; i++) {
-        NSString* before = [charsToEscape substringWithRange:NSMakeRange(i, 1)];
-        NSString* after = [@"\\" stringByAppendingString:before];
+        NSString *before = [charsToEscape substringWithRange:NSMakeRange(i, 1)];
+        NSString *after = [@"\\" stringByAppendingString:before];
         [self replaceOccurrencesOfString:before
                               withString:after
                                  options:0

--- a/sources/NSStringITerm.m
+++ b/sources/NSStringITerm.m
@@ -2196,11 +2196,34 @@ static TECObjectRef CreateTECConverterForUTF8Variants(TextEncodingVariant varian
 }
 
 - (void)escapeShellCharactersIncludingNewlines:(BOOL)includingNewlines {
-    NSString* charsToEscape = [NSString shellEscapableCharacters];
-    if (includingNewlines) {
-        charsToEscape = [charsToEscape stringByAppendingString:@"\r\n"];
+    if ([iTermAdvancedSettingsModel escapeWithQuotes]) {
+        // Only need to escape single quote and backslash in a single-quoted string
+        NSString* charsToEscape = @"\\'";
+        NSString* charsToSearch = [NSString shellEscapableCharacters];
+        if (includingNewlines) {
+            charsToEscape = [charsToEscape stringByAppendingString:@"\r\n"];
+            charsToSearch = [charsToSearch stringByAppendingString:@"\r\n"];
+        }
+        bool didEscape = false;
+        for (int i = 0; i < [charsToSearch length]; i ++) {
+            if ([self containsString:[charsToSearch substringWithRange:NSMakeRange(i, 1)]]) {
+                didEscape = true;
+                break;
+            }
+        }
+        if (didEscape) {
+            [self escapeCharacters:charsToEscape];
+            [self insertString:@"'" atIndex:0];
+            [self appendString:@"'"];
+        }
+    } else {
+        NSString* charsToEscape = [NSString shellEscapableCharacters];
+        if (includingNewlines) {
+            charsToEscape = [charsToEscape stringByAppendingString:@"\r\n"];
+        }
+        [self escapeCharacters:charsToEscape];
     }
-    [self escapeCharacters:charsToEscape];
+
 }
 
 - (void)escapeCharacters:(NSString *)charsToEscape {

--- a/sources/iTermAdvancedSettingsModel.h
+++ b/sources/iTermAdvancedSettingsModel.h
@@ -92,6 +92,7 @@ extern NSString *const iTermAdvancedSettingsDidChange;
 + (double)echoProbeDuration;
 + (BOOL)enableSemanticHistoryOnNetworkMounts;
 + (BOOL)enableUnderlineSemanticHistoryOnCmdHover;
++ (BOOL)escapeWithQuotes;
 + (BOOL)excludeBackgroundColorsFromCopiedStyle;
 + (BOOL)experimentalKeyHandling;
 + (double)extraSpaceBeforeCompactTopTabBar;

--- a/sources/iTermAdvancedSettingsModel.m
+++ b/sources/iTermAdvancedSettingsModel.m
@@ -534,6 +534,7 @@ DEFINE_BOOL(workAroundNumericKeypadBug, YES, SECTION_EXPERIMENTAL @"Treat the eq
 DEFINE_BOOL(tmuxVariableWindowSizesSupported, NO, SECTION_EXPERIMENTAL @"Allow variable window sizes in tmux integration");
 DEFINE_BOOL(aggressiveBaseCharacterDetection, NO, SECTION_EXPERIMENTAL @"Detect base unicode characters with lookup table.\nApple's algorithm for segmenting composed characters makes bad choices, such as for Tamil. Enable this to reduce text overlapping.");
 DEFINE_BOOL(accelerateUploads, YES, SECTION_EXPERIMENTAL @"Make uploads with it2ul really fast.");
+DEFINE_BOOL(escapeWithQuotes, NO, SECTION_EXPERIMENTAL @"Escape dragged file paths with single quotes instead of backslashes.");
 
 #pragma mark - Scripting
 #define SECTION_SCRIPTING @"Scripting: "


### PR DESCRIPTION
Some shells like [xonsh](https://xon.sh) don't support file paths escaped `with\ backslashes` and require `'quoted strings'` instead. This adds an experimental option to change how iTerm handles escaping to support this alternate format.