### PR TITLE
 Fix preferences pane search bar style on Big Sur.

### DIFF
--- a/sources/PreferencePanel.m
+++ b/sources/PreferencePanel.m
@@ -744,7 +744,7 @@ andEditComponentWithIdentifier:(NSString *)identifier
 }
 #endif
 
-- (NSArray *)orderedToolbarIdentifiers {
+- (NSArray *)orderedToolbarIdentifiersWithExcludesSearch:(BOOL)excludesSearch {
     if (!_globalToolbarItem) {
         return @[];
     }
@@ -759,7 +759,11 @@ andEditComponentWithIdentifier:(NSString *)identifier
                          [_mouseToolbarItem itemIdentifier],
                          [_shortcutsToolbarItem itemIdentifier],
                          [_advancedToolbarItem itemIdentifier],
-                         _searchFieldToolbarItem.itemIdentifier];
+                         NSToolbarFlexibleSpaceItemIdentifier,
+                         [_searchFieldToolbarItem itemIdentifier] ];
+    if (excludesSearch) {
+        result = [result subarrayWithRange:NSMakeRange(0, [result count] - 2)];
+    }
     return result;
 }
 
@@ -810,15 +814,15 @@ andEditComponentWithIdentifier:(NSString *)identifier
 }
 
 - (NSArray *)toolbarAllowedItemIdentifiers:(NSToolbar *)toolbar {
-    return [self orderedToolbarIdentifiers];
+    return [self orderedToolbarIdentifiersWithExcludesSearch:NO];
 }
 
 - (NSArray *)toolbarDefaultItemIdentifiers:(NSToolbar *)toolbar {
-    return [self orderedToolbarIdentifiers];
+    return [self orderedToolbarIdentifiersWithExcludesSearch:NO];
 }
 
 - (NSArray *)toolbarSelectableItemIdentifiers:(NSToolbar *)toolbar {
-    return [self orderedToolbarIdentifiers];
+    return [self orderedToolbarIdentifiersWithExcludesSearch:YES];
 }
 
 #pragma mark - Hotkey Window

--- a/sources/PreferencePanel.m
+++ b/sources/PreferencePanel.m
@@ -744,7 +744,7 @@ andEditComponentWithIdentifier:(NSString *)identifier
 }
 #endif
 
-- (NSArray *)orderedToolbarIdentifiersWithExcludesSearch:(BOOL)excludesSearch {
+- (NSArray *)orderedToolbarIdentifiersExcludingSearch:(BOOL)excludesSearch {
     if (!_globalToolbarItem) {
         return @[];
     }
@@ -814,15 +814,15 @@ andEditComponentWithIdentifier:(NSString *)identifier
 }
 
 - (NSArray *)toolbarAllowedItemIdentifiers:(NSToolbar *)toolbar {
-    return [self orderedToolbarIdentifiersWithExcludesSearch:NO];
+    return [self orderedToolbarIdentifiersExcludingSearch:NO];
 }
 
 - (NSArray *)toolbarDefaultItemIdentifiers:(NSToolbar *)toolbar {
-    return [self orderedToolbarIdentifiersWithExcludesSearch:NO];
+    return [self orderedToolbarIdentifiersExcludingSearch:NO];
 }
 
 - (NSArray *)toolbarSelectableItemIdentifiers:(NSToolbar *)toolbar {
-    return [self orderedToolbarIdentifiersWithExcludesSearch:YES];
+    return [self orderedToolbarIdentifiersExcludingSearch:YES];
 }
 
 #pragma mark - Hotkey Window


### PR DESCRIPTION
The search bar on iTerm preference pane has a hover background like normal toolbar items, which is slightly different from search bar seen on toolbars is other Apps like Finder.
![Screenshot 2021-04-27 AM 10 38 47](https://user-images.githubusercontent.com/8158163/116176454-c171af80-a744-11eb-9cf1-94ef14aec214.png)

After some time diving into is issue, the solution is quite simple, just exclude it from `toolbarSelectableItemIdentifiers`.

This pull request removes `searchFieldToolbarItem` from `toolbarSelectableItemIdentifiers` to make it non-selectable, thus removes the hover background. A `NSToolbarFlexibleSpaceItemIdentifier` is also added between other items and the search bar item to achieve proper layout on Big Sur.

Since this change may introduce compatibility issue with older systems. I've tested it on Big Sur 11.2, Catalina 10.15.7 & Mojave 10.14.6.

- On Big Sur 11.2

![Screenshot 2021-04-27 AM 10 47 45](https://user-images.githubusercontent.com/8158163/116177217-03e7bc00-a746-11eb-90a7-f69a9f73d58c.png)

- On Catalina 10.15.7

<img width="921" alt="Screenshot 2021-04-26 AM 9 53 35" src="https://user-images.githubusercontent.com/8158163/116177021-af444100-a745-11eb-889f-00f144d954ec.png">
