### PR TITLE
Fix wrong URL encoding for sematic history paths

### DIFF
--- a/sources/iTermSemanticHistoryController.m
+++ b/sources/iTermSemanticHistoryController.m
@@ -420,7 +420,7 @@ NSString *const kSemanticHistoryColumnNumberKey = @"semanticHistory.columnNumber
         return;
     }
 
-    path = [path stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]];
+    path = [path stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLPathAllowedCharacterSet]];
     NSURL *url = nil;
     NSString *editorIdentifier = identifier;
     if (lineNumber) {
@@ -669,7 +669,7 @@ NSString *const kSemanticHistoryColumnNumberKey = @"semanticHistory.columnNumber
 
         url = [url stringByPerformingSubstitutions:numericSubstitutions];
         NSString *(^urlEscapeFunction)(NSString *) = ^NSString *(NSString *string) {
-            return [string stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]];
+            return [string stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLPathAllowedCharacterSet]];
         };
         iTermParsedExpression *parsedExpression = [iTermExpressionParser parsedExpressionWithInterpolatedString:url
                                                                                                escapingFunction:urlEscapeFunction


### PR DESCRIPTION
This fixes wrong encoding of paths when cmd-clicking on existing files
in sematic history to for example open the file in MacVim or a custom
URL.

The problem is that URLHostAllowedCharacterSet does not contain the
slash character, so eg. /Users/foo/bar baz.txt is encoded as
%2FUsers%2Ffoo%2Fbar%20baz.txt instead of the correct
/Users/foo/bar%20baz.txt.

While some application might not care this at least breaks opening files
in MacVim, which requires proper path encoding.

This changes to use the correct URLPathAllowedCharacterSet instead.

It is possible that URLHostAllowedCharacterSet contained "/" in the past,
even though it is not a valid character for the host part of a URL and
Apple fixed it it newer SDK versions.

This fixes issue [#8994 – Wrong URL Encoding for files opened via Semantic History](https://gitlab.com/gnachman/iterm2/-/issues/8994).