### PR TITLE
Optionally disable Cmd-Click opening Command Info

### DIFF
--- a/sources/PTYTextView.m
+++ b/sources/PTYTextView.m
@@ -5875,7 +5875,8 @@ scrollToFirstResult:(BOOL)scrollToFirstResult
 
 - (void)mouseHandlerOpenTargetWithEvent:(NSEvent *)event
                            inBackground:(BOOL)inBackground {
-    if ([self showCommandInfoForEvent:event]) {
+    if ([iTermAdvancedSettingsModel enableCmdClickPromptForShowCommandInfo]
+        && [self showCommandInfoForEvent:event]) {
         return;
     }
     [_urlActionHelper openTargetWithEvent:event inBackground:inBackground];

--- a/sources/iTermAdvancedSettingsModel.h
+++ b/sources/iTermAdvancedSettingsModel.h
@@ -136,6 +136,7 @@ extern NSString *const iTermAdvancedSettingsDidChange;
 + (double)echoProbeDuration;
 + (void)setEchoProbeDuration:(double)value;
 + (BOOL)enableCharacterAccentMenu;
++ (BOOL)enableCmdClickPromptForShowCommandInfo;
 
 #if ITERM2_SHARED_ARC
 + (BOOL)enableSecureKeyboardEntryAutomatically;

--- a/sources/iTermAdvancedSettingsModel.m
+++ b/sources/iTermAdvancedSettingsModel.m
@@ -326,6 +326,7 @@ DEFINE_BOOL(stealKeyFocus, NO, SECTION_MOUSE @"When Focus Follows Mouse is enabl
 DEFINE_BOOL(aggressiveFocusFollowsMouse, NO, SECTION_MOUSE @"When Focus Follows Mouse is enabled, activate the window under the cursor when iTerm2 becomes active?");
 DEFINE_BOOL(cmdClickWhenInactiveInvokesSemanticHistory, NO, SECTION_MOUSE @"⌘-click in an active pane while iTerm2 isn't the active app invokes Semantic History.\nBy default, iTerm2 respects the OS standard that ⌘-click in an app that doesn't have keyboard focus behaves like a non-⌘ click that does not raise the window.");
 DEFINE_BOOL(enableUnderlineSemanticHistoryOnCmdHover, YES, SECTION_MOUSE @"Underline Semantic History-selectable items under the cursor while holding ⌘?");
+DEFINE_BOOL(enableCmdClickPromptForShowCommandInfo, YES, SECTION_MOUSE @"⌘-click in the prompt shows the Command Info window");
 DEFINE_BOOL(sensitiveScrollWheel, NO, SECTION_MOUSE @"Scroll on any scroll wheel movement, no matter how small?");
 DEFINE_FLOAT(scrollWheelAcceleration, 1, SECTION_MOUSE @"Speed up scroll gestures by this factor.");
 

--- a/sources/iTermURLActionFactory.m
+++ b/sources/iTermURLActionFactory.m
@@ -309,6 +309,9 @@ static NSMutableArray<iTermURLActionFactory *> *sFactories;
 #pragma mark - Sub-factories
 
 - (URLAction *)urlActionForPrompt {
+    if (![iTermAdvancedSettingsModel enableCmdClickPromptForShowCommandInfo]) {
+        return nil;
+    }
     VT100GridWindowedRange range = { 0 };
     id<VT100ScreenMarkReading> mark = [self.extractor.dataSource commandMarkAt:self.coord range:&range];
     if (!mark || mark.promptRange.start.x < 0 || !mark.command) {


### PR DESCRIPTION
This adds an advanced setting which defaults to the current behaviour, but when switched off, disables the feature that Cmd-Click in a prompt opens the Command Info window. The Cmd-Click instead falls back to Smart Selection. The window can still be accessed via right click as normal.