### PR TITLE
Fix SGR0 when using 'Copy with Control Sequences'

### DIFF
--- a/sources/SelectionExtraction.swift
+++ b/sources/SelectionExtraction.swift
@@ -219,7 +219,7 @@ class SGRSelectionExtractor: StringSelectionExtractor {
         let temp = NSMutableAttributedString()
         super.extract(temp, attributeProvider: attributeProvider)
         let result = NSMutableString()
-        let sgr0 = "\u{1b}[0"
+        let sgr0 = "\u{1b}[0m"
         temp.enumerateAttribute(sgrAttribute,
                                 in: NSMakeRange(0, temp.length),
                                 options: []) { value, range, stop in


### PR DESCRIPTION
I found that when I use **Edit -> Copy with Control Sequences** on `Build 3.5.20220828-nightly`, the resulting copied text has `\x1b[0` *without* a trailing `m` before newlines and at the end of the text.

I could definitely be confused here (ECMA-48 is a bit dense haha), but it *seemed* like the SGR sequences are required to end in the character `m` (aka `\x6d` aka 06/13). Specifically it says

> **8.3.117 SGR - SELECT GRAPHIC RENDITION**
> Notation: (Ps...)
> Representation: CSI Ps... 06/13
> Parameter default value: Ps = 0

If this is intentional (aka, there's some part of the spec I'm missing, which is more than likely) then we can just close this out.

Note: I had trouble getting this to build locally (kept failing with `No account for team "H7V7XYVQ7D"` despite changing it to `Sign to Run Locally`), but I can try again if you'd like me to specifically verify the change locally.