### PR TITLE
Allow requesting Bluetooth permission

### DIFF
--- a/plists/beta-iTerm2.plist
+++ b/plists/beta-iTerm2.plist
@@ -122,6 +122,8 @@
         <string>The operation being performed by a program in iTerm2 requires elevated permission.</string>
         <key>NSAppleEventsUsageDescription</key>
         <string>An application in iTerm2 wants to use AppleScript.</string>
+        <key>NSBluetoothAlwaysUsageDescription</key>
+        <string>An application in iTerm2 wants to use Bluetooth.</string>
         <key>NSCalendarsUsageDescription</key>
         <string>An application in iTerm2 wants to use Calendar data.</string>
         <key>NSCameraUsageDescription</key>

--- a/plists/iTerm2.plist
+++ b/plists/iTerm2.plist
@@ -122,6 +122,8 @@
         <string>The operation being performed by a program in iTerm2 requires elevated permission.</string>
         <key>NSAppleEventsUsageDescription</key>
         <string>An application in iTerm2 wants to use AppleScript.</string>
+        <key>NSBluetoothAlwaysUsageDescription</key>
+        <string>An application in iTerm2 wants to use Bluetooth.</string>
         <key>NSCalendarsUsageDescription</key>
         <string>An application in iTerm2 wants to use Calendar data.</string>
         <key>NSCameraUsageDescription</key>

--- a/plists/iTerm2ForAppleScriptTesting-Info.plist
+++ b/plists/iTerm2ForAppleScriptTesting-Info.plist
@@ -96,6 +96,8 @@
 			<string>Owner</string>
 		</dict>
 	</array>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>An application in iTerm2 wants to use Bluetooth.</string>
 	<key>NSCalendarsUsageDescription</key>
 	<string>An application in iTerm2 wants to use Calendar data.</string>
 	<key>NSCameraUsageDescription</key>

--- a/plists/nightly-iTerm2.plist
+++ b/plists/nightly-iTerm2.plist
@@ -122,6 +122,8 @@
         <string>The operation being performed by a program in iTerm2 requires elevated permission.</string>
         <key>NSAppleEventsUsageDescription</key>
         <string>An application in iTerm2 wants to use AppleScript.</string>
+        <key>NSBluetoothAlwaysUsageDescription</key>
+        <string>An application in iTerm2 wants to use Bluetooth.</string>
         <key>NSCalendarsUsageDescription</key>
         <string>An application in iTerm2 wants to use Calendar data.</string>
         <key>NSCameraUsageDescription</key>

--- a/plists/preview-iTerm2.plist
+++ b/plists/preview-iTerm2.plist
@@ -118,6 +118,8 @@
         <string>The operation being performed by a program in iTerm2 requires elevated permission.</string>
         <key>NSAppleEventsUsageDescription</key>
         <string>An application in iTerm2 wants to use AppleScript.</string>
+        <key>NSBluetoothAlwaysUsageDescription</key>
+        <string>An application in iTerm2 wants to use Bluetooth.</string>
         <key>NSCalendarsUsageDescription</key>
         <string>An application in iTerm2 wants to use Calendar data.</string>
         <key>NSCameraUsageDescription</key>

--- a/plists/release-iTerm2.plist
+++ b/plists/release-iTerm2.plist
@@ -118,6 +118,8 @@
         <string>The operation being performed by a program in iTerm2 requires elevated permission.</string>
         <key>NSAppleEventsUsageDescription</key>
         <string>An application in iTerm2 wants to use AppleScript.</string>
+        <key>NSBluetoothAlwaysUsageDescription</key>
+        <string>An application in iTerm2 wants to use Bluetooth.</string>
         <key>NSCalendarsUsageDescription</key>
         <string>An application in iTerm2 wants to use Calendar data.</string>
         <key>NSCameraUsageDescription</key>


### PR DESCRIPTION
Command line programs that use CoreBluetooth will crash with SIGABRT if this is not included in info.plist. The message doesn't seem to actually be shown, but [CentralManager.didUpdateState:](https://developer.apple.com/documentation/corebluetooth/cbcentralmanagerdelegate/1518888-centralmanagerdidupdatestate?language=objc) will be called with the state set to [CBManagerStateUnauthorized](https://developer.apple.com/documentation/corebluetooth/cbmanagerstate/cbmanagerstateunauthorized?language=objc) unless the users enables Bluetooth permission in *System Preferences*.