### PR TITLE
Add forgotten VSCode Insiders ⌘-click open handling

### DIFF
--- a/sources/iTermSemanticHistoryController.m
+++ b/sources/iTermSemanticHistoryController.m
@@ -251,7 +251,7 @@ NSString *const kSemanticHistoryColumnNumberKey = @"semanticHistory.columnNumber
         // I don't expect this to ever happen.
         return;
     }
-    NSArray<NSString *> *possibleIdentifiers = codium ? @[ kVSCodiumIdentifier1, kVSCodiumIdentifier2 ] : @[kVSCodeIdentifier];
+    NSArray<NSString *> *possibleIdentifiers = codium ? @[ kVSCodiumIdentifier1, kVSCodiumIdentifier2 ] : @[kVSCodeIdentifier, kVSCodeInsidersIdentifier];
     NSString *identifier;
     NSString *bundlePath = nil;
     for (NSString *candidate in possibleIdentifiers) {
@@ -362,6 +362,7 @@ NSString *const kSemanticHistoryColumnNumberKey = @"semanticHistory.columnNumber
               kVSCodeIdentifier,
               kVSCodiumIdentifier1,
               kVSCodiumIdentifier2,
+              kVSCodeInsidersIdentifier,
               kSublimeText2Identifier,
               kSublimeText3Identifier,
               kSublimeText4Identifier,
@@ -397,7 +398,8 @@ NSString *const kSemanticHistoryColumnNumberKey = @"semanticHistory.columnNumber
     }
     if ([identifier isEqualToString:kVSCodeIdentifier] ||
         [identifier isEqualToString:kVSCodiumIdentifier1] ||
-        [identifier isEqualToString:kVSCodiumIdentifier2]) {
+        [identifier isEqualToString:kVSCodiumIdentifier2] ||
+        [identifier isEqualToString:kVSCodeInsidersIdentifier]) {
         if (lineNumber != nil) {
             path = [NSString stringWithFormat:@"%@:%@", path, lineNumber];
         }

--- a/sources/iTermSemanticHistoryPrefsController.h
+++ b/sources/iTermSemanticHistoryPrefsController.h
@@ -20,6 +20,7 @@ extern NSString *kAtomIdentifier;
 extern NSString *kVSCodeIdentifier;
 extern NSString *kVSCodiumIdentifier1;
 extern NSString *kVSCodiumIdentifier2;
+extern NSString *kVSCodeInsidersIdentifier;
 extern NSString *kTextmateIdentifier;
 extern NSString *kTextmate2Identifier;
 extern NSString *kBBEditIdentifier;


### PR DESCRIPTION
The bundle identifiers for both VSCode and VSCode Insiders (beta builds) were already present but only the VSCode non-Insiders was used in the ⌘-click open logic. This adds the Insiders bundle ID to be handled the same way as standard VSCode.

Fixes [issue 11236](https://gitlab.com/gnachman/iterm2/-/issues/11236).