### PR TITLE
Highlight text and keep foreground color

### DIFF
--- a/sources/iTermMetalPerFrameState.m
+++ b/sources/iTermMetalPerFrameState.m
@@ -1245,10 +1245,6 @@ ambiguousIsDoubleWidth:(BOOL)ambiguousIsDoubleWidth
         // Blue link text.
         rawColor = VectorForColor([_configuration->_colorMap colorForKey:kColorMapLink]);
         caches->havePreviousCharacterAttributes = NO;
-    } else if (selected) {
-        // Selected text.
-        rawColor = VectorForColor([colorMap colorForKey:kColorMapSelectedText]);
-        caches->havePreviousCharacterAttributes = NO;
     } else if (_configuration->_reverseVideo &&
                ((c->foregroundColor == ALTSEM_DEFAULT && c->foregroundColorMode == ColorModeAlternate) ||
                 (c->foregroundColor == ALTSEM_CURSOR && c->foregroundColorMode == ColorModeAlternate))) {

--- a/sources/iTermTextDrawingHelper.m
+++ b/sources/iTermTextDrawingHelper.m
@@ -1891,10 +1891,6 @@ NSColor *iTermTextDrawingHelperGetTextColor(iTermTextDrawingHelper *self,
         // Blue link text.
         rawColor = [context->colorMap colorForKey:kColorMapLink];
         context->havePreviousCharacterAttributes = NO;
-    } else if (context->hasSelectedText) {
-        // Selected text.
-        rawColor = [context->colorMap colorForKey:kColorMapSelectedText];
-        context->havePreviousCharacterAttributes = NO;
     } else if (context->reverseVideo &&
                ((c->foregroundColor == ALTSEM_DEFAULT && c->foregroundColorMode == ColorModeAlternate) ||
                 (c->foregroundColor == ALTSEM_CURSOR && c->foregroundColorMode == ColorModeAlternate))) {


### PR DESCRIPTION
When highlighting text, it doesn't look nice to change all the foreground colors to black. Here is a proposed patch that will keep the color of the font.

I'm not a regular iTerm2 dev, I just wanted to fix the colors.. If there is a need to make this into an option in user preferences, I would need help.
