### PR TITLE
Set BUILD_LIBRARY_FOR_DISTRIBUTION for frameworks

### DIFF
--- a/BetterFontPicker/BetterFontPicker.xcodeproj/project.pbxproj
+++ b/BetterFontPicker/BetterFontPicker.xcodeproj/project.pbxproj
@@ -452,6 +452,7 @@
 		A6DBE795225A565700144200 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
@@ -482,6 +483,7 @@
 		A6DBE796225A565700144200 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Developer ID Application: GEORGE NACHMAN (H7V7XYVQ7D)";
 				CODE_SIGN_STYLE = Manual;

--- a/SearchableComboListView/SearchableComboListView.xcodeproj/project.pbxproj
+++ b/SearchableComboListView/SearchableComboListView.xcodeproj/project.pbxproj
@@ -388,6 +388,7 @@
 		A6B557F323DCD15300F5DF2D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
@@ -416,6 +417,7 @@
 		A6B557F423DCD15300F5DF2D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;


### PR DESCRIPTION
This allows for building the project with a newer Swift compiler than the one that was used to compile the binary dependencies that are in committed to the repository.

(This requires a rebuild of the frameworks, too; I trust you can take care of that.)