### PR TITLE
provide gitlab description templates

### DIFF
--- a/.gitlab/issue_templates/Bug.md
+++ b/.gitlab/issue_templates/Bug.md
@@ -1,15 +1,15 @@
 # Bug report
 
-<!-- Thanks for filing an issue! Please answer the questions below so I can help you. -->
+Thanks for filing an issue! Please answer the questions below so I can help you.
 
-- [ ] iTerm2 version:
-- [ ] OS version:
-- [ ] Attach `~/Library/Preferences/com.googlecode.iterm2.plist` here (drag-drop from finder into this window)
-- [ ] Attach a [debug log](https://iterm2.com/debuglog), if possible.
-- [ ] Attach a screen capture video if it would make the reproduction steps clearer.
+- iTerm2 version:
+- OS version:
+- Attach `~/Library/Preferences/com.googlecode.iterm2.plist` here (drag-drop from finder into this window)
+- Attach a [debug log](https://iterm2.com/debuglog), if possible.
+- Attach a screen capture video if it would make the reproduction steps clearer.
 
-<!-- PLEASE ATTACH YOUR PLIST FILE FOR BUG REPORTS!
-Seriously! I'll probably ask you for it if you don’t. -->
+PLEASE ATTACH YOUR PLIST FILE FOR BUG REPORTS!
+Seriously! I'll probably ask you for it if you don’t.
 
 ## Detailed steps to reproduce the problem
 
@@ -22,5 +22,4 @@ Seriously! I'll probably ask you for it if you don’t. -->
 ## What should have happened
 
 ---
-<!-- Here be automations. -->
 /label ~Bug

--- a/.gitlab/issue_templates/Bug.md
+++ b/.gitlab/issue_templates/Bug.md
@@ -20,3 +20,7 @@ Seriously! I'll probably ask you for it if you don’t. -->
 ## What happened
 
 ## What should have happened
+
+---
+<!-- Here be automations. -->
+/label ~Bug

--- a/.gitlab/issue_templates/Bug.md
+++ b/.gitlab/issue_templates/Bug.md
@@ -1,0 +1,22 @@
+# Bug report
+
+<!-- Thanks for filing an issue! Please answer the questions below so I can help you. -->
+
+- [ ] iTerm2 version:
+- [ ] OS version:
+- [ ] Attach `~/Library/Preferences/com.googlecode.iterm2.plist` here (drag-drop from finder into this window)
+- [ ] Attach a [debug log](https://iterm2.com/debuglog), if possible.
+- [ ] Attach a screen capture video if it would make the reproduction steps clearer.
+
+<!-- PLEASE ATTACH YOUR PLIST FILE FOR BUG REPORTS!
+Seriously! I'll probably ask you for it if you don’t. -->
+
+## Detailed steps to reproduce the problem
+
+1.
+2.
+3.
+
+## What happened
+
+## What should have happened

--- a/.gitlab/issue_templates/Crash.md
+++ b/.gitlab/issue_templates/Crash.md
@@ -1,0 +1,23 @@
+# Crash report
+
+<!-- Thanks for filing an issue! Please answer the questions below so I can help you. -->
+
+- [ ] iTerm2 version:
+- [ ] OS version:
+- [ ] Attach `~/Library/Preferences/com.googlecode.iterm2.plist` here (drag-drop from finder into this window)
+- [ ] Attach a [debug log](https://iterm2.com/debuglog), if possible.
+- [ ] Attach a screen capture video if it would make the reproduction steps clearer.
+- [ ] Please attach the [crash log](https://gitlab.com/gnachman/iterm2/wikis/crash-logs).
+
+<!-- PLEASE ATTACH YOUR PLIST FILE FOR BUG REPORTS!
+Seriously! I'll probably ask you for it if you don’t. -->
+
+## Detailed steps to reproduce the problem
+
+1.
+2.
+3.
+
+## What happened
+
+## What should have happened

--- a/.gitlab/issue_templates/Crash.md
+++ b/.gitlab/issue_templates/Crash.md
@@ -21,3 +21,7 @@ Seriously! I'll probably ask you for it if you don’t. -->
 ## What happened
 
 ## What should have happened
+
+---
+<!-- Here be automations. -->
+/label ~Crash

--- a/.gitlab/issue_templates/Crash.md
+++ b/.gitlab/issue_templates/Crash.md
@@ -1,13 +1,13 @@
 # Crash report
 
-<!-- Thanks for filing an issue! Please answer the questions below so I can help you. -->
+Thanks for filing an issue! Please answer the questions below so I can help you.
 
-- [ ] iTerm2 version:
-- [ ] OS version:
-- [ ] Attach `~/Library/Preferences/com.googlecode.iterm2.plist` here (drag-drop from finder into this window)
-- [ ] Attach a [debug log](https://iterm2.com/debuglog), if possible.
-- [ ] Attach a screen capture video if it would make the reproduction steps clearer.
-- [ ] Please attach the [crash log](https://gitlab.com/gnachman/iterm2/wikis/crash-logs).
+- iTerm2 version:
+- OS version:
+- Attach `~/Library/Preferences/com.googlecode.iterm2.plist` here (drag-drop from finder into this window)
+- Attach a [debug log](https://iterm2.com/debuglog), if possible.
+- Attach a screen capture video if it would make the reproduction steps clearer.
+- Please attach the [crash log](https://gitlab.com/gnachman/iterm2/wikis/crash-logs).
 
 <!-- PLEASE ATTACH YOUR PLIST FILE FOR BUG REPORTS!
 Seriously! I'll probably ask you for it if you don’t. -->
@@ -23,5 +23,4 @@ Seriously! I'll probably ask you for it if you don’t. -->
 ## What should have happened
 
 ---
-<!-- Here be automations. -->
 /label ~Crash

--- a/.gitlab/issue_templates/Perfomance Issues.md
+++ b/.gitlab/issue_templates/Perfomance Issues.md
@@ -1,17 +1,16 @@
 # Performance issue
 
-<!-- Thanks for filing an issue! Please answer the questions below so I can help you. -->
+Thanks for filing an issue! Please answer the questions below so I can help you.
 
-- [ ] iTerm2 version:
-- [ ] OS version:
-- [ ] Attach `~/Library/Preferences/com.googlecode.iterm2.plist` here (drag-drop from finder into this window)
-- [ ] Attach a [debug log](https://iterm2.com/debuglog), if possible.
-- [ ] Attach a screen capture video if it would make the reproduction steps clearer.
-- [ ] Please attach a [process sample](https://gitlab.com/gnachman/iterm2/-/wikis/HowToSample)
-- [ ] Are you reporting excessive memory usage? Please attach a [heap analysis](https://gitlab.com/gnachman/iterm2/wikis/heapshot)
+- iTerm2 version:
+- OS version:
+- Attach `~/Library/Preferences/com.googlecode.iterm2.plist` here (drag-drop from finder into this window)
+- Attach a [debug log](https://iterm2.com/debuglog), if possible.
+- Attach a screen capture video if it would make the reproduction steps clearer.
+- Please attach a [process sample](https://gitlab.com/gnachman/iterm2/-/wikis/HowToSample)
 
-<!-- PLEASE ATTACH YOUR PLIST FILE FOR BUG REPORTS!
-Seriously! I'll probably ask you for it if you don’t. -->
+PLEASE ATTACH YOUR PLIST FILE FOR BUG REPORTS!
+Seriously! I'll probably ask you for it if you don’t.
 
 ## Detailed steps to reproduce the problem
 
@@ -24,5 +23,4 @@ Seriously! I'll probably ask you for it if you don’t. -->
 ## What should have happened
 
 ---
-<!-- Here be automations. -->
 /label ~Performance

--- a/.gitlab/issue_templates/Perfomance Issues.md
+++ b/.gitlab/issue_templates/Perfomance Issues.md
@@ -22,3 +22,7 @@ Seriously! I'll probably ask you for it if you don’t. -->
 ## What happened
 
 ## What should have happened
+
+---
+<!-- Here be automations. -->
+/label ~Performance

--- a/.gitlab/issue_templates/Perfomance Issues.md
+++ b/.gitlab/issue_templates/Perfomance Issues.md
@@ -1,0 +1,24 @@
+# Performance issue
+
+<!-- Thanks for filing an issue! Please answer the questions below so I can help you. -->
+
+- [ ] iTerm2 version:
+- [ ] OS version:
+- [ ] Attach `~/Library/Preferences/com.googlecode.iterm2.plist` here (drag-drop from finder into this window)
+- [ ] Attach a [debug log](https://iterm2.com/debuglog), if possible.
+- [ ] Attach a screen capture video if it would make the reproduction steps clearer.
+- [ ] Please attach a [process sample](https://gitlab.com/gnachman/iterm2/-/wikis/HowToSample)
+- [ ] Are you reporting excessive memory usage? Please attach a [heap analysis](https://gitlab.com/gnachman/iterm2/wikis/heapshot)
+
+<!-- PLEASE ATTACH YOUR PLIST FILE FOR BUG REPORTS!
+Seriously! I'll probably ask you for it if you don’t. -->
+
+## Detailed steps to reproduce the problem
+
+1.
+2.
+3.
+
+## What happened
+
+## What should have happened


### PR DESCRIPTION
added three GitLab [description (issue) templates](https://docs.gitlab.com/ee/user/project/description_templates.html), for three different cases:

- Bug reports
- Crash report
- Perfomance issues

this could replace the default issue template and could clear up some confusion over what information is required by the reporter for each issue type.
 it also automatically applies labels on issue creation. the labels would need to be created on the [project (gitlab.com/gnachman/iterm2) manually once](https://docs.gitlab.com/ee/user/project/labels.html#project-labels), though.

take it for a test drive over here 😉 : https://gitlab.com/niklasjanz/iterm2/-/issues/new
the templates can also be referenced in the URL directly, like so: https://gitlab.com/niklasjanz/iterm2/-/issues/new?issuable_template=Crash
