### PR TITLE
Only apply 'exclude from app switcher' setting when all windows are hotkey windows

### DIFF
--- a/sources/PseudoTerminal.m
+++ b/sources/PseudoTerminal.m
@@ -134,7 +134,6 @@ NSString *const iTermSelectedTabDidChange = @"iTermSelectedTabDidChange";
 NSString *const iTermWindowDidCloseNotification = @"iTermWindowDidClose";
 NSString *const iTermTabDidCloseNotification = @"iTermTabDidClose";
 NSString *const iTermDidCreateTerminalWindowNotification = @"iTermDidCreateTerminalWindowNotification";
-extern NSString *const iTermProcessTypeDidChangeNotification;
 
 static NSString *const kWindowNameFormat = @"iTerm Window %d";
 
@@ -1605,8 +1604,6 @@ ITERM_WEAKLY_REFERENCEABLE
             [aSession terminate];
         }
     }
-    [[NSNotificationCenter defaultCenter] postNotificationName:iTermProcessTypeDidChangeNotification
-    object:nil];
 }
 
 - (PTYTab *)tabForSession:(PTYSession *)session {
@@ -10755,8 +10752,7 @@ static CGFloat iTermDimmingAmount(PSMTabBarControl *tabView) {
                 break;
         }
     }
-    [[NSNotificationCenter defaultCenter] postNotificationName:iTermProcessTypeDidChangeNotification
-    object:nil];
+
     return aSession;
 }
 

--- a/sources/PseudoTerminal.m
+++ b/sources/PseudoTerminal.m
@@ -134,6 +134,7 @@ NSString *const iTermSelectedTabDidChange = @"iTermSelectedTabDidChange";
 NSString *const iTermWindowDidCloseNotification = @"iTermWindowDidClose";
 NSString *const iTermTabDidCloseNotification = @"iTermTabDidClose";
 NSString *const iTermDidCreateTerminalWindowNotification = @"iTermDidCreateTerminalWindowNotification";
+extern NSString *const iTermProcessTypeDidChangeNotification;
 
 static NSString *const kWindowNameFormat = @"iTerm Window %d";
 
@@ -1604,6 +1605,8 @@ ITERM_WEAKLY_REFERENCEABLE
             [aSession terminate];
         }
     }
+    [[NSNotificationCenter defaultCenter] postNotificationName:iTermProcessTypeDidChangeNotification
+    object:nil];
 }
 
 - (PTYTab *)tabForSession:(PTYSession *)session {
@@ -10752,7 +10755,8 @@ static CGFloat iTermDimmingAmount(PSMTabBarControl *tabView) {
                 break;
         }
     }
-
+    [[NSNotificationCenter defaultCenter] postNotificationName:iTermProcessTypeDidChangeNotification
+    object:nil];
     return aSession;
 }
 

--- a/sources/iTermAdvancedSettingsModel.h
+++ b/sources/iTermAdvancedSettingsModel.h
@@ -52,6 +52,7 @@ extern NSString *const iTermAdvancedSettingsDidChange;
 + (int)autocompleteMaxOptions;
 + (NSString *)autoLogFormat;
 + (BOOL)autologAppends;
++ (BOOL)automaticallyToggleLSUI;
 + (NSString *)badgeFont;
 + (BOOL)badgeFontIsBold;
 + (double)badgeMaxHeightFraction;

--- a/sources/iTermAdvancedSettingsModel.m
+++ b/sources/iTermAdvancedSettingsModel.m
@@ -315,7 +315,7 @@ DEFINE_BOOL(dockIconTogglesWindow, NO, SECTION_HOTKEY @"If the only window is a 
 DEFINE_BOOL(hotkeyWindowFloatsAboveOtherWindows, NO, SECTION_HOTKEY @"The hotkey window floats above other windows even when another application is active.\nYou must disable “Prefs > Keys > Hotkey window hides when focus is lost” for this setting to be effective.");
 DEFINE_FLOAT(hotKeyDoubleTapMaxDelay, 0.3, SECTION_HOTKEY @"The maximum amount of time allowed between presses of a modifier key when performing a modifier double-tap.");
 DEFINE_FLOAT(hotKeyDoubleTapMinDelay, 0.01, SECTION_HOTKEY @"The minimum amount of time required between presses of a modifier key when performing a modifier double-tap.");
-DEFINE_BOOL(automaticallyToggleLSUI, YES_IF_BETA_ELSE_NO, SECTION_HOTKEY @"Automatically sets iTerm2 as LSUIElement when the “Exclude iTerm2 from dock and app switcher” setting is enabled AND only Hotkey windows are open. Unsets iTerm2 as LSUIElement when the “Exclude iTerm2 from dock and app switcher” setting is enabled AND at least one non-Hotkey window is open.");
+DEFINE_BOOL(automaticallyToggleLSUI, YES_IF_BETA_ELSE_NO, SECTION_HOTKEY @"Disable “Exclude iTerm2 from Dock and ⌘-Tab App Switcher” when any windows are not hotkey windows.");
 
 #pragma mark General
 

--- a/sources/iTermAdvancedSettingsModel.m
+++ b/sources/iTermAdvancedSettingsModel.m
@@ -315,7 +315,7 @@ DEFINE_BOOL(dockIconTogglesWindow, NO, SECTION_HOTKEY @"If the only window is a 
 DEFINE_BOOL(hotkeyWindowFloatsAboveOtherWindows, NO, SECTION_HOTKEY @"The hotkey window floats above other windows even when another application is active.\nYou must disable “Prefs > Keys > Hotkey window hides when focus is lost” for this setting to be effective.");
 DEFINE_FLOAT(hotKeyDoubleTapMaxDelay, 0.3, SECTION_HOTKEY @"The maximum amount of time allowed between presses of a modifier key when performing a modifier double-tap.");
 DEFINE_FLOAT(hotKeyDoubleTapMinDelay, 0.01, SECTION_HOTKEY @"The minimum amount of time required between presses of a modifier key when performing a modifier double-tap.");
-DEFINE_BOOL(automaticallyToggleLSUI, YES_IF_BETA_ELSE_NO, SECTION_HOTKEY @"Automatically sets iTerm2 as LSUIElement when the 'Exclude iTerm2 from dock and app switcher' setting is enabled AND only Hotkey windows are open. Unsets iTerm2 as LSUIElement when the 'Exclude iTerm2 from dock and app switcher' setting is enabled AND at least one non-Hotkey window is open.");
+DEFINE_BOOL(automaticallyToggleLSUI, YES_IF_BETA_ELSE_NO, SECTION_HOTKEY @"Automatically sets iTerm2 as LSUIElement when the “Exclude iTerm2 from dock and app switcher” setting is enabled AND only Hotkey windows are open. Unsets iTerm2 as LSUIElement when the “Exclude iTerm2 from dock and app switcher” setting is enabled AND at least one non-Hotkey window is open.");
 
 #pragma mark General
 

--- a/sources/iTermAdvancedSettingsModel.m
+++ b/sources/iTermAdvancedSettingsModel.m
@@ -315,6 +315,7 @@ DEFINE_BOOL(dockIconTogglesWindow, NO, SECTION_HOTKEY @"If the only window is a 
 DEFINE_BOOL(hotkeyWindowFloatsAboveOtherWindows, NO, SECTION_HOTKEY @"The hotkey window floats above other windows even when another application is active.\nYou must disable “Prefs > Keys > Hotkey window hides when focus is lost” for this setting to be effective.");
 DEFINE_FLOAT(hotKeyDoubleTapMaxDelay, 0.3, SECTION_HOTKEY @"The maximum amount of time allowed between presses of a modifier key when performing a modifier double-tap.");
 DEFINE_FLOAT(hotKeyDoubleTapMinDelay, 0.01, SECTION_HOTKEY @"The minimum amount of time required between presses of a modifier key when performing a modifier double-tap.");
+DEFINE_BOOL(automaticallyToggleLSUI, YES_IF_BETA_ELSE_NO, SECTION_HOTKEY @"Automatically sets iTerm2 as LSUIElement when the 'Exclude iTerm2 from dock and app switcher' setting is enabled AND only Hotkey windows are open. Unsets iTerm2 as LSUIElement when the 'Exclude iTerm2 from dock and app switcher' setting is enabled AND at least one non-Hotkey window is open.");
 
 #pragma mark General
 

--- a/sources/iTermApplicationDelegate.m
+++ b/sources/iTermApplicationDelegate.m
@@ -2063,7 +2063,12 @@ static BOOL hasBecomeActive = NO;
 #pragma mark - Private
 
 - (void)updateProcessType {
-    [[iTermApplication sharedApplication] setIsUIElement:[iTermPreferences boolForKey:kPreferenceKeyUIElement]];
+    bool onlyHotKeyWindowsOpen = true;
+    for (PseudoTerminal* term in [self terminals]) {
+        onlyHotKeyWindowsOpen &= [term isHotKeyWindow];
+    }
+    bool isUIElement = [iTermPreferences boolForKey:kPreferenceKeyUIElement];
+    [[iTermApplication sharedApplication] setIsUIElement:isUIElement && onlyHotKeyWindowsOpen];
 }
 
 - (PseudoTerminal *)terminalToOpenFileIn {

--- a/sources/iTermApplicationDelegate.m
+++ b/sources/iTermApplicationDelegate.m
@@ -2063,12 +2063,17 @@ static BOOL hasBecomeActive = NO;
 #pragma mark - Private
 
 - (void)updateProcessType {
-    bool onlyHotKeyWindowsOpen = true;
-    for (PseudoTerminal* term in [self terminals]) {
-        onlyHotKeyWindowsOpen &= [term isHotKeyWindow];
+    bool enableLSUI = [iTermPreferences boolForKey:kPreferenceKeyUIElement];
+
+    if ([iTermAdvancedSettingsModel automaticallyToggleLSUI]) {
+        bool onlyHotKeyWindowsOpen = true;
+        for (PseudoTerminal* term in [self terminals]) {
+            onlyHotKeyWindowsOpen &= [term isHotKeyWindow];
+        }
+        enableLSUI &= onlyHotKeyWindowsOpen;
     }
-    bool isUIElement = [iTermPreferences boolForKey:kPreferenceKeyUIElement];
-    [[iTermApplication sharedApplication] setIsUIElement:isUIElement && onlyHotKeyWindowsOpen];
+    
+    [[iTermApplication sharedApplication] setIsUIElement:enableLSUI];
 }
 
 - (PseudoTerminal *)terminalToOpenFileIn {

--- a/sources/iTermApplicationDelegate.m
+++ b/sources/iTermApplicationDelegate.m
@@ -2063,14 +2063,12 @@ static BOOL hasBecomeActive = NO;
 #pragma mark - Private
 
 - (void)updateProcessType {
-    bool enableLSUI = [iTermPreferences boolForKey:kPreferenceKeyUIElement];
+    BOOL enableLSUI = [iTermPreferences boolForKey:kPreferenceKeyUIElement];
 
     if ([iTermAdvancedSettingsModel automaticallyToggleLSUI]) {
-        bool onlyHotKeyWindowsOpen = true;
-        for (PseudoTerminal* term in [self terminals]) {
-            onlyHotKeyWindowsOpen &= [term isHotKeyWindow];
-        }
-        enableLSUI &= onlyHotKeyWindowsOpen;
+        const BOOL onlyHotKeyWindowsOpen = [self.terminals allWithBlock:^BOOL(PseudoTerminal *term) { return term.isHotKeyWindow; }];
+
+        enableLSUI = enableLSUI && onlyHotKeyWindowsOpen;
     }
     
     [[iTermApplication sharedApplication] setIsUIElement:enableLSUI];

--- a/sources/iTermController.m
+++ b/sources/iTermController.m
@@ -78,6 +78,8 @@
 - (void)_cycleWindowsReversed:(BOOL)back;
 @end
 
+extern NSString *const iTermProcessTypeDidChangeNotification;
+
 // Pref keys
 static iTermController *gSharedInstance;
 
@@ -226,6 +228,11 @@ static iTermController *gSharedInstance;
             [terminal setWindowTitle];
         }
     }
+}
+
+- (void)updateProcessType {
+    [[NSNotificationCenter defaultCenter] postNotificationName:iTermProcessTypeDidChangeNotification
+    object:nil];
 }
 
 - (BOOL)haveTmuxConnection {
@@ -1302,12 +1309,14 @@ static iTermController *gSharedInstance;
 
     [_terminalWindows addObject:terminalWindow];
     [self updateWindowTitles];
+    [self updateProcessType];
     [[iTermPresentationController sharedInstance] update];
 }
 
 - (void)removeTerminalWindow:(PseudoTerminal *)terminalWindow {
     [_terminalWindows removeObject:terminalWindow];
     [self updateWindowTitles];
+    [self updateProcessType];
     [[iTermPresentationController sharedInstance] update];
 }
 

--- a/sources/iTermController.m
+++ b/sources/iTermController.m
@@ -232,7 +232,7 @@ static iTermController *gSharedInstance;
 
 - (void)updateProcessType {
     [[NSNotificationCenter defaultCenter] postNotificationName:iTermProcessTypeDidChangeNotification
-    object:nil];
+                                                        object:nil];
 }
 
 - (BOOL)haveTmuxConnection {


### PR DESCRIPTION
Hi,

This is a prototype to only apply the 'exclude from app switcher' setting when all windows are hotkey windows. Why?

I have two modes of operation for iTerm:
1. To quickly enter transient commands.
2. For long lived vim/ssh/log sessions.

Hotkey windows are ideally suited for the first case, and standard windows are great for the second. The pedant in me dislikes having iTerm appear in the app switcher when I only have a hotkey window open, but having iTerm in the app switcher is required for the second use case. I want the best of both worlds, so I implemented this prototype PR to achieve that:

**iTerm2 excluded from app switcher when only a hotkey window is open:**
<img width="480" alt="iTerm2 excluded from app switcher when only a hotkey window is open" src="https://user-images.githubusercontent.com/1374614/84956114-6caae480-b0f0-11ea-91a0-210501a964eb.png">

**iTerm2 included in app switcher when a non-hotkey window is open:**
<img width="480" alt="iTerm2 included in app switcher when a non-hotkey window is open" src="https://user-images.githubusercontent.com/1374614/84956137-7896a680-b0f0-11ea-9d5f-5d720ec40141.png">

I labeled this prototype because I am not well-versed in either Objective C or Apple UI apps, so before I commit more time to learning how to make the change properly, I wanted to ask a few questions:

1. Is there an existing way to achieve what I'm trying to do here?
2. Is this something you would accept as part of iTerm2?
If so:
3. Is the approach along the right lines?
4. Should it be configured separately from the existing settings?

Thanks,

-Andy