### PR TITLE
Prevent images from disappearing due to scaling

### DIFF
--- a/sources/VT100Screen.m
+++ b/sources/VT100Screen.m
@@ -3897,6 +3897,7 @@ basedAtAbsoluteLineNumber:(long long)absoluteLineNumber
         double scale = maxWidth / (double)width;
         width = self.width;
         height *= scale;
+        height = MAX(1, height);
         fullAuto = NO;
         requestedWidthInPoints = width * cellSize.width;
         requestedHeightInPoints = height * cellSize.height;
@@ -3909,6 +3910,7 @@ basedAtAbsoluteLineNumber:(long long)absoluteLineNumber
         double scale = (double)height / maxHeight;
         height = maxHeight;
         width *= scale;
+        width = MAX(1, width);
         fullAuto = NO;
         requestedWidthInPoints = width * cellSize.width;
         requestedHeightInPoints = height * cellSize.height;


### PR DESCRIPTION
When I run longcat (https://github.com/mattn/longcat) on iTerm2 with option
"-H -n N" with large integer N, the image is not shown.

![スクリーンショット 2019-10-01 23 02 50](https://user-images.githubusercontent.com/107537/65969444-bf2f6c80-e49f-11e9-8c33-08f2545a94d7.png)

The debug log says:
```
1569935975.044434 VT100Screen.m:3950 (-[VT100Screen appendImageAtCursorWithName:width:units:height:units:preserveAspectRatio:roundUp:inset:image:data:]): Append 0 rows of image characters with 80 columns. The value of c.image is 1
```
There is a problem in scaling process that can make width (or height) zero.
I've confirmed the problem is fixed by 5c0ecac and the image is shown.