### PR TITLE
Recheck blur when changing window styles

### DIFF
--- a/sources/PseudoTerminal.m
+++ b/sources/PseudoTerminal.m
@@ -4664,6 +4664,7 @@ ITERM_WEAKLY_REFERENCEABLE
         return;
     }
     [self changeToWindowType:(iTermWindowType)menuItem.tag];
+    [[self currentTab] recheckBlur];
 }
 
 - (IBAction)toggleFullScreenMode:(id)sender {


### PR DESCRIPTION
When changing window styles using `Window > Window Style`, the window's blur setting is temporarily lost until the window regains focus. This re-enables the blur after modifying the window style.