### PR TITLE
Preliminary fixes for macOS Monterey

### DIFF
--- a/sources/PTYSplitView.m
+++ b/sources/PTYSplitView.m
@@ -209,6 +209,9 @@
 }
 
 - (void)setFrame:(NSRect)frame {
+    if (NSEqualRects(self.frame, frame)) {
+        return;
+    }
     DLog(@"%@: setFrame:%@\n%@", self, NSStringFromRect(frame), [NSThread callStackSymbols]);
     [super setFrame:frame];
 }

--- a/sources/iTermMetalBufferPool.h
+++ b/sources/iTermMetalBufferPool.h
@@ -6,6 +6,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/sources/iTermWindowHacks.m
+++ b/sources/iTermWindowHacks.m
@@ -7,6 +7,8 @@
 
 #import "iTermWindowHacks.h"
 
+#import <CoreGraphics/CoreGraphics.h>
+
 @implementation iTermWindowHacks
 
 void WindowListApplierFunction(const void *inputDictionary, void *context) {


### PR DESCRIPTION
iTerm will fail to build/crash at launch without these, so here are some very quick patches. Let me know if you would like these to be fixed in some other way.