### PR TITLE
Add scientific notation context menu synonym

### DIFF
--- a/sources/iTermTextViewContextMenuHelper.m
+++ b/sources/iTermTextViewContextMenuHelper.m
@@ -1208,12 +1208,12 @@ static uint64_t iTermInt64FromBytes(const unsigned char *bytes, BOOL bigEndian) 
 
 - (NSString *)scientificNotationConversionHelp {
     NSString *scientificNotationRegex = @"^-?(0|[1-9]\\d*)?(\\.\\d+)?[eE][+\\-]?\\d+$";
-    BOOL isScientificNotation = [self isMatchedByRegex:scientificNotationRegex];
+    const BOOL isScientificNotation = [self isMatchedByRegex:scientificNotationRegex];
     if (!isScientificNotation) {
         return nil;
     }
 
-    NSDecimalNumber *number = [[NSDecimalNumber alloc] initWithString: self];
+    NSDecimalNumber *number = [[NSDecimalNumber alloc] initWithString:self];
     if (!number || [number isEqual:[NSDecimalNumber notANumber]]) {
         return nil;
     }

--- a/sources/iTermTextViewContextMenuHelper.m
+++ b/sources/iTermTextViewContextMenuHelper.m
@@ -1221,7 +1221,7 @@ static uint64_t iTermInt64FromBytes(const unsigned char *bytes, BOOL bigEndian) 
     NSNumberFormatter *numberFormatter = [[NSNumberFormatter alloc] init];
     numberFormatter.numberStyle = NSNumberFormatterDecimalStyle;
     numberFormatter.maximumFractionDigits = 1000;
-    NSString *formattedNumber = [numberFormatter stringFromNumber: number];
+    NSString *formattedNumber = [numberFormatter stringFromNumber:number];
 
     return [NSString stringWithFormat:@"%@ = %@", self, formattedNumber];
 }

--- a/sources/iTermTextViewContextMenuHelper.m
+++ b/sources/iTermTextViewContextMenuHelper.m
@@ -1075,6 +1075,10 @@ static uint64_t iTermInt64FromBytes(const unsigned char *bytes, BOOL bigEndian) 
     if (hexOrDecimalConversion) {
         [array addObject:hexOrDecimalConversion];
     }
+    NSString *scientificNotationConversion = [self scientificNotationConversionHelp];
+    if (scientificNotationConversion) {
+        [array addObject:scientificNotationConversion];
+    }
     NSString *timestampConversion = [self timestampConversionHelp];
     if (timestampConversion) {
         [array addObject:timestampConversion];
@@ -1200,6 +1204,26 @@ static uint64_t iTermInt64FromBytes(const unsigned char *bytes, BOOL bigEndian) 
                        humanReadableSize];
         }
     }
+}
+
+- (NSString *)scientificNotationConversionHelp {
+    NSString *scientificNotationRegex = @"^-?(0|[1-9]\\d*)?(\\.\\d+)?[eE][+\\-]?\\d+$";
+    BOOL isScientificNotation = [self isMatchedByRegex:scientificNotationRegex];
+    if (!isScientificNotation) {
+        return nil;
+    }
+
+    NSDecimalNumber *number = [[NSDecimalNumber alloc] initWithString: self];
+    if (!number || [number isEqual:[NSDecimalNumber notANumber]]) {
+        return nil;
+    }
+
+    NSNumberFormatter *numberFormatter = [[NSNumberFormatter alloc] init];
+    numberFormatter.numberStyle = NSNumberFormatterDecimalStyle;
+    numberFormatter.maximumFractionDigits = 1000;
+    NSString *formattedNumber = [numberFormatter stringFromNumber: number];
+
+    return [NSString stringWithFormat:@"%@ = %@", self, formattedNumber];
 }
 
 - (NSString *)timestampConversionHelp {


### PR DESCRIPTION
Hi!!

This code adds a translation from scientific notation to decimal format in the context menu.
I implemented this feature some time ago and at least for me it has proved to be very useful, so I think it might be useful for others as well.

Some examples:

`1e10` -> `1e3 = 1,000`
`.314E1` -> `.314E1 = 3.14`
`-314e-2` -> `-314e-2 = 3.14`

Screenshot:

![screenshot](https://gonzulabucket.s3.amazonaws.com/Images/5E7D2386-3340-4B07-A5A5-782AE838EED9.png?AWSAccessKeyId=AKIA2RV7BQ3KL4HERDPN&Signature=0spe5CXEhKkOu3%2F7jYdAdzVgSp4%3D&Expires=2147483623)