### PR TITLE
Ignore dynamic profile files that end in "~" (GNU-syle backups)

### DIFF
--- a/sources/iTermDynamicProfileManager.m
+++ b/sources/iTermDynamicProfileManager.m
@@ -278,6 +278,9 @@
         if ([file hasPrefix:@"."]) {
             DLog(@"Skipping it because of leading dot");
             continue;
+        } else if ([file hasSuffix:@"~"]) {
+            DLog(@"Skipping it because of trailing tilde (GNU-style backup file)");
+            continue;
         }
         NSString *fullName = [path stringByAppendingPathComponent:file];
         if (![self loadDynamicProfilesFromFile:fullName intoArray:newProfiles guids:guids]) {


### PR DESCRIPTION
**Note well: this may not be the optimal way to do this, and I may have missed other spots that enumerate directory contents.**

GNU tools often support or default to making backups of modified files. By default, the previous contents of the file are preserved in `filename~` or `filename.~1~`. See [the coreutils docs](https://www.gnu.org/software/coreutils/manual/html_node/Backup-options.html) and [some Emacs docs](https://www.gnu.org/software/emacs/manual/html_node/emacs/Backup-Names.html). Note that Emacs produces `filename~` backups by default. Users generally do not expect these files to be read automatically.

When using Emacs to edit a dynamic profile, saving it immediately causes an iTerm diagnostic: both `filename` and `filename~` will likely contain the same UUID.

Instead of making a special case for `~`, this problem could be solved by requiring dynamic profiles have a known suffix, like `.json`. This eliminates all kinds of directory detritus at the cost of breaking some people's configs.