### PR TITLE
Support opening to line number in all JetBrains IDEs

### DIFF
--- a/sources/iTermSemanticHistoryController.m
+++ b/sources/iTermSemanticHistoryController.m
@@ -207,24 +207,9 @@ NSString *const kSemanticHistoryColumnNumberKey = @"semanticHistory.columnNumber
     return executable;
 }
 
-- (NSString *)intelliJIDEALauncherInApplicationBundle:(NSBundle *)bundle {
-    DLog(@"Trying to find IntelliJ IDEA launcher in %@", bundle.bundlePath);
-    return [[[[bundle.bundleURL URLByAppendingPathComponent:@"Contents"] URLByAppendingPathComponent:@"MacOS"] URLByAppendingPathComponent:@"idea"] path];
-}
-
 - (void)launchAppWithBundleIdentifier:(NSString *)bundleIdentifier args:(NSArray *)args {
-    NSBundle *bundle = [self applicationBundleWithIdentifier:bundleIdentifier];
-    if (!bundle) {
-        DLog(@"No bundle for %@", bundleIdentifier);
-        return;
-    }
-    NSString *executable = [self executableInApplicationBundle:bundle];
-    if (!executable) {
-        DLog(@"No executable for %@ in %@", bundleIdentifier, bundle);
-        return;
-    }
-    DLog(@"Launch %@: %@ %@", bundleIdentifier, executable, args);
-    [self launchTaskWithPath:executable arguments:args completion:nil];
+    args = [@[ @"-nb", bundleIdentifier, @"--args" ] arrayByAddingObjectsFromArray: args];
+    [self launchTaskWithPath:@"/usr/bin/open" arguments:args completion:nil];
 }
 
 - (void)launchVSCodeWithPath:(NSString *)path codium:(BOOL)codium {
@@ -286,27 +271,6 @@ NSString *const kSemanticHistoryColumnNumberKey = @"semanticHistory.columnNumber
 
 }
 
-- (void)launchIntelliJIDEAWithArguments:(NSArray<NSString *> *)args path:(NSString *)path {
-    NSBundle *bundle = [self applicationBundleWithIdentifier:kIntelliJIDEAIdentifier];
-    if (!bundle) {
-        DLog(@"Failed to find IDEA bundle");
-        return;
-    }
-    NSString *launcher = [self intelliJIDEALauncherInApplicationBundle:bundle];
-    if (!launcher) {
-        DLog(@"Failed to find launcher in %@", bundle);
-        if (path) {
-            DLog(@"Launch idea with path %@", path);
-            [self launchAppWithBundleIdentifier:kIntelliJIDEAIdentifier
-                                           path:path];
-        }
-        return;
-    }
-    [self launchTaskWithPath:launcher
-                   arguments:args
-                  completion:nil];
-}
-
 - (NSString *)absolutePathForAppBundleWithIdentifier:(NSString *)bundleId {
     return [[NSWorkspace sharedWorkspace] absolutePathForAppBundleWithIdentifier:bundleId];
 }
@@ -344,8 +308,11 @@ NSString *const kSemanticHistoryColumnNumberKey = @"semanticHistory.columnNumber
               kTextmateIdentifier,
               kTextmate2Identifier,
               kBBEditIdentifier,
-              kEmacsAppIdentifier,
-              kIntelliJIDEAIdentifier ];
+              kEmacsAppIdentifier ];
+}
+
++ (NSArray *)bundleIdPrefixesThatSupportOpeningToLineNumber {
+    return @[ kJetBrainsIdentifierPrefix ];
 }
 
 - (void)openFile:(NSString *)path
@@ -414,7 +381,7 @@ NSString *const kSemanticHistoryColumnNumberKey = @"semanticHistory.columnNumber
         [self launchEmacsWithArguments:args];
         return;
     }
-    if ([identifier isEqualToString:kIntelliJIDEAIdentifier]) {
+    if ([identifier hasPrefix:kJetBrainsIdentifierPrefix]) {
         NSArray<NSString *> *args = @[];
         if (path) {
             if (lineNumber) {
@@ -423,7 +390,7 @@ NSString *const kSemanticHistoryColumnNumberKey = @"semanticHistory.columnNumber
                 args = @[ path ];
             }
         }
-        [self launchIntelliJIDEAWithArguments:args path:path];
+        [self launchAppWithBundleIdentifier:identifier args:args];
         return;
     }
 
@@ -730,6 +697,11 @@ NSString *const kSemanticHistoryColumnNumberKey = @"semanticHistory.columnNumber
 }
 
 - (BOOL)canOpenFileWithLineNumberUsingEditorWithBundleId:(NSString *)appBundleId {
+    for (NSString* prefix in [self.class bundleIdPrefixesThatSupportOpeningToLineNumber]) {
+        if ([appBundleId hasPrefix:prefix]) {
+            return YES;
+        }
+    }
     return [[self.class bundleIdsThatSupportOpeningToLineNumber] containsObject:appBundleId];
 }
 

--- a/sources/iTermSemanticHistoryPrefsController.h
+++ b/sources/iTermSemanticHistoryPrefsController.h
@@ -24,6 +24,8 @@ extern NSString *kTextmate2Identifier;
 extern NSString *kBBEditIdentifier;
 extern NSString *kEmacsAppIdentifier;
 extern NSString *kIntelliJIDEAIdentifier;
+extern NSString *kIntelliJPyCharmIdentifier;
+extern NSString *kJetBrainsIdentifierPrefix;
 
 extern NSString *kSemanticHistoryBestEditorAction;
 extern NSString *kSemanticHistoryUrlAction;

--- a/sources/iTermSemanticHistoryPrefsController.m
+++ b/sources/iTermSemanticHistoryPrefsController.m
@@ -34,6 +34,7 @@ NSString *kVSCodiumIdentifier = @"com.visualstudio.code.oss";
 NSString *kVSCodeInsidersIdentifier = @"com.microsoft.VSCodeInsiders";
 NSString *kEmacsAppIdentifier = @"org.gnu.Emacs";
 NSString *kIntelliJIDEAIdentifier = @"com.jetbrains.intellij.ce";
+NSString *kJetBrainsIdentifierPrefix = @"com.jetbrains.";
 
 NSString *kSemanticHistoryBestEditorAction = @"best editor";
 NSString *kSemanticHistoryUrlAction = @"url";


### PR DESCRIPTION
From iTerm's documentation:

> If you hold cmd and click on a URL it will be opened. If you hold cmd and click on a filename, it will be opened. There is special support for MacVim, TextMate, and BBEdit when you cmd-click on a text file's name: if it is followed by a colon and line number, the file will be opened at that line number.

Currently, iTerm can open to line number for IDEA, but it doesn't support any other IntelliJ editors like WebStorm, PyCharm, etc.

This PR implements support for every JetBrains IDE, since they can all handle the `--line` argument on command line.

The one tricky change was:

```objc
- (void)launchAppWithBundleIdentifier:(NSString *)bundleIdentifier args:(NSArray *)args {
    args = [@[ @"-nb", bundleIdentifier, @"--args" ] arrayByAddingObjectsFromArray: args];
    [self launchTaskWithPath:@"/usr/bin/open" arguments:args completion:nil];
}
```

In order to open JetBrains IDEs correctly, it's necessary to use e.g. `open -nb com.jetbrains.WebStorm --args --line 4 index.js`. Simply invoking the executable directly will result in strange errors. (Note that their official docs use `open -n`: https://www.jetbrains.com/help/pycharm/working-with-the-ide-features-from-command-line.html#toolbox)