### PR TITLE
Do not warn multi line paste when the RemovingNewLines flag is true.

### DIFF
--- a/sources/iTermPasteHelper.m
+++ b/sources/iTermPasteHelper.m
@@ -573,6 +573,9 @@ const NSInteger iTermQuickPasteBytesPerCallDefaultValue = 768;
             }
         }
     }
+    if (pasteEvent.flags & kPasteFlagsRemovingNewlines) {
+        return YES;
+    }
 
     NSCharacterSet *newlineCharacterSet =
         [NSCharacterSet characterSetWithCharactersInString:@"\r\n"];


### PR DESCRIPTION
   The newlines will be removed when sanitizing.