### PR TITLE
fix(keys): Correctly map 'increase height' shortcut.

### DIFF
--- a/sources/iTermEditKeyActionWindowController.m
+++ b/sources/iTermEditKeyActionWindowController.m
@@ -44,7 +44,7 @@
     IBOutlet NSPopUpButton *_colorPresetsPopup;
     IBOutlet NSView *_pasteSpecialViewContainer;
     IBOutlet NSButton *_okButton;
-    
+
     iTermPasteSpecialViewController *_pasteSpecialViewController;
     iTermFunctionCallTextFieldDelegate *_functionCallDelegate;
     iTermFunctionCallTextFieldDelegate *_labelDelegate;
@@ -132,7 +132,7 @@
 
         [[iTermSearchableComboViewGroup alloc] initWithLabel:@"Resize Pane" items:@[
             [[iTermSearchableComboViewItem alloc] initWithLabel:@"Decrease Height" tag:KEY_ACTION_DECREASE_HEIGHT],
-            [[iTermSearchableComboViewItem alloc] initWithLabel:@"Increase Height" tag:KEY_ACTION_DECREASE_HEIGHT],
+            [[iTermSearchableComboViewItem alloc] initWithLabel:@"Increase Height" tag:KEY_ACTION_INCREASE_HEIGHT],
             [[iTermSearchableComboViewItem alloc] initWithLabel:@"Decrease Width" tag:KEY_ACTION_DECREASE_WIDTH],
             [[iTermSearchableComboViewItem alloc] initWithLabel:@"Increase Width" tag:KEY_ACTION_INCREASE_WIDTH],
         ]],
@@ -643,7 +643,6 @@
                 self.parameterValue = [[_menuToSelectPopup selectedItem] title];
             }
             break;
-
 
         case KEY_ACTION_SPLIT_HORIZONTALLY_WITH_PROFILE:
         case KEY_ACTION_SPLIT_VERTICALLY_WITH_PROFILE:


### PR DESCRIPTION
### What does this PR do?
Fixes a bug in the "Keys" menu, where assigning a keybinding to "Increase Height" instead assigns to "Decrease Height" — looks like this was [introduced](https://github.com/gnachman/iTerm2/commit/2a58778cb62c8318ba003f8991fcdeab122cedbc#diff-d685851ee8f00202cb41d7229dba8234R135) as part of a refactoring a couple weeks ago.

Screengrab demonstrating issue:

![Screen Capture on 2020-02-15 at 17-32-58](https://user-images.githubusercontent.com/583147/74596152-534a3c80-5019-11ea-9a05-bd89f003c44f.gif)
