### PR TITLE
Fix XCode 12 compile error

### DIFF
--- a/sources/NSScreen+iTerm.m
+++ b/sources/NSScreen+iTerm.m
@@ -93,9 +93,11 @@
 }
 
 - (CGFloat)notchHeight {
+#ifdef MAX_OS_VERSION_12_0
     if (@available(macOS 12.0, *)) {
         return self.safeAreaInsets.top;
     }
+#endif
     return 0;
 }
 
@@ -107,11 +109,13 @@
 }
 
 - (CGFloat)it_menuBarHeight {
+#ifdef MAX_OS_VERSION_12_0
     if (@available(macOS 12, *)) {
         // When the "current" screen has a notch, there doesn't seem to be a way to get the height
         // of the menu bar on other screens :(
         return MAX(24, self.safeAreaInsets.top);
     }
+#endif
     return NSApp.mainMenu.menuBarHeight;
 }
 

--- a/sources/iTermRootTerminalView.m
+++ b/sources/iTermRootTerminalView.m
@@ -1252,11 +1252,13 @@ NS_CLASS_AVAILABLE_MAC(10_14)
     if (fakeHeight > 0) {
         return fakeHeight;
     }
+#ifdef MAC_OS_VERSION_12_0
     if (@available(macOS 12, *)) {
         // self.safeAreaInsets is all 0s on a notch Mac. Why the hell doesn't anything work right?
         const NSEdgeInsets safeAreaInsets = self.window.screen.safeAreaInsets;
         return safeAreaInsets.top;
     }
+#endif
     return 0;
 }
 


### PR DESCRIPTION
```
error: property 'safeAreaInsets' not found on object of type 'NSScreen *'
```