### PR TITLE
Using python3 on macOS 12.3 and fix null environment issue for tmux integration.

### DIFF
--- a/sources/PTYSession.m
+++ b/sources/PTYSession.m
@@ -2261,7 +2261,7 @@ ITERM_WEAKLY_REFERENCEABLE
                                         substitutions:(NSDictionary *)substitutions {
     DLog(@"environmentForNewJobFromEnvironment:%@ substitutions:%@",
          environment, substitutions);
-    NSMutableDictionary *env = [[environment mutableCopy] autorelease];
+    NSMutableDictionary *env = environment ? [[environment mutableCopy] autorelease] : [NSMutableDictionary dictionary];
     if (env[TERM_ENVNAME] == nil) {
         env[TERM_ENVNAME] = _termVariable;
     }

--- a/tools/updateVersion.py
+++ b/tools/updateVersion.py
@@ -1,41 +1,37 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
-import commands
 import os
-import sys
 import time
+import subprocess
 
 try:
-        del os.environ["MACOSX_DEPLOYMENT_TARGET"]
+    del os.environ["MACOSX_DEPLOYMENT_TARGET"]
 except KeyError:
-        pass
+    pass
 from Foundation import NSMutableDictionary
 
 if os.environ["CONFIGURATION"] == "Development":
-        cmd = "git log -1 --format=\"%H\""
-        status, output = commands.getstatusoutput(cmd)
-        if status != 0:
-                sys.exit(status)
+    cmd = "git log -1 --format=\"%H\""
+    output = subprocess.check_output(cmd, shell=True).decode("utf-8")
 
-        revision = "git.unknown"
-        for line in output.split("\n"):
-            if len(line.strip()) > 0:
-                revision = "git." + line.strip()[:10]
-                break
+    revision = "git.unknown"
+    for line in output.split("\n"):
+        if len(line.strip()) > 0:
+            revision = "git." + line.strip()[:10]
+            break
 
 elif os.environ["CONFIGURATION"] == "Nightly":
-        revision = time.strftime("%Y%m%d-nightly")
+    revision = time.strftime("%Y%m%d-nightly")
 else:
-        revision = time.strftime("%Y%m%d")
+    revision = time.strftime("%Y%m%d")
 
 buildDir = os.environ["BUILT_PRODUCTS_DIR"]
 infoFile = os.environ["INFOPLIST_PATH"]
 path = os.path.join(buildDir, infoFile)
 plist = NSMutableDictionary.dictionaryWithContentsOfFile_(path)
 version = open("version.txt").read().strip() % {"extra": revision}
-print "Updating versions:", infoFile, version
+print("Updating versions:", infoFile, version)
 plist["CFBundleShortVersionString"] = version
 plist["CFBundleGetInfoString"] = version
 plist["CFBundleVersion"] = version
 plist.writeToFile_atomically_(path, 1)
-


### PR DESCRIPTION
1. macOS Monterey 12.3 removes python2.
2. Fix issue: https://gitlab.com/gnachman/iterm2/-/issues/10136#note_884250463