### PR TITLE
Allow full range of blurRadius for 10.14+ and add option to create a new window with the current profile

### DIFF
--- a/Interfaces/MainMenu.xib
+++ b/Interfaces/MainMenu.xib
@@ -128,9 +128,15 @@
                 <menuItem title="Shell" id="83">
                     <menu key="submenu" title="Shell" id="81">
                         <items>
-                            <menuItem title="New Window" alternate="YES" keyEquivalent="n" identifier="New Window" id="872">
+                            <menuItem title="New Window" keyEquivalent="n" identifier="New Window" id="872">
                                 <connections>
                                     <action selector="newWindow:" target="201" id="873"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="New Window with Current Profile" keyEquivalent="N" identifier="New Window with Current Profile" id="hVd-f7-nvC">
+                                <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                <connections>
+                                    <action selector="newWindowWithSameProfile:" target="201" id="Vf0-jd-DF2"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="New Tab" keyEquivalent="t" identifier="New Tab" id="867">

--- a/Interfaces/PreferencePanel.xib
+++ b/Interfaces/PreferencePanel.xib
@@ -3248,7 +3248,7 @@ DQ
                 <slider verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5363">
                     <rect key="frame" x="36" y="283" width="218" height="21"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <sliderCell key="cell" continuous="YES" alignment="left" minValue="0.10000000000000001" maxValue="30" doubleValue="0.10000000000000001" tickMarkPosition="below" sliderType="linear" id="5368"/>
+                    <sliderCell key="cell" continuous="YES" alignment="left" minValue="0.10000000000000001" maxValue="100" doubleValue="25" tickMarkPosition="below" sliderType="linear" id="5368"/>
                     <connections>
                         <action selector="settingChanged:" target="BMA-OA-Kzc" id="AJB-o1-kDf"/>
                         <outlet property="nextKeyView" destination="4973" id="5373"/>

--- a/sources/PTYTab.m
+++ b/sources/PTYTab.m
@@ -2460,10 +2460,12 @@ static void SetAgainstGrainDim(BOOL isVertical, NSSize *dest, CGFloat value) {
         }
     }
     if (count > 0) {
-        if (@available(macOS 10.13, *)) {
+        if (@available(macOS 10.14, *)) {
+            return sum / count;
+        } else if (@available(macOS 10.13, *)) {
             // Issue 6115. It turns red for values over 26. When I drop 10.12 support I can adjust
             // the slider to not go above 26. But it's super slow before you get
-          // to 26, so let's limit it to 24. Issue 6138.
+            // to 26, so let's limit it to 24. Issue 6138.
             return MIN(24, sum / count);
         } else {
             return sum / count;

--- a/sources/iTermApplicationDelegate.m
+++ b/sources/iTermApplicationDelegate.m
@@ -1601,6 +1601,15 @@ static BOOL hasBecomeActive = NO;
     }
 }
 
+- (IBAction)newWindowWithSameProfile:(id)sender {
+    DLog(@"newWindowWithSameProfile: invoked");
+    BOOL cancel;
+    BOOL tmux = [self possiblyTmuxValueForWindow:YES cancel:&cancel];
+    if (!cancel) {
+        [[iTermController sharedInstance] newWindowWithSameProfile:sender possiblyTmux:tmux];
+    }
+}
+
 - (IBAction)newSessionWithSameProfile:(id)sender
 {
     [[iTermController sharedInstance] newSessionWithSameProfile:sender];

--- a/sources/iTermController.h
+++ b/sources/iTermController.h
@@ -71,6 +71,7 @@ typedef NS_ENUM(NSUInteger, iTermHotkeyWindowType) {
 // actions are forwarded from application
 - (IBAction)newWindow:(id)sender;
 - (void)newWindow:(id)sender possiblyTmux:(BOOL)possiblyTmux;
+- (void)newWindowWithSameProfile:(id)sender possiblyTmux:(BOOL)possiblyTmux;
 - (void)newSessionWithSameProfile:(id)sender;
 - (void)newSession:(id)sender possiblyTmux:(BOOL)possiblyTmux;
 - (void)previousTerminal;


### PR DESCRIPTION
Full range of blurRadius is working on 10.14 without the artifacts noted in issue #6115 and #6138. No way that I know of to create a new window with the current profile (other than directly linking a specific profile to a keyboard shortcut), so I added this option in the Shell menu because I find myself always needing it. Right now, you have to create a 'New Tab with Current Profile' and then drag the tab off the window, and this is cumbersome.