### PR TITLE
Add escape code for rich notifications.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ api/library/python/iterm2/docs/_build
 BetterFontPicker/BetterFontPicker.xcodeproj/project.xcworkspace/xcuserdata/gnachman.xcuserdatad/UserInterfaceState.xcuserstate
 BetterFontPicker/BetterFontPicker.xcodeproj/xcuserdata
 BetterFontPicker/BetterFontPicker.xcodeproj/project.xcworkspace/xcuserdata/
+
+# AppCode files
+.idea

--- a/sources/VT100ScreenDelegate.h
+++ b/sources/VT100ScreenDelegate.h
@@ -368,7 +368,7 @@ typedef NS_ENUM(NSUInteger, VT100ScreenWorkingDirectoryPushType) {
                               remoteHost:(id<VT100RemoteHostReading> _Nullable)remoteHost;
 - (void)screenCopyStringToPasteboard:(NSString * _Nonnull)string;
 - (void)screenReportPasteboard:(NSString * _Nonnull)pasteboard completion:(void (^ _Nonnull)(void))completion;
-- (void)screenPostUserNotification:(NSString * _Nonnull)string;
+- (void)screenPostUserNotification:(NSString * _Nonnull)string rich:(BOOL)rich;
 // Called while joined. Don't let `mutableState` escape.
 - (void)screenSync:(VT100ScreenMutableState * _Nonnull)mutableState;
 - (void)screenUpdateCommandUseWithGuid:(NSString * _Nonnull)screenmarkGuid

--- a/sources/VT100ScreenMutableState+TerminalDelegate.m
+++ b/sources/VT100ScreenMutableState+TerminalDelegate.m
@@ -892,6 +892,10 @@
 }
 
 - (void)terminalPostUserNotification:(NSString *)message {
+    [self terminalPostUserNotification:message rich:NO];
+}
+
+- (void)terminalPostUserNotification:(NSString *)message rich:(BOOL)rich {
     DLog(@"begin %@", message);
     if (!self.postUserNotifications) {
         DLog(@"Declining to allow terminal to post user notification %@", message);
@@ -900,7 +904,7 @@
     [self addSideEffect:^(id<VT100ScreenDelegate>  _Nonnull delegate) {
         DLog(@"begin side-effect");
         DLog(@"Post %@", message);
-        [delegate screenPostUserNotification:message];
+        [delegate screenPostUserNotification:message rich:rich];
     }];
 }
 

--- a/sources/VT100Terminal.m
+++ b/sources/VT100Terminal.m
@@ -3978,6 +3978,8 @@ static BOOL VT100TokenIsTmux(VT100Token *token) {
                                                               payload:payload];
             }
         }
+    } else if ([key isEqualToString:@"Notification"]) {
+        [_delegate terminalPostUserNotification:(NSString *)value rich:YES];
     } else if ([key isEqualToString:@"Capabilities"]) {
         if ([_delegate terminalIsTrusted] && [_delegate terminalShouldSendReport]) {
             [_delegate terminalSendCapabilitiesReport];

--- a/sources/VT100TerminalDelegate.h
+++ b/sources/VT100TerminalDelegate.h
@@ -270,8 +270,11 @@ typedef NS_ENUM(NSUInteger, VT100TerminalProtectedMode) {
 // Restores the window/icon (depending on isWindow) title from a stack.
 - (void)terminalPopCurrentTitleForWindow:(BOOL)isWindow;
 
-// Posts a message to Notification center. Returns YES if the message was posted.
+// Posts a message to Notification center.
 - (void)terminalPostUserNotification:(NSString *)message;
+
+// Posts a rich notification message to Notification center.
+- (void)terminalPostUserNotification:(NSString *)message rich:(BOOL)rich;
 
 // Enters Tmux mode.
 - (void)terminalStartTmuxModeWithDCSIdentifier:(NSString *)dcsID;

--- a/sources/iTermNotificationController.h
+++ b/sources/iTermNotificationController.h
@@ -73,6 +73,20 @@
            tabIndex:(int)tabIndex
           viewIndex:(int)viewIndex;
 
+// Generate a notification with all possible fields.
+// title, subtitle, and image file are all optional
+// and can be nil.  The description argument must
+// not be nil, but can be the empty string.
+//
+// Returns YES if the notification was posted.
+- (BOOL)notifyRich:(NSString *)title
+      withSubtitle:(NSString *)subtitle
+   withDescription:(NSString *)description
+         withImage:(NSString *)image
+       windowIndex:(int)windowIndex
+          tabIndex:(int)tabIndex
+         viewIndex:(int)viewIndex;
+
 // Adds the sticky argument.
 - (BOOL)notify:(NSString *)title
     withDescription:(NSString *)description

--- a/sources/iTermNotificationController.m
+++ b/sources/iTermNotificationController.m
@@ -29,6 +29,7 @@
 
 #import "DebugLogging.h"
 #import "iTermController.h"
+#import "iTermImage.h"
 #import "iTermAdvancedSettingsModel.h"
 #import "PreferencePanel.h"
 #import "PseudoTerminal.h"
@@ -82,6 +83,51 @@
                     tabIndex:tabIndex
                    viewIndex:viewIndex
                       sticky:NO];
+}
+
+- (BOOL)notifyRich:(NSString *)title
+      withSubtitle:(NSString *)subtitle
+   withDescription:(NSString *)description
+         withImage:(NSString *)image
+       windowIndex:(int)windowIndex
+          tabIndex:(int)tabIndex
+         viewIndex:(int)viewIndex {
+    DLog(@"Notify title=%@ description=%@ window=%@ tab=%@ view=%@",
+            title, description, @(windowIndex), @(tabIndex), @(viewIndex));
+
+    if (description == nil) {
+        DLog(@"notifyRich passed nil description.");
+        return NO;
+    }
+
+    // Send to NSUserDefaults directly
+    NSUserNotification *notification = [[NSUserNotification alloc] init];
+    notification.informativeText = description;
+
+    NSDictionary *context = nil;
+    if (windowIndex >= 0) {
+        context = @{ @"win": @(windowIndex),
+                     @"tab": @(tabIndex),
+                     @"view": @(viewIndex) };
+    }
+    notification.userInfo = context;
+
+    if (title != nil) {
+        notification.title = title;
+    }
+    if (subtitle != nil) {
+        notification.subtitle = subtitle;
+    }
+    if (image != nil) {
+        NSData *data = [NSData dataWithContentsOfFile:image];
+        if (data != nil) {
+            notification.contentImage = [[[iTermImage imageWithCompressedData:data] images] firstObject];
+        }
+    }
+    DLog(@"Post notification %@", notification);
+    [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:notification];
+
+    return [notification isPresented];
 }
 
 - (BOOL)notify:(NSString *)title


### PR DESCRIPTION
This pull request adds support for a "rich" notification escape code.
There might a better choice than calling them "rich", but the feature
allows more control over notifications than the existing escape code.

I had considered whether it might be better to try to implement this
functionality via the "custom" escape code and Python API, and then
using another program such as terminal-notifier
(https://github.com/julienXX/terminal-notifier) to present the
notifications.  However, it does not seem possible to get an external
tool to focus the correct window/tab when clicking on the notification.

To keep parsing simple, each of the fields for the notification is
base64 encoded.

It might make sense to lock this down further with add an allow/deny
list for the notification image, similar to what there appears to be for
setting a background image.  However, I wasn't able to determine where
those lists were defined.

It also appears that there the code is using an older deprecated
notifications API.  It seems better to address that in a separate change
though.  However, it looks the new API was introduced in Mojave, so I'm
not sure if there backwards compatibility implications.

Finally, it has also been quite a long time since I have written much
Objective-C, so definitely let me know if there are any improvements to
style that I should make.