### PR TITLE
Don't use justified text for crash log

### DIFF
--- a/ThirdParty/UKCrashReporter/UKCrashReporter.xib
+++ b/ThirdParty/UKCrashReporter/UKCrashReporter.xib
@@ -227,7 +227,7 @@ My E-Mail address is %%EMAILADDRESS, in case you want to get back to me.
                                                                 <attributes>
                                                                     <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                                                     <font key="NSFont" size="10" name="Monaco"/>
-                                                                    <paragraphStyle key="NSParagraphStyle" alignment="justified" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO">
+                                                                    <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO">
                                                                         <tabStops>
                                                                             <textTab alignment="left" location="0.0">
                                                                                 <options/>


### PR DESCRIPTION
Fixes this:

<img width="704" alt="Screen Shot 2021-03-24 at 16 45 58" src="https://user-images.githubusercontent.com/13786931/112397981-6c172e00-8cc0-11eb-8bec-d9e9dafb6622.png">
