### PR TITLE
Small additions to settabcolor example and connection.py documentation

### DIFF
--- a/api/library/python/iterm2/docs/examples/settabcolor.rst
+++ b/api/library/python/iterm2/docs/examples/settabcolor.rst
@@ -7,8 +7,6 @@ Set Tab Color
 
 This script sets the tab color for the current session to a hard-coded value. It also turns on the use of tab color for that session. It does not modify the underlying profile, so only the current session is affected.
 
-It also shows how to parse the ITERM_SESSION_ID environment variable to set the tab color for the tab that originally ran this script, instead of the currently active tab.
-
 .. code-block:: python
 
     #!/usr/bin/env python3.7

--- a/api/library/python/iterm2/docs/examples/settabcolor.rst
+++ b/api/library/python/iterm2/docs/examples/settabcolor.rst
@@ -7,15 +7,21 @@ Set Tab Color
 
 This script sets the tab color for the current session to a hard-coded value. It also turns on the use of tab color for that session. It does not modify the underlying profile, so only the current session is affected.
 
+It also shows how to parse the ITERM_SESSION_ID environment variable to set the tab color for the tab that originally ran this script, instead of the currently active tab.
+
 .. code-block:: python
 
     #!/usr/bin/env python3.7
 
-    import iterm2
+    import iterm2, os, re
+
+    def original_session(app):
+        '''Gets the session based on the ITERM_SESSION_ID env var'''
+        return re.match(r'^(\w+:)?(.*)', os.environ.get('ITERM_SESSION_ID')).group(2)
 
     async def main(connection):
         app=await iterm2.async_get_app(connection)
-        session=app.current_terminal_window.current_tab.current_session
+        session=app.current_terminal_window.current_tab.current_session # or original_session(app)
         change = iterm2.LocalWriteOnlyProfile()
         color = iterm2.Color(255, 128, 128)
         change.set_tab_color(color)

--- a/api/library/python/iterm2/docs/examples/settabcolor.rst
+++ b/api/library/python/iterm2/docs/examples/settabcolor.rst
@@ -13,15 +13,11 @@ It also shows how to parse the ITERM_SESSION_ID environment variable to set the 
 
     #!/usr/bin/env python3.7
 
-    import iterm2, os, re
-
-    def original_session(app):
-        '''Gets the session based on the ITERM_SESSION_ID env var'''
-        return re.match(r'^(\w+:)?(.*)', os.environ.get('ITERM_SESSION_ID')).group(2)
+    import iterm2
 
     async def main(connection):
         app=await iterm2.async_get_app(connection)
-        session=app.current_terminal_window.current_tab.current_session # or original_session(app)
+        session=app.current_terminal_window.current_tab.current_session
         change = iterm2.LocalWriteOnlyProfile()
         color = iterm2.Color(255, 128, 128)
         change.set_tab_color(color)

--- a/api/library/python/iterm2/docs/tutorial/running.rst
+++ b/api/library/python/iterm2/docs/tutorial/running.rst
@@ -112,6 +112,8 @@ Auto-Run Scripts
 If you'd like your script to launch automatically when iTerm2 starts, move it
 to `$HOME/Library/ApplicationSupport/iTerm2/Scripts/AutoLaunch`.
 
+.. _running-repl:
+
 REPL
 ----
 

--- a/api/library/python/iterm2/iterm2/connection.py
+++ b/api/library/python/iterm2/iterm2/connection.py
@@ -93,6 +93,8 @@ class Connection:
         connection and returns it without creating an asyncio event loop.
 
         :returns: A new connection to iTerm2.
+
+        .. seealso:: ":ref:`Running in a REPL <running-repl>`"
         """
         connection = Connection()
 


### PR DESCRIPTION
In Python, I was naively passing the `ITERM_SESSION_ID` envvar into `app.get_session_by_id()` but not getting any sessions back. I then realized the env var is prefixed a window+tab+pane identifier which is not part of the session ID. I wasn't sure if this prefix always exists, so the example code regexes for the session id in a more flexible way than simply `.split(':')`.

I didn't see this mentioned anywhere, and couldn't find a great place to add it, so I just added it to the code sample on the example that I was basing my work on in the first place. I was hitting this because I was appending a tab color change to the end of long-running scripts, and the tab change would get applied to my CURRENT tab instead of the previous tab where I had left the long-running script running.

I also found the `connection.py:async_create()` documentation without finding the `running.rst:REPL` section, so a link from `async_create` to that doc section would have been helpful. :-) 
