### PR TITLE
Fix vertical cursor height

### DIFF
--- a/sources/Metal/Renderers/iTermCursorRenderer.m
+++ b/sources/Metal/Renderers/iTermCursorRenderer.m
@@ -371,9 +371,9 @@ NS_ASSUME_NONNULL_BEGIN
 
     CGFloat height;
     if ([iTermAdvancedSettingsModel fullHeightCursor]) {
-        height = tState.cellConfiguration.cellSize.height;
+        height = MAX(tState.cellConfiguration.cellSize.height, tState.cellConfiguration.cellSizeWithoutSpacing.height);
     } else {
-        height = tState.cellConfiguration.cellSizeWithoutSpacing.height;
+        height = MIN(tState.cellConfiguration.cellSize.height, tState.cellConfiguration.cellSizeWithoutSpacing.height);
     }
     tState.vertexBuffer =
         [_cellRenderer newQuadOfSize:CGSizeMake(tState.configuration.scale * width,


### PR DESCRIPTION
The height of the vertical cursor does not change when line spacing < 1.
<img width="650" alt="image" src="https://user-images.githubusercontent.com/61110387/130612847-81ae0308-48c7-4ed9-912a-2ba15a98f3cf.png">
However, the height of the box cursor does change.
<img width="650" alt="image" src="https://user-images.githubusercontent.com/61110387/130613019-60c3a9f8-bc61-4faa-9fc4-d0492af3d2ff.png">
Trying to make them behave consistently.