### PR TITLE
Tooltip documentation for tab title setting

### DIFF
--- a/Interfaces/PreferencePanel.xib
+++ b/Interfaces/PreferencePanel.xib
@@ -4897,7 +4897,7 @@ DQ
                                             <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="tVY-OD-hsd">
                                                 <rect key="frame" x="18" y="20" width="200" height="18"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                <string key="toolTip">Native full screen windows animate into their own desktop. Non-native full screen windows quickly expand to fill the window's screen.</string>
+                                                <string key="toolTip">When this is checked.... DOCUMENTATION.</string>
                                                 <buttonCell key="cell" type="check" title="Separate window title per tab" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="NbC-dp-wjc">
                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                     <font key="font" metaFont="system"/>


### PR DESCRIPTION
The tab title setting has identical tooltip documentation to the setting above it.

Let me know what the copy should be and I'll update the PR!

<img width="645" alt="Screen Shot 2020-01-15 at 9 35 05 PM" src="https://user-images.githubusercontent.com/6097/72488471-105d3500-37df-11ea-8b1e-317c5bb07923.png">
<img width="644" alt="Screen Shot 2020-01-15 at 9 35 32 PM" src="https://user-images.githubusercontent.com/6097/72488472-105d3500-37df-11ea-8e9f-03a1aed54174.png">
