### PR TITLE
Allow switching tabs using '^ Number'

### DIFF
--- a/Interfaces/PreferencePanel.xib
+++ b/Interfaces/PreferencePanel.xib
@@ -5771,6 +5771,9 @@ DQ
                                                             <menuItem title="⌘ Number" tag="4" id="4133">
                                                                 <modifierMask key="keyEquivalentModifierMask"/>
                                                             </menuItem>
+                                                            <menuItem title="^ Number" tag="1" id="4135">
+                                                                <modifierMask key="keyEquivalentModifierMask"/>
+                                                            </menuItem>
                                                             <menuItem title="⌥⌘ Number" state="on" tag="6" id="4137">
                                                                 <modifierMask key="keyEquivalentModifierMask"/>
                                                             </menuItem>

--- a/sources/iTermPreferences.m
+++ b/sources/iTermPreferences.m
@@ -620,6 +620,9 @@ static NSString *sPreviousVersion;
 
 + (NSUInteger)maskForModifierTag:(iTermPreferencesModifierTag)tag {
     switch (tag) {
+        case kPreferencesModifierTagControl:
+            return NSEventModifierFlagControl;
+
         case kPreferencesModifierTagEitherCommand:
             return NSEventModifierFlagCommand;
 


### PR DESCRIPTION
Same request as https://gitlab.com/gnachman/iterm2/-/issues/7387, but now atop master. Allowing tab switch using `^` makes the shortcuts more consistent with browsers.