### PR TITLE
Improve input speed for tmux integration

### DIFF
--- a/sources/TmuxGateway.m
+++ b/sources/TmuxGateway.m
@@ -856,13 +856,48 @@ error:
     }
 
     // Send multiple small send-keys commands because commands longer than 1024 bytes crash tmux 1.8.
+    const NSUInteger maxLiteralCharacters = 1000;  // 1024 - len('send -lt %123456789 ') = 1004
+    const NSUInteger maxHexCharacters = maxLiteralCharacters / 8;  // len(' C-Space') = 8
+
+    BOOL asLiteralCharacters = NO;
     NSMutableArray *commands = [NSMutableArray array];
-    const NSUInteger stride = 80;
-    for (NSUInteger start = 0; start < codePoints.count; start += stride) {
-        NSUInteger length = MIN(stride, codePoints.count - start);
-        NSRange range = NSMakeRange(start, length);
-        NSArray *subarray = [codePoints subarrayWithRange:range];
-        [commands addObject:[self dictionaryForSendKeysCommandWithCodePoints:subarray windowPane:windowPane]];
+    NSMutableArray *subarray = [NSMutableArray arrayWithCapacity:MIN(codePoints.count, maxLiteralCharacters)];
+
+    for (NSNumber *number in codePoints) {
+        BOOL currentAsLiteralCharacter = [self canSendAsLiteralCharacter:number];
+        if (asLiteralCharacters != currentAsLiteralCharacter) {
+            if (subarray.count > 0) {
+                [commands addObject:[self dictionaryForSendKeysCommandWithCodePoints:subarray
+                                                                          windowPane:windowPane
+                                                                 asLiteralCharacters:asLiteralCharacters]];
+                [subarray removeAllObjects];
+            }
+            [subarray addObject:number];
+            asLiteralCharacters = currentAsLiteralCharacter;
+            continue;
+        }
+
+        [subarray addObject:number];
+        if (!asLiteralCharacters && subarray.count >= maxHexCharacters) {
+            [commands addObject:[self dictionaryForSendKeysCommandWithCodePoints:subarray
+                                                                      windowPane:windowPane
+                                                             asLiteralCharacters:asLiteralCharacters]];
+            [subarray removeAllObjects];
+            continue;
+        }
+        if (asLiteralCharacters && subarray.count >= maxLiteralCharacters) {
+            [commands addObject:[self dictionaryForSendKeysCommandWithCodePoints:subarray
+                                                                      windowPane:windowPane
+                                                             asLiteralCharacters:asLiteralCharacters]];
+            [subarray removeAllObjects];
+            continue;
+        }
+    }
+
+    if (subarray.count > 0) {
+        [commands addObject:[self dictionaryForSendKeysCommandWithCodePoints:subarray
+                                                                  windowPane:windowPane
+                                                         asLiteralCharacters:asLiteralCharacters]];
     }
 
     [delegate_ tmuxSetSecureLogging:YES];
@@ -884,16 +919,38 @@ error:
     return !([self.minimumServerVersion isEqual:version2_2] && [self.maximumServerVersion isEqual:version2_2]);
 }
 
+- (BOOL) canSendAsLiteralCharacter:(NSNumber *)codePoint {
+    int number = [codePoint intValue];
+    if (number < 0x21 || number >= 0x7f) {
+        return NO;
+    }
+    for (const char *p = "\"#';\\{}"; *p != '\0'; p++) {
+        if (number == *p) {
+            return NO;
+        }
+    }
+    return YES;
+}
+
+- (NSString *)numbersAsLiteralCharacters:(NSArray<NSNumber *> *)codePoints {
+    NSMutableString *result = [NSMutableString stringWithCapacity:codePoints.count];
+    for (NSNumber *number in codePoints) {
+        [result appendFormat:@"%c", number.intValue];
+    }
+    return result;
+}
+
 - (NSDictionary *)dictionaryForSendKeysCommandWithCodePoints:(NSArray<NSNumber *> *)codePoints
-                                                  windowPane:(int)windowPane {
+                                                  windowPane:(int)windowPane
+                                         asLiteralCharacters:(BOOL)asLiteralCharacters {
     NSString *value;
-    if ([codePoints isEqual:@[ @0 ]]) {
-        value = @"C-Space";
+    if (asLiteralCharacters) {
+        value = [self numbersAsLiteralCharacters:codePoints];
     } else {
         value = [codePoints numbersAsHexStrings];
     }
-    NSString *command = [NSString stringWithFormat:@"send-keys -t \"%%%d\" %@",
-                         windowPane, value];
+    NSString *command = [NSString stringWithFormat:@"send %@ %%%d %@",
+                         asLiteralCharacters ? @"-lt" : @"-t", windowPane, value];
     NSDictionary *dict = [self dictionaryForCommand:command
                                      responseTarget:self
                                    responseSelector:@selector(noopResponseSelector:)


### PR DESCRIPTION
# make tmux integration input faster

## Issue

More technical details at [10179: Improve input speed for tmux integration](https://gitlab.com/gnachman/iterm2/-/issues/10179).

## tmux send-keys

The `-l` flag disables key name lookup and processes the keys as literal UTF-8 characters.

Most input can be sent directly. No need to convert to hex, which is 5 times slower.


## simple test code

I wrote a simple project to test the piece of code: [TmuxSendKeys](https://github.com/lonnywong/TmuxSendKeys/blob/main/TmuxSendKeys/TmuxGateway.m)

Make sure that any bytes from `0x00` to `0xFF`  is processed correctly.


## test with iTerm2

1. login to the server via `telnet`
2. use `tcpdump` to capture tcp packets
3. run `tmux -CC` and do a some works
4. analyze the tcp packets


## tested tmux version
* 1.8
* 2.1
* 2.6
* 3.0a