### PR TITLE
Recheck blur when updating tab bar theme

### DIFF
--- a/sources/PseudoTerminal.m
+++ b/sources/PseudoTerminal.m
@@ -9037,6 +9037,7 @@ static CGFloat iTermDimmingAmount(PSMTabBarControl *tabView) {
     [_contentView.tabBarControl setTabsHaveCloseButtons:[iTermPreferences boolForKey:kPreferenceKeyTabsHaveCloseButton]];
     _contentView.tabBarControl.height = [self desiredTabBarHeight];
 
+    [[self currentTab] recheckBlur];
     [self updateTabColors];
     [self updateToolbeltAppearance];
     if (@available(macOS 10.14, *)) {


### PR DESCRIPTION
When changing the tab bar theme in `Preferences > Appearance > Theme`, all active windows lose their blur until each window is clicked individually or regains focus. This re-enables blur after changing the tab bar theme.