### PR TITLE
WIP (Don't merge): Fix external editor URL scheme improperly encoding file URLs

### DIFF
--- a/sources/iTermSemanticHistoryController.m
+++ b/sources/iTermSemanticHistoryController.m
@@ -420,7 +420,7 @@ NSString *const kSemanticHistoryColumnNumberKey = @"semanticHistory.columnNumber
         return;
     }
 
-    path = [path stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]];
+    path = [path stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLPathAllowedCharacterSet]];
     NSURL *url = nil;
     NSString *editorIdentifier = identifier;
     if (lineNumber) {


### PR DESCRIPTION
Fixes how iTerm2 handles encoding for the file protocol URL it uses to spawn external editors such as TextMate or MacVim. In particular, previously the slashes in the file:// URL were all encoded to "%2F", which would be incorrect as it resulted in paths such as file://%2FUsers%2Ffoo%2Ffile%20with%20space. The URL is invalid in that case and it's an accident that it worked with existing editors.

Fix this by using the proper character set to encode (path) instead of the original "host" configuration.

Also see https://github.com/macvim-dev/macvim/issues/1020.