### PR TITLE
Adds command+shift+t keyboard shortcut to 'Duplicate Tab' under 'Shell'

### DIFF
--- a/Interfaces/MainMenu.xib
+++ b/Interfaces/MainMenu.xib
@@ -144,8 +144,8 @@
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="1199"/>
-                            <menuItem title="Duplicate Tab" identifier="Duplicate Tab" id="Heo-Xb-RKN">
-                                <modifierMask key="keyEquivalentModifierMask"/>
+                            <menuItem title="Duplicate Tab" keyEquivalent="t" identifier="Duplicate Tab" id="Heo-Xb-RKN">
+                                <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
                                 <connections>
                                     <action selector="duplicateTab:" target="-1" id="DcR-B7-VKj"/>
                                 </connections>


### PR DESCRIPTION
This shortcut appears to not otherwise be in use. I use Duplicate Tab for opening multiple tabs to work on different things in the same directory, but have to click several times to get the tabs I want. A keyboard shortcut would make this experience nicer and I suspect there may be other users who would also benefit from this.