### PR TITLE
Fixed xcodebuild

### DIFF
--- a/iTerm2.xcodeproj/project.pbxproj
+++ b/iTerm2.xcodeproj/project.pbxproj
@@ -3596,6 +3596,13 @@
 			remoteGlobalIDString = 1D6ED85219AEA20D005A7799;
 			remoteInfo = iTerm2ForApplescriptTesting;
 		};
+		69021A922344313A00FDA6CA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0464AB0C006CD2EC7F000001 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1DFA7C661923E83500DF1410;
+			remoteInfo = SSKeychain;
+		};
 		A667195D1DCE36EF000CE608 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0464AB0C006CD2EC7F000001 /* Project object */;
@@ -10539,6 +10546,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				69021A932344313A00FDA6CA /* PBXTargetDependency */,
 			);
 			name = iTerm2Shared;
 			productName = SSKeychain;
@@ -13117,6 +13125,11 @@
 			isa = PBXTargetDependency;
 			target = 1D6ED85219AEA20D005A7799 /* iTerm2ForApplescriptTesting */;
 			targetProxy = 1D6EDB0C19AEA276005A7799 /* PBXContainerItemProxy */;
+		};
+		69021A932344313A00FDA6CA /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1DFA7C661923E83500DF1410 /* SSKeychain */;
+			targetProxy = 69021A922344313A00FDA6CA /* PBXContainerItemProxy */;
 		};
 		A667195E1DCE36EF000CE608 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/iTerm2.xcodeproj/xcshareddata/xcschemes/iTerm2.xcscheme
+++ b/iTerm2.xcodeproj/xcshareddata/xcschemes/iTerm2.xcscheme
@@ -26,20 +26,8 @@
       buildConfiguration = "Development"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      enableAddressSanitizer = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "A6C7641B1B45CB2800E3C992"
-               BuildableName = "iTerm2XCTests.xctest"
-               BlueprintName = "iTerm2XCTests"
-               ReferencedContainer = "container:iTerm2.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-      </Testables>
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      enableAddressSanitizer = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -56,6 +44,18 @@
             isEnabled = "YES">
          </AdditionalOption>
       </AdditionalOptions>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A6C7641B1B45CB2800E3C992"
+               BuildableName = "iTerm2XCTests.xctest"
+               BlueprintName = "iTerm2XCTests"
+               ReferencedContainer = "container:iTerm2.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Development"
@@ -68,6 +68,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       stopOnEveryUBSanitizerIssue = "YES"
+      migratedStopOnEveryIssue = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable


### PR DESCRIPTION
Added SSKeychain as a dependency to the iTerm2Shared target, thus allowing `xcodebuild -project iTerm2.xcodeproj` to successfully build iTerm2.app from the command line without a `can't locate file for: -lSSKeychain` error being generated.