### PR TITLE
Automatically set Alert on Next Mark on all unfocused sessions

### DIFF
--- a/sources/PTYSession.m
+++ b/sources/PTYSession.m
@@ -6823,6 +6823,7 @@ scrollToFirstResult:(BOOL)scrollToFirstResult {
         DLog(@"Is tmux gateway");
         return;
     }
+    [self setAlertOnNextMark:!focused];
     _focused = focused;
     if (_screen.terminalReportFocus) {
         DLog(@"Will report focus");


### PR DESCRIPTION
I love the "Alert on Next Mark" feature so much so that I became annoyed to have to constantly enable it. I realized I always want to be notified when any session other than the active one, has yielded. Maybe it is useful for others too hence the PR.

Not sure if this could be accepted upstream in some shape or form (gated by a setting?).

And thank you for this amazing project!