### PR TITLE
Change minimum value of blending level from 5 to 0

### DIFF
--- a/Interfaces/PreferencePanel.xib
+++ b/Interfaces/PreferencePanel.xib
@@ -3349,7 +3349,7 @@ DQ
                         <slider toolTip="How much of the background image is visible through the background color." verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6320">
                             <rect key="frame" x="-2" y="-6" width="215" height="28"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                            <sliderCell key="cell" continuous="YES" alignment="left" minValue="0.050000000000000003" maxValue="1" doubleValue="0.40000000000000002" tickMarkPosition="below" sliderType="linear" id="6321"/>
+                            <sliderCell key="cell" continuous="YES" alignment="left" minValue="0" maxValue="1" doubleValue="0.40000000000000002" tickMarkPosition="below" sliderType="linear" id="6321"/>
                             <connections>
                                 <action selector="settingChanged:" target="BMA-OA-Kzc" id="O9z-H1-Kma"/>
                                 <outlet property="nextKeyView" destination="4976" id="6322"/>


### PR DESCRIPTION
This fixes the bug of not being able to enter values like 10, 20, etc. when setting the blending level from the textbox alongside the slider in Preferences -> Window tab.

Fixes Issue: https://gitlab.com/gnachman/iterm2/-/issues/10772