### PR TITLE
Fix View menu offset on macOS Big Sur and later

### DIFF
--- a/sources/ColorsMenuItemView.m
+++ b/sources/ColorsMenuItemView.m
@@ -65,6 +65,7 @@ const int kDefaultColorStokeWidth = 2;
 const int kMenuFontSize = 14;
 const int kMenuLabelOffsetX_PreBigSur = 20;
 const int kMenuLabelOffsetX_BigSur = 24;
+const int kMenuLabelOffsetX_BigSurOnState = 10;
 const int kMenuLabelOffsetY = 32;
 
 const CGFloat iTermColorsMenuItemViewDisabledAlpha = 0.3;
@@ -137,7 +138,11 @@ const CGFloat iTermColorsMenuItemViewDisabledAlpha = 0.3;
 
 - (CGFloat)colorXOffset {
     if (@available(macOS 10.16, *)) {
-        return kColorAreaOffsetX_BigSur;
+        if (!self.viewMenuHasSubmenuOnState) {
+            return kColorAreaOffsetX_BigSur - kMenuLabelOffsetX_BigSurOnState;
+        } else {
+            return kColorAreaOffsetX_BigSur;
+        }
     }
     return kColorAreaOffsetX_PreBigSur;
 }
@@ -260,6 +265,9 @@ const CGFloat iTermColorsMenuItemViewDisabledAlpha = 0.3;
     CGFloat x;
     if (@available(macOS 10.16, *)) {
         x = kMenuLabelOffsetX_BigSur;
+        if (!self.viewMenuHasSubmenuOnState) {
+            x -= kMenuLabelOffsetX_BigSurOnState;
+        }
     } else {
         x = kMenuLabelOffsetX_PreBigSur;
     }
@@ -321,6 +329,19 @@ const CGFloat iTermColorsMenuItemViewDisabledAlpha = 0.3;
     }
     _mouseDownIndex = [self indexForPoint:[self convertPoint:event.locationInWindow fromView:nil]];
     [self updateSelectedIndexForEvent:event];
+}
+
+- (BOOL)viewMenuHasSubmenuOnState {
+    for (NSMenuItem *mainMenuItem in NSApp.mainMenu.itemArray) {
+        if ([mainMenuItem.title isEqual:@"View"]) {
+            for (NSMenuItem *viewMenuItem in mainMenuItem.submenu.itemArray) {
+                if (viewMenuItem.state == NSControlStateValueOn) {
+                    return YES;
+                }
+            }
+        }
+    }
+    return NO;
 }
 
 @end


### PR DESCRIPTION
This pull request fixes the alignment of the `ColorsMenuItemView` view when there are no menu items with an `on` state in the View menu on macOS Big Sur and later.

Before and after:
<img width="352" alt="Before" src="https://user-images.githubusercontent.com/2276355/187002889-addbe939-9d0c-4715-be4f-b9f32c3be1ef.png"> <img width="351" alt="After" src="https://user-images.githubusercontent.com/2276355/187002886-a8c3b2a8-0220-482c-a73f-3558b9283fbb.png">


The `viewMenuHasSubmenuOnState` method is perhaps too coupled to this class so it may be better placed elsewhere.