### PR TITLE
Major rework

### DIFF
--- a/tests/imgls.pl
+++ b/tests/imgls.pl
@@ -1,30 +1,41 @@
 #!/usr/bin/perl
 
-# imgls: ls(1) listing supplemented with image thumbnails and image dimensions
+# imgls.pl: ls(1) listing supplemented with image thumbnails and dimensions
 #
-#    Usage: imgls [--width #] [--height #] [--[no]par] [ls options] filename [filename]
+#    Usage: imgls [--width #] [--height #] [--[no]preserve_ratio]
+#                 [--[no]dimensions] [--[no]unknown] [ls options] [file ...]
 #
-# Writing an image to an iTerm window is fairly trivial; the bulk of this code handles features such
-# as supporting ls(1) options, including recursion, supporting width and height image dimensions via
-# command line, making the output pretty, and using faster Perl modules when available on the system.
+# Writing an image to an iTerm window is simple. See the official documentation
+# at https://iterm2.com/documentation-images.html and the write_image() function below.
 #
-# See function write_image() below to learn how to output an image, as per https://iterm2.com/images.html
+# Many of ls' options are supported, but not all.  The program does not support ls'
+# default -C columnar output mode - output is always one entry per line.  Writing
+# images across the page in columns appears to be problematic.
+#
+# In addition, options are available to specify setting image properties (width, height,
+# preserve aspect ratio), include inline image dimensions, and disable output of
+# generic icons for unsupported image types. Finally, a table-based image dimensions
+# lookup mechanism is employed to obtain image dimensions.  It can call on Perl
+# modules such as Image::Size, or call on external programs such as sips, mdls or php.
+# It is easy to add additional entries to the table.  You can use the --method option
+# to select any of the currently supported methods ('sips', 'mdls', 'php', and
+# 'image::size').  These are tried, in that order; the first that appears to work
+# is used for all.
 
 use v5.14;
 use strict;
 use utf8;
 use warnings;
 
-use File::Basename;
+use File::stat;
 use File::Which;
-use Getopt::Long qw(:config no_permute pass_through require_order);
-use IO::Handle;
 use MIME::Base64;
-
-# Use the faster Image::Size if available to calculate an image's size.
-BEGIN {
-    eval "require Image::Size";
-}
+use File::Basename;
+use Encode qw(decode);
+use List::Util qw(max);
+use POSIX qw(strftime ceil floor modf);
+use Capture::Tiny ':all';
+use Getopt::Long qw(:config no_permute pass_through require_order);
 
 STDERR->autoflush(1);
 STDOUT->autoflush(1);
@@ -32,124 +43,380 @@ binmode STDOUT, ':encoding(UTF-8)';
 binmode STDERR, ':encoding(UTF-8)';
 
 my $prog = basename $0;
+sub usage {
+    my $leader = "usage: $prog";
+    say 
+        "usage: $prog",
+        " [--width #] [--height #] [--[no]preserve_ratio] [--[no]dimensions]",
+        "\n",
+        ' ' x length($leader),
+        " [--[no]unknown] [ls options] [file ...]";
 
-# some default values
-my @lscmd  = qw/ls/;
-my @lsopts = qw/-l -d/;                 # default ls(1) options
-my %imgparams = (                       # default image option parameters
-    height              => '3',         # character cells tall
-    width               => '3',         # character cells wide
-    inline              => '1',
-    preserveAspectRatio => 'true',
-);
-
-# Encodes and outputs an image file to the window
-#    arg 1: path to an image file
-#
-sub write_image {
-    my $file = shift;
-
-    # prepare the argument parameter list
-    # add the name and size to the image argument parameter list
-    $imgparams{'name'} = encode_base64($file, '');                              # file name is base64 encoded
-    $imgparams{'size'} = (stat($file))[7];                                      # file size in bytes
-
-    # write image data to STDERR so filters on STDOUT work as expected
-    printf STDERR "%s%s%s;File=%s:%s%s",
-            "\033", "]", "1337",                                                # image leadin sequence (OSC + 1337)
-            join(';', map { $_ . '=' . $imgparams{$_} } keys %imgparams),       # semicolon separated pairs of param=value pairs
-            encode_base64(get_image_bytes($file)),                              # base64 encoded image bytes
-            "\007";                                                             # end-of-encoding char (BEL = ^G)
+    exit shift;
 }
 
-### main code 
+# Some defaults
+my $def_image_width     = 3;                    # height (in character cells)
+my $def_image_height    = 1;                    # width  (in character cells)
+my $def_preserve_ratio  = 'true';               # preserve aspect ratio
 
-my $php = which('php');
-my $phpcmd = q/$a = getimagesize("$argv[1]"); if ($a==FALSE) exit(1); else { echo $a[0] . "x" .$a[1]; exit(0); }/;
-
-# grab --width and --height command line options if they exist
-my $result = GetOptions (
-    "height=s" => \$imgparams{'height'},
-    "width=s" => \$imgparams{'width'},
-    "par!" => sub { $imgparams{'preserveAspectRatio'} = $_[1] ? 'true' : 'false' },
+my %imgparams = (                               # default image option parameters
+    inline              => 1,                   # image appears inline with text
+    height              => $def_image_height,   # character cells tall
+    width               => $def_image_width,    # character cells wide
+    preserveAspectRatio => $def_preserve_ratio, # no stretchmarks please
 );
-# grab any ls(1) options
-while (@ARGV) {
-    last unless $ARGV[0] =~ /^-/;
-    push @lsopts, shift @ARGV;
+
+my %failed_types;                               # cache of file extensions that have failed
+my %stat_cache;                                 # cache of file/directory lstat() calls
+my $curtime = time();
+my $sixmonths = (365 / 2) * 86400;
+
+my %opts = (
+    height      => \$imgparams{'height'},
+    width       => \$imgparams{'width'},
+);
+get_options(\%opts);
+
+# find a method to obtain image dimensions
+my $dims_methods = init_dims_methods();
+my $dims_method  = find_dims_methods($dims_methods);
+
+# single pixel image for non-renderable files
+my ($one_pixel_black, $one_pixel_black_len) = get_black_pixel_image();
+
+my $do_newline;
+my $dot_filter = $opts{'A'} ? qr/^\.{1,2}$/ : qr/^\./;
+$dot_filter    = undef          if $opts{'a'};
+
+# special: empty @ARGV, or contains only '.'
+my $do_header = @ARGV > 1 ? 1 : 0;
+if (@ARGV <= 1) {
+    push @ARGV, '.'     if @ARGV == 0;
 }
-push @ARGV, "." unless @ARGV;  # default to current directory if none provided
 
-# don't recurse when no -R option supplied as an ls option
-my $recurse = grep /R/, @lsopts;
-my $lsa = grep /a/, @lsopts;
+my (@files, @dirs);
+for (@ARGV) {
+    if (! -e _lstat($_)) {
+        say "$prog: $_: No such file or directory";
+    }
+    elsif (-f _lstat($_)) {
+        push @files, $_;
+    }
+    else {
+        push @dirs, $_;
+    }
+}
+@files = ls_sort(@files);
+@dirs  = ls_sort(@dirs);
 
-my $lines_output = 0;
-my $nfiles = @ARGV;
-while (@ARGV) {
-    my $path = shift;
+if ($opts{'d'}) {
+    push @files, @dirs;
+    @dirs = ();
+}
+do_ls(undef, @files)    if @files;
+
+while (@dirs) {
+    my $path = shift @dirs;
 
     if (! -e $path) {
         say "$prog: $path: No such file or directory";
         next;
     }
-
-    if (-d $path) {
-        my $dh;
-        unless (opendir($dh, $path)) {
-            say "Unable to open directory $path: $!";
-            next;
-        }
-
-        if ($recurse or $nfiles > 1) {
-            print "\n" if $lines_output;                        # output newline separator between directory headers, except first one
-            print $path, ":\n";
-        }
-        while (readdir($dh)) {
-            next if /^\./ and not $lsa;                         # skip dot files when -a is not specified
-            if ($recurse and $_ !~ /^\.\.?$/ and -d "$path/$_") {
-                push @ARGV, "$path/$_";                         # handle directory recursion - processed after files
-            }
-            do_ls_cmd("$path/$_");
-        }
-        closedir $dh;
+    my (@f, @d);
+    get_dir_content($path, $dot_filter, \@f, \@d) or
+        next;
+    do_ls($path, @f, @d);
+    if ($opts{'R'}) {
+        push @dirs, grep { ! /\.\.?$/ } @d;
     }
-    else {
-        do_ls_cmd("$path");
-    }
-    $lines_output++;
+    $do_newline++;
 }
 
-sub do_ls_cmd {
+# Encodes and outputs an image file to the window
+#    arg 1: path to an image file
+#    arg 2: size, in bytes, of the image
+# Image data is written to STDERR so filters on STDOUT work as expected.
+sub write_image {
+    my ($file, $size) = @_;
+    my $encoded;
+
+    $imgparams{'name'} = encode_base64($file, '');                      # file name is base64 encoded
+    $imgparams{'size'} = $size;                                         # file size in bytes
+
+    if (ref $file eq '')  {
+        my $bytes = get_image_bytes($file);
+        $encoded = encode_base64($bytes)                if defined $bytes;
+    }
+    if (! $encoded or ref $file eq 'SCALAR') {
+        $encoded = $one_pixel_black;
+        $imgparams{'name'} = encode_base64('one_pixel_black', '');
+        $imgparams{'size'} = $one_pixel_black_len;
+    }
+
+    printf STDERR "%s%s%s;File=%s:%s%s",
+            "\033", "]", "1337",                                                # image leadin sequence (OSC + 1337)
+            join(';', map { $_ . '=' . $imgparams{$_} } keys %imgparams),       # semicolon separated pairs of param=value pairs
+            $encoded,                                                           # base64 encoded image bytes
+            "\007";                                                             # end-of-encoding char (BEL = ^G)
+}
+
+sub get_options {
+    local $SIG{__WARN__} = sub { say "$prog: ", $_[0]; usage(1) };
+    Getopt::Long::Configure(qw/no_ignore_case bundling no_passthrough/);
+    my $result = GetOptions(\%opts,
+        'dimensions!'           => sub { $opts{'unknown'}++; $opts{$_[0]} = $_[1] },
+        "height=s",
+        'method=s',                                                             # use to force dimensions method
+        "preserve_ratio!"       => sub { $imgparams{'preserveAspectRatio'} = $_[1] ? 'true' : 'false' },
+        'unknown!'              => sub { $opts{'dimensions'}++; $opts{$_[0]} = $_[1] },
+        'width=s',
+        # supported ls options
+        't'                     => sub { delete $opts{'S'}; $opts{'t'}++ },
+        'S'                     => sub { delete $opts{'t'}; $opts{'S'}++ },
+        qw/ A F R a d h i k l n o p r s u /, 'c|U',
+    );
+
+    $opts{'d'} and delete $opts{'R'};
+    $opts{'n'} and $opts{'l'}++;
+    $opts{'o'} and $opts{'l'}++;
+    $opts{'s'} and $opts{'show_blocks'}++;
+}
+
+sub get_dir_content {
+    my ($path, $filter, $filesref, $dirsref) = @_;
+    my $dh;
+
+    unless (opendir($dh, $path)) {
+        say "Unable to open directory $path: $!";
+        return undef;
+    }
+
+    #if ($opts{'R'} or $nfiles > 1) {
+    #    print "\n" if $lines_output;                        # output newline separator between directory headers, except first one
+    #    print $path, ":\n";
+    #}
+    while (readdir($dh)) {
+        next if defined $filter and $_ =~ /$filter/;
+        my $p = "$path/$_";
+        if (-d _lstat($p)) {
+            push @$dirsref, $p;
+        }
+        else {
+            push @$filesref, $p;
+        }
+    }
+    closedir $dh;
+    return 1;
+}
+
+sub do_ls {
+    my $path = shift;
+
+    my $blocks_total = 0;
+    my (@hfiles, %widths, $st);
+    for my $file (ls_sort(@_)) {
+        #say "FILE: $file";
+
+        my %h;
+        $h{'file'}      = $file;
+        $h{'filename'}  = defined $path ? (split /\//, $file)[-1] : $file;
+        $h{'st'}        = $st = _lstat($file);
+        $h{'ino'}       = $st->ino                      if $opts{'i'};
+        $h{'bytes'}     = $st->size;
+        $h{'bytesh'}    = format_human($h{'bytes'})     if $opts{'h'};
+        $h{'dims'}      = get_dimensions($file)         if $opts{'dimensions'} and -f $st && -r $st && $h{'bytes'};
+        $h{'nlink'}     = $st->nlink                    if $opts{'s'} or $opts{'l'};
+
+        if ($opts{'show_blocks'} or $opts{'l'}) {
+            $h{'blocks'} = $st->blocks;
+            if ( ! -d $st and ($opts{'a'} or $h{'filename'} !~ /^\.[^.]+/)) {
+                $blocks_total += $st->blocks;
+            }
+        }
+
+        if ($opts{'l'}) {
+            $h{'lsmodes'} = Stat::lsMode::format_mode($st->mode);
+            $h{'owner'} = ($opts{'n'} ? $st->uid : getpwuid $st->uid) // $st->uid;
+            $h{'group'} = ($opts{'n'} ? $st->gid : getgrgid $st->gid) // $st->gid       if not $opts{'o'};
+            # XXX
+            $h{'time'}  = format_time($st->mtime);
+        }
+        push @hfiles, \%h;
+
+        $widths{'dim_w'}  = max(defined $h{'dims'} ? length($h{'dims'}{'width'})  : 0, $widths{'dim_w'} // 0);
+        $widths{'dim_h'}  = max(defined $h{'dims'} ? length($h{'dims'}{'height'}) : 0, $widths{'dim_h'} // 0);
+        for my $key (qw/blocks ino bytes bytesh owner group nlink/) {
+            $widths{$key} = max(length($h{$key}), $widths{$key} // 0)   if exists $h{$key};
+        }
+    }
+
+    # Header output when @ARGV was > 1, or after second dir
+    print "\n"                                          if $path and $do_newline;
+    print "$path:\n"                                    if $path and $do_header++;
+
+    #   total blocks inline when -d, as header when -l or -s
+    say "total ", $blocks_total / ($opts{'k'} ? 2 : 1)   if $path and ! $opts{'d'} and ($opts{'show_blocks'} or $opts{'l'});
+
+    for my $h (@hfiles) {
+        if (! -f $h->{'st'} or ! $h->{'bytes'} or ($opts{'dimensions'} and ! $h->{'dims'} and ! $opts{'unknown'})) {
+            # may not produce correct num of dashes: --pre --h 3 --w 10
+            #printf "%s", '-' x ($imgparams{'width'} =~ /^\d+$/ ? $imgparams{'width'} : $def_image_width);
+            # pass a ref to indicate the data is already base64 encoded
+            write_image \$one_pixel_black, $one_pixel_black_len;
+        }
+        else {
+            write_image $h->{'file'}, $h->{'bytes'};
+        }
+
+        if ($opts{'dimensions'}) {
+            if ($widths{'dim_w'} or $widths{'dim_h'}) {
+                my $min_w = $widths{'dim_w'} // 1;
+                my $min_h = $widths{'dim_h'} // 1;
+                if ($h->{'dims'}{'width'} or $h->{'dims'}{'height'}) {
+                    printf " [%*d x %*d] ", $min_w, $h->{'dims'}{'width'} // 0, $min_h, $h->{'dims'}{'height'} // 0;
+                }
+                else {
+                    printf " %*s   %*s   ", $min_w, ' ', $min_h, ' ';
+                }
+            }
+        }
+
+        printf " %*d",  $widths{'ino'},    $h->{'ino'}                  if $opts{'i'};
+        printf " %*d",  $widths{'blocks'}, $h->{'blocks'}               if $opts{'s'};
+        printf " %s",   $h->{'lsmodes'}                                 if exists $h->{'lsmodes'};
+        printf " %*s",  $widths{'nlink'},  $h->{'nlink'}                if exists $h->{'nlink'};
+        printf " %*s",  $widths{'owner'},  $h->{'owner'}                if exists $h->{'owner'};
+        printf "  %*s", $widths{'group'},  $h->{'group'}                if exists $h->{'group'};
+        if ($opts{'l'}) {
+            printf "  %*d", $widths{'bytes'},  $h->{'bytes'}            if ! $opts{'h'};
+            printf "  %4s", $h->{'bytesh'}                              if $opts{'h'};
+        }
+        printf " %s",   $h->{'time'}                                    if exists $h->{'time'};
+        print  " ",     Encode::decode('UTF-8', defined $path ? (split /\//, $h->{'file'})[-1] : $h->{'file'});
+        printf "%s",    get_F_type($h->{'st'})                          if $opts{'F'} or $opts{'p'};
+        print "\n";
+    }
+}
+
+# Get the image's dimensions to supplement the image and ls output.
+sub get_dimensions {
     my $file = shift;
 
-    # Get the image dimensions to supplement the image and ls output.
-    # Use Image::Size when available (non-stock), otherwise use PHP fallback method.
-    my $dims;
-    if (-e $file and -r $file) {
-        if (Image::Size->can('imgsize')) {
-            my ($w, $h) = Image::Size::imgsize($file);
-            $dims = join 'x', $w, $h        if defined $w and defined $h;
+    my ($ret, $ext);
+    $file =~ /\.([^.]+)$/ and $ext = $1;
+
+    if ($dims_method and (!$ext or ($ext and ! exists $failed_types{$ext}))) {
+        if (ref $dims_method->{'prog'} eq 'CODE') {
+            $ret = $dims_method->{'format'}->($file);
         }
-        elsif ($php) {
-            $dims = get_cmd_output($php, '-r', $phpcmd, $file);
+        else {
+            my ($stdout, $stderr, $exit) = capture {
+                system($dims_method->{'prog'}, @{$dims_method->{'args'}}, $file);
+            };
+            if ($stdout) {
+                $ret = $dims_method->{'format'}->($stdout);
+            }
         }
     }
-    if ($dims) {
-        write_image $file;
-        printf "%11s ", $dims;                                  # append the image's dimensions
-    }
-    else {
-        printf "%s %11s ",
-            ' ' x ($imgparams{'width'} =~ /^\d+$/ ?  $imgparams{'width'} : 3),
-            ' ';
-    }
-    system @lscmd, @lsopts, $file;
+
+    $failed_types{$ext}++       if ! $ret and $ext;
+    return $ret;
 }
 
-sub usage {
-    say "Usage: $prog [--width #] [--height #] [--[no]par] [ls options] filename [filename]";
-    exit shift;
+# List of methods to obtain image dimensions, tried in prioritized order.
+# Can be external programs or perl module.  Expected to return undef when no
+# dimensions can be found, or a hash ref with 'width' and 'height' elements.
+sub init_dims_methods {
+    return [
+        {
+            prog        => 'sips',
+            args        => [ '-g', 'pixelWidth', '-g', 'pixelHeight' ],
+            format      => sub {
+                my $out = shift;
+                return ($out =~ /pixelWidth: (\d+)\s+pixelHeight: (\d+)/s) ? { width => $1, height => $2 } : undef;
+            }
+        },
+        {
+            prog        => 'mdls',
+            args        => [ '-name', 'kMDItemPixelWidth', '-name', 'kMDItemPixelHeight' ],
+            format      => sub {
+                my $out = shift;
+                my %dim;
+                for my $d (qw /Width Height/) {
+                    $dim{$d} = $1               if $out =~ /kMDItemPixel$d\s*=\s*(\d+)$/m;
+                }
+                return ($dim{'Width'} and $dim{'Height'}) ? { width => $dim{'Width'}, height => $dim{'Height'} } : undef;
+            }
+        },
+
+        {
+            prog        => 'php',
+            args        => [ '-r', q/$a = getimagesize("$argv[1]"); if ($a==FALSE) exit(1); else { echo $a[0] . "x" .$a[1]; exit(0); }/ ],
+            format      => sub {
+                my $out = shift;
+                return undef unless $out;
+                my @d = split /x/, $out;
+                return { width => $d[0], height => $d[1] };
+            }
+        },
+        # Use Image::Size last, due to limitations mentioned elsewhere
+        {
+            prog        => \&have_Image_Size,
+            format      => \&call_Image_Size,
+            name        => 'Image::Size',
+        }
+    ]
+};
+
+# Look for a dims_methods program to determine image dimensions
+sub find_dims_methods {
+    my $methods = shift;
+
+    if ($opts{'method'}) {
+        @$methods = grep {
+            (exists $_->{'name'} and (lc($_->{'name'}) eq lc($opts{'method'}))) or
+            ($_->{'prog'} eq $opts{'method'}) } @$methods;
+    }
+
+    for (@$methods) {
+        if (ref $_->{'prog'} eq 'CODE' and $_->{'prog'}->()) {
+            return $_;
+        }
+        elsif (my $choice = which($_->{'prog'})) {
+            $_->{'prog'} = $choice;
+            return $_;
+        }
+    }
+
+    say "$prog: no methods found to obtain image dimensions. Tried: ",
+        map { "\n   " . (exists $_->{'name'} ? $_->{'name'} : $_->{'prog'}) } @$methods;
+
+    exit 1;
+}
+
+# Allow Image::Size to be used if available to calculate an image's size.  It
+# does not support dimensions of PDF files, so it will be tried last.
+sub have_Image_Size {
+    eval "require Image::Size";
+    return Image::Size->can('imgsize');
+}
+
+sub call_Image_Size {
+    my $file = shift;
+
+    my ($w, $h, $type) = Image::Size::imgsize($file);
+    if (defined $w and defined $h) {
+        # Bug: Workaround negative BMP size values, discovered with export to BMP via
+        # SnagIt and Pixelmator (classic).
+        if ($type eq 'BMP') {                   
+            $w = (2**32) - $w   if $w > 2**31;
+            $h = (2**32) - $h   if $h > 2**31;
+        }
+        return { width => $w, height => $h };
+    }
+
+    return undef;
 }
 
 # grab the specified image file's contents
@@ -166,35 +433,129 @@ sub get_image_bytes {
     return $filebytes;
 }
 
-sub get_cmd_output {
-    my $prog = shift;
+sub ls_sort {
+    return if ! (@_ or scalar @_ > 1);
 
-    use English;
-    my ($ret, $pid);
-    die "Can't fork: $!" unless defined($pid = open(KID, "-|"));
-    if ($pid) {           # parent
-        $ret .= $_       while <KID>;
-        close KID;
-        return $ret;
+    # XXX t and r issue and y
+    if ($opts{'t'}) {
+        # descending
+        @_ = sort { _lstat($b)->mtime <=> _lstat($a)->mtime } @_;
+    }
+    # ctime, then lexical within times
+    # does not match macOS' ls(1) cmd, which seems wrong (or at least does not
+    # match the man page) nor does it appear to match any info returned by
+    # stat(1) or mdls.
+    elsif ($opts{'c'}) {
+        @_ = sort { _lstat($a)->ctime <=> _lstat($b)->ctime || $a cmp $b } @_;
+    }
+    elsif ($opts{'u'}) {
+        @_ = sort { _lstat($a)->atime <=> _lstat($b)->atime } @_;
+    }
+    elsif ($opts{'S'}) {
+        @_ = sort { _lstat($b)->size <=> _lstat($a)->size || $a cmp $b } @_;
     }
     else {
-        my @temp     = ($EUID, $EGID);
-        my $orig_uid = $UID;
-        my $orig_gid = $GID;
-        $EUID = $UID;
-        $EGID = $GID;
-        # Drop privileges
-        $UID  = $orig_uid;
-        $GID  = $orig_gid;
-        # Make sure privs are really gone
-        ($EUID, $EGID) = @temp;
-        die "Can't drop privileges"
-            unless $UID == $EUID  && $GID eq $EGID;
-        $ENV{PATH} = "/bin:/usr/bin"; # Minimal PATH.
-    # Consider sanitizing the environment even more.
-        exec $prog, @_,
-            or warn "Failed to run $prog: $!";
+        @_ = sort @_;
+    }
+
+    return $opts{'r'} ? reverse @_ : @_;
+}
+
+sub get_F_type {
+    my $st = shift;
+
+    return '/'  if -d $st and ($opts{'p'} or $opts{'F'});
+    return ''   unless $opts{'F'};
+    return '@'  if -l $st;
+    return '|'  if -p $st;
+    return '='  if -S $st;
+    return '*'  if -x $st;      # must come after other tests
+    #return '%'                 # whiteout not supported
+    return '';
+}
+
+sub format_time {
+    my $time = shift;
+
+    my $fmt;
+    if ($time + $sixmonths > $curtime and $time < $curtime + $sixmonths) {
+        # dd mmm hh:mm
+        $fmt = "%b %e %R";
+    }
+    else {
+        # dd mmm  yyyy
+        $fmt = "%b %e  %Y";
+    }
+    return strftime $fmt, localtime($time);
+}
+
+sub format_human {
+    my $bytes = shift;
+
+    my @units = ('B', 'K', 'M', 'G', 'T', 'P');
+    my $scale = floor((length($bytes) - 1) / 3);
+    my $float = $bytes / (1024 ** $scale);
+
+    my ($frac, $int) = modf($float);
+    if (length($bytes) < 3 or length($int) >= 2) {
+        sprintf "%d%s", $frac <.5 ? $float : $float + 1, $units[$scale];
+    }
+    else {
+        sprintf "%.1f%s", $float, $units[$scale];
     }
 }
 
-# vim: set expandtab
+sub _lstat {
+    my $file = shift;
+    #say "... cache hit: $file" if exists $stat_cache{$file};
+    return $stat_cache{$file}   if exists $stat_cache{$file};
+
+    #say "\t... cache miss: $file";
+    if (my $s = lstat($file)) {
+        return $stat_cache{$file} = $s;
+    }
+
+    return $file;
+}
+
+# Generate 1 pixel black PNG as placeholding for non-image-able files.
+sub get_black_pixel_image {
+    # base 64 encoded single black pixel png
+    my $one_pixel_black = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIW2NgYGD4DwABBAEAwS2OUAAAAABJRU5ErkJggg==';
+    return ($one_pixel_black, length $one_pixel_black);
+}
+
+# Based on Stat::lsMode, Copyright 1998 M-J. Dominus, (mjd-perl-lsmode@plover.com)
+# You may distribute this module under the same terms as Perl itself.
+
+package Stat::lsMode;
+
+sub format_mode {
+    my $mode = shift;
+
+    return undef        unless defined $mode;
+
+    my @permchars  = qw(--- --x -w- -wx r-- r-x rw- rwx);
+    my @ftypechars = qw(. p c ? d ? b ? - ? l ? s ? ? ?);
+    $ftypechars[0] = '';
+
+    my $setids     = ($mode & 07000) >> 9;
+    my @permstrs   = @permchars[($mode & 0700) >> 6, ($mode & 0070) >> 3, $mode & 0007];
+    my $ftype      = $ftypechars[($mode & 0170000) >> 12];
+
+    if ($setids) {
+        if ($setids & 01) {             # sticky
+            $permstrs[2] =~ s/([-x])$/$1 eq 'x' ? 't' : 'T'/e;
+        }
+        if ($setids & 04) {             # setuid
+            $permstrs[0] =~ s/([-x])$/$1 eq 'x' ? 's' : 'S'/e;
+        }
+        if ($setids & 02) {             # setgid
+            $permstrs[1] =~ s/([-x])$/$1 eq 'x' ? 's' : 'S'/e;
+        }
+    }
+
+    join '', $ftype, @permstrs;
+}
+
+# vim: expandtab


### PR DESCRIPTION
1. Eliminate calling ls(1), instead support most of its functionality internally.
2. Output is now correctly column-aligned.
3. New mechanism to detect / call on programs / methods for obtaining image dimensions (default method is sips, others are mdls, php, and image::size; selectable via --method option).
4. New option --[no]unknown to suppress showing broken image icons.
5. Option --par renamed to --preserve_ratio.
6. Embedded 1px black image used for aligning columns.