### PR TITLE
Don't attempt to extract a URL from invalid coordinates (-1,-1)

### DIFF
--- a/sources/iTermTextViewContextMenuHelper.m
+++ b/sources/iTermTextViewContextMenuHelper.m
@@ -361,14 +361,18 @@ static const int kMaxSelectedTextLengthForCustomActions = 400;
                                                                  @"Context menu")
                      action:@selector(copy:) keyEquivalent:@""];
 
-    iTermTextExtractor *extractor = [self.delegate contextMenuTextExtractor:self];
-    NSString *urlID;
-    NSURL *url = [extractor urlOfHypertextLinkAt:coord urlId:&urlID];
-    if (url) {
-        NSMenuItem *item = [theMenu addItemWithTitle:@"Copy Link Address" action:@selector(copyLinkAddress:) keyEquivalent:@""];
-        item.target = self;
-        item.representedObject = url;
+    // Don't attempt to extract a URL from invalid coordinates (-1,-1) if opened from the session titlebar
+    if (coord.x >= 0 && coord.y >= 0) {
+        iTermTextExtractor *extractor = [self.delegate contextMenuTextExtractor:self];
+        NSString *urlID;
+        NSURL *url = [extractor urlOfHypertextLinkAt:coord urlId:&urlID];
+        if (url) {
+            NSMenuItem *item = [theMenu addItemWithTitle:@"Copy Link Address" action:@selector(copyLinkAddress:) keyEquivalent:@""];
+            item.target = self;
+            item.representedObject = url;
+        }
     }
+    
     [theMenu addItemWithTitle:NSLocalizedStringFromTableInBundle(@"Paste",
                                                                  @"iTerm",
                                                                  [NSBundle bundleForClass: [self class]],


### PR DESCRIPTION
When the terminal context menu is opened from a session titlebar, the coordinates passed to `menuAtCoord:(VT100GridCoord)coord` are (-1,-1), of which the y-coordinate is used as an array index to extract a line from the terminal grid in order to extract a URL. This causes a crash due to a `[-1]` array index downstream in `getLineAtIndex:(int)theIndex` as the context menu is being built when left-clicking the session titlebar context menu button in all versions after 2534252ebfada543237ea6d6ee9bf47dabe15579 with the following message:

```
Performing @selector(openMenu:) from sender NSButton 0x600001e6c4d0
Assertion failed: (NO), function -[VT100Screen getLineAtIndex:withBuffer:],
file /Users/.../iTerm2/sources/VT100Screen.m, line 1804.
```

This PR adds a lower bounds check on the coordinates before attempting to retrieve the line and extract the URL.