### PR TITLE
Smart Selection "Word bounded by WS" now omits trailing * or @ character

### DIFF
--- a/plists/SmartSelectionRules.plist
+++ b/plists/SmartSelectionRules.plist
@@ -8,7 +8,7 @@
 			<key>notes</key>
 			<string>Word bounded by whitespace</string>
 			<key>regex</key>
-			<string>\S+</string>
+			<string>\S+(?<!\*)</string>
 			<key>precision</key>
 			<string>low</string>
 		</dict>

--- a/plists/SmartSelectionRules.plist
+++ b/plists/SmartSelectionRules.plist
@@ -8,7 +8,7 @@
 			<key>notes</key>
 			<string>Word bounded by whitespace</string>
 			<key>regex</key>
-			<string>\S+(?<!\*)</string>
+			<string>\S+(?<![\*\@])</string>
 			<key>precision</key>
 			<string>low</string>
 		</dict>


### PR DESCRIPTION
This changes the default behavior of Smart Selection so that the "word bounded by Whitespace" regex does not include trailing @ or * characters by default.  This improves behavior of the selector for those of us who use `ls -F` by default.  

`ls -F` displays a character at the end of a filename to indicate special file types or directories.  E.g. it adds a "*" to executable files and an "@" at the end of symbolic links.  The default regex of `\S+` includes those characters which can cause weird side effects with a typical pattern of use like this `ls`, user selects filename, user pastes into another command line window.  The default would include `executable_file*` or `symbolic_link@` which doesn't exist or might refer to multiple files.  

The trailing `*` is especially troublesome in cases where there are multiple files of the same name.  For example:

```
$ ls -F /usr/bin/* |grep ssh
/usr/bin/ssh*
/usr/bin/ssh-add*
/usr/bin/ssh-agent*
/usr/bin/ssh-copy-id*
/usr/bin/ssh-keygen*
/usr/bin/ssh-keyscan*
```

If someone tries to run /usr/bin/ssh* we'll get en error as the shell will expand to include the other files:
```
$ /usr/bin/ssh*
ssh: Could not resolve hostname /usr/bin/ssh-add: nodename nor servname provided, or not known
```



