### PR TITLE
iTermActionsDidChangeNotification: use initPrivate

### DIFF
--- a/sources/iTermActionsModel.m
+++ b/sources/iTermActionsModel.m
@@ -122,7 +122,7 @@ static NSString *const iTermActionsUserDefaultsKey = @"Actions";
 @implementation iTermActionsDidChangeNotification
 
 + (instancetype)notificationWithMutationType:(iTermActionsDidChangeMutationType)mutationType index:(NSInteger)index {
-    iTermActionsDidChangeNotification *notif = [[self alloc] init];
+    iTermActionsDidChangeNotification *notif = [[self alloc] initPrivate];
     notif->_mutationType = mutationType;
     notif->_index = index;
     return notif;


### PR DESCRIPTION
In `iTermActionsDidChangeNotification`, use `[self initPrivate]` instead of
`[self init]`, which is marked `NS_UNAVAILABLE` in `iTermBaseNotification`.

Fixes build with newer clang versions.