### PR TITLE
Add dark appearance support for AI setup image

### DIFF
--- a/sources/AITerm.xib
+++ b/sources/AITerm.xib
@@ -8,6 +8,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="AITermRegistrationWindowController" customModule="iTerm2SharedARC">
             <connections>
+                <outlet property="image" destination="c9k-v5-1fv" id="2yA-Rk-cUD"/>
+                <outlet property="imageView" destination="c9k-v5-1fv" id="rxi-ty-HwY"/>
                 <outlet property="message" destination="VK8-MA-zGT" id="zuV-gQ-H06"/>
                 <outlet property="okButton" destination="rr2-ko-uv8" id="3zU-qh-OrI"/>
                 <outlet property="textField" destination="5Sq-ah-i4Z" id="Lvm-Xp-jPr"/>


### PR DESCRIPTION
This adds support for a dark appearance image, there's probably a better way of achieving this but there didn't seem to be assets available to add to.

Before and after:
<img src="https://github.com/gnachman/iTerm2/assets/2276355/48c53665-5e53-492f-bb5a-79fbf9694c01" width="45%"> <img src="https://github.com/gnachman/iTerm2/assets/2276355/ceb1ea26-9663-49c8-9167-90b2abdc2928" width="45%">
