### PR TITLE
Only restore previously active app if iTerm is active

### DIFF
--- a/sources/iTermPreviousState.m
+++ b/sources/iTermPreviousState.m
@@ -85,9 +85,9 @@
 
     NSRunningApplication *app = [self appToSwitchBackToIfAllowed];
     BOOL result = NO;
-    if (app) {
+    if (app && [NSApp isActive]) {
         DLog(@"Restore app %@", app);
-        DLog(@"** Restor previously active app from\n%@", [NSThread callStackSymbols]);
+        DLog(@"** Restore previously active app from\n%@", [NSThread callStackSymbols]);
         result = [app activateWithOptions:0];
         DLog(@"activateWithOptions:0 returned %@", @(result));
     }


### PR DESCRIPTION
Fixes a bug when iTerm restores previously active app when another app is already active:
- Activate some application (e.g. `TextEdit`) then open another app window in front of it (e.g. `Calculator`)
- Open iTerm hotkey window
- With iTerm hotkey window open click a first activated app (`TextEdit`)
- iTerm restores previously open app (`Calculator`) in place of just activated `TextEdit`

Same bug can be reproduced when running an `open` command from a hotkey window: e.g. running `open .` opens Finder window and then reactivates another app that was open previously.
