### PR TITLE
tmux new-window supports adding a new tab next to the current tab

### DIFF
--- a/sources/PTYTab.m
+++ b/sources/PTYTab.m
@@ -3666,10 +3666,8 @@ typedef struct {
     if (parseTree[kLayoutDictTabIndex]) {
         // Add tab at a specified index.
         [term insertTab:theTab atIndex:[parseTree[kLayoutDictTabIndex] intValue]];
-    } else if ([parseTree[kLayoutDictTabOpenedManually] boolValue]) {
-        [term addTabAtAutomaticallyDeterminedLocation:theTab];
     } else {
-        [term appendTab:theTab];
+        [term addTabAtAutomaticallyDeterminedLocation:theTab];
     }
     [theTab didAddToTerminal:term withArrangement:arrangement];
     [theTab updateTmuxTitleMonitor];


### PR DESCRIPTION
1. Set `Add new tabs at the end of the tab bar, not next to current tab.` to `No`
<img width="1008" alt="image" src="https://user-images.githubusercontent.com/20320324/166409836-0d4badf2-b017-4569-becb-9cced3c15fff.png">

2. Run `tmux -CC`

3. Add a new tab by `CMD + T`

4. Switch to the left tab

5. Run `tmux new-window`

The new tab should be next to the left tab, not at the end of the tab bar.