### PR TITLE
Fix a PTYSession retain cycle

### DIFF
--- a/sources/PTYSession.m
+++ b/sources/PTYSession.m
@@ -4297,7 +4297,10 @@ ITERM_WEAKLY_REFERENCEABLE
         if (error) {
             return [NSString stringWithFormat:@"🐞 %@", error.localizedDescription];
         }
-        [self.delegate sessionSubtitleDidChange:self];
+        __typeof(self) strongSelf = weakSelf;
+        if (strongSelf) {
+            [strongSelf.delegate sessionSubtitleDidChange:strongSelf];
+        }
         return newValue;
     }];
 }


### PR DESCRIPTION
We forgot to use weakSelf in the observer block, keeping the entire session (and all its lines) alive even after the window had closed.