### PR TITLE
Fix integration w/ tmux 3.3 by ignoring errors if @uservars option is not set

### DIFF
--- a/sources/TmuxWindowOpener.m
+++ b/sources/TmuxWindowOpener.m
@@ -217,7 +217,7 @@ NSString *const kTmuxWindowOpenerWindowOptionStyleValueFullScreen = @"FullScreen
 - (NSDictionary *)dictForGetUserVars:(NSNumber *)wp {
     ++pendingRequests_;
     DLog(@"Increment pending requests to %d", pendingRequests_);
-    NSString *command = [NSString stringWithFormat:@"show-options -v -p -t %%%d @uservars",
+    NSString *command = [NSString stringWithFormat:@"show-options -q -v -p -t %%%d @uservars",
                          [wp intValue]];
     return [gateway_ dictionaryForCommand:command
                            responseTarget:self


### PR DESCRIPTION
I was experiencing something similar to https://github.com/tmux/tmux/issues/3199, and I believe it is caused by https://github.com/tmux/tmux/commit/7bd9cdf6fcf43e0edc8ab3a4accf2009ca5aa35e.

Prior to https://github.com/tmux/tmux/commit/7bd9cdf6fcf43e0edc8ab3a4accf2009ca5aa35e, tmux's `show-options` would fail silently, even if `-q` was not specified. Now, it generates an error that appears to upset iTerm2. I see errors in `/var/debuglog.txt` to the effect:

```
"A tmux pane terminated immediately after creation…"
```

Passing `-q` explicitly should restore the `fail silently` behavior that iTerm2 previously depended upon.