### PR TITLE
Adjust "Check for Updates…" capitalization

### DIFF
--- a/Interfaces/MainMenu.xib
+++ b/Interfaces/MainMenu.xib
@@ -31,7 +31,7 @@
                             <menuItem isSeparatorItem="YES" id="Dxk-DH-qzi">
                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                             </menuItem>
-                            <menuItem title="Check For Updates…" identifier="Check For Updates…" id="880">
+                            <menuItem title="Check for Updates…" identifier="Check for Updates…" id="880">
                                 <connections>
                                     <action selector="checkForUpdatesFromMenu:" target="201" id="vmh-LD-TwW"/>
                                 </connections>

--- a/api/library/python/iterm2/docs/menu_ids.rst
+++ b/api/library/python/iterm2/docs/menu_ids.rst
@@ -19,7 +19,7 @@ Menu Item                                                                       
 ======================================================================================= ==============================================================================
 iTerm2 > About iTerm2                                                                   `About iTerm2`                                                                
 iTerm2 > Show Tip of the Day                                                            `Show Tip of the Day`                                                         
-iTerm2 > Check For Updates…                                                             `Check For Updates…`                                                          
+iTerm2 > Check for Updates…                                                             `Check for Updates…`                                                          
 iTerm2 > Toggle Debug Logging                                                           `Toggle Debug Logging`                                                        
 iTerm2 > Copy Performance Stats                                                         `Copy Performance Stats`                                                      
 iTerm2 > Capture GPU Frame                                                              `Capture Metal Frame`                                                         

--- a/api/library/python/iterm2/iterm2/mainmenu.py
+++ b/api/library/python/iterm2/iterm2/mainmenu.py
@@ -93,7 +93,7 @@ class MainMenu:
     class iTerm2(enum.Enum):
         ABOUT_ITERM2 = MenuItemIdentifier("About iTerm2", "About iTerm2")
         SHOW_TIP_OF_THE_DAY = MenuItemIdentifier("Show Tip of the Day", "Show Tip of the Day")
-        CHECK_FOR_UPDATES = MenuItemIdentifier("Check For Updates…", "Check For Updates…")
+        CHECK_FOR_UPDATES = MenuItemIdentifier("Check for Updates…", "Check for Updates…")
         TOGGLE_DEBUG_LOGGING = MenuItemIdentifier("Toggle Debug Logging", "Toggle Debug Logging")
         COPY_PERFORMANCE_STATS = MenuItemIdentifier("Copy Performance Stats", "Copy Performance Stats")
         CAPTURE_GPU_FRAME = MenuItemIdentifier("Capture GPU Frame", "Capture Metal Frame")

--- a/sources/iTermApplicationDelegate.m
+++ b/sources/iTermApplicationDelegate.m
@@ -1265,7 +1265,7 @@ void TurnOnDebugLoggingAutomatically(void) {
 
     [[iTermBuriedSessions sharedInstance] setMenus:[NSArray arrayWithObjects:_buriedSessions, _statusIconBuriedSessions, nil]];
 
-    item = [[[NSMenuItem alloc] initWithTitle:@"Check For Updates"
+    item = [[[NSMenuItem alloc] initWithTitle:@"Check for Updates…"
                                        action:@selector(checkForUpdatesFromMenu:)
                                 keyEquivalent:@""] autorelease];
     [menu addItem:item];


### PR DESCRIPTION
This pull request adjusts the capitalization of the "for" preposition, short prepositions are most commonly not capitalized in the title case. The vast majority of apps on macOS also follow this.