### PR TITLE
Add Nixpkgs-specific make flag to fix build with nix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,10 @@ Deployment:
 	xcodebuild -parallelizeTargets -target iTerm2 -configuration Deployment && \
 	chmod -R go+rX build/Deployment
 
+Nix:
+	xcodebuild -parallelizeTargets -target iTerm2 -scheme iTerm2 -configuration Deployment -derivedDataPath . CODE_SIGN_IDENTITY= DEVELOPMENT_TEAM= && \
+	chmod -R go+rX Build/Products/Deployment
+
 Nightly: force
 	cp plists/nightly-iTerm2.plist plists/iTerm2.plist
 	# xcodebuild -parallelizeTargets -target iTerm2 -configuration Nightly CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO && git checkout -- plists/iTerm2.plist


### PR DESCRIPTION
### Problem
[Nix](https://nixos.org/nix/) has its default home directory under `/private/var/empty`. As a result, Xcode sets the build directory relative to this home directory. Since Mojave the user has no write permission in that directory and the build fails.

### Solution
Set the build directory to a path where Nix has write permission. This is done with the 
`-derivedDataPath` flag to `xcodebuild`.

### Other
 - I also updated the path where the executable lies.
Before: `build/Deployment`
New: `Build/Products/Deployment`

You may want to change them for the other Makefile flags as well.

- Added empty `CODE_SIGN_IDENTITY`and `DEVELOPMENT_TEAM` to fix codesign issue.

### My Setup
- macOS Catalina 10.15
- Xcode 11.1