### PR TITLE
attempt to add async_set_preference

### DIFF
--- a/api/library/python/iterm2/iterm2/__init__.py
+++ b/api/library/python/iterm2/iterm2/__init__.py
@@ -37,7 +37,7 @@ from iterm2.keyboard import (
     Modifier, Keycode, Keystroke, KeystrokePattern, KeystrokeMonitor,
     KeystrokeFilter)
 
-from iterm2.preferences import PreferenceKey, async_get_preference
+from iterm2.preferences import PreferenceKey, async_get_preference, async_set_preference
 
 from iterm2.profile import (
     Profile, PartialProfile, BadGUIDException, LocalWriteOnlyProfile,

--- a/api/library/python/iterm2/iterm2/preferences.py
+++ b/api/library/python/iterm2/iterm2/preferences.py
@@ -119,3 +119,18 @@ async def async_get_preference(
     proto = await iterm2.rpc.async_get_preference(connection, key.value)
     j = proto.preferences_response.results[0].get_preference_result.json_value
     return json.loads(j)
+
+async def async_set_preference(
+		connection, key: PreferenceKey, value: typing.Union[None, typing.Any]) -> None:
+	"""
+	Set a preference by key.
+
+	:param key: The preference key, from the `PreferenceKey` enum.
+	:param value: An object with the preference value, or `None` to unset.
+	"""
+    proto = await iterm2.rpc.async_set_preference(connection, key, json.dumps(value))
+    status = proto.preferences_response.results[0].set_preference_result.status
+    if status == iterm2.api_pb2.PreferencesResponse.Result.SetPreferenceResult.Status.Value("OK"):
+        return
+    raise iterm2.rpc.RPCException(
+        iterm2.api_pb2.PreferencesResponse.Result.SetPreferenceResult.Status.Name(status))


### PR DESCRIPTION
Hello, this merge request hopes to expose the `iterm2.rpc.async_set_preferences` call to Python.

I'm still learning how to actually compile & test this code, and am not generally familiar with OSX development, so it may take me a while to wrangle this into a validated state. I'm hoping this is still a useful PR in this state, untested as it is. It seeks to fix an issue I just opened for this, [gnachman/iterm2#9810](https://gitlab.com/gnachman/iterm2/-/issues/9810)

note, i have also not yet investigated what might be added for documentation, nor tests.