### PR TITLE
Display correct window restoration instructions for macOS 14

### DIFF
--- a/sources/GeneralPreferencesViewController.m
+++ b/sources/GeneralPreferencesViewController.m
@@ -816,7 +816,7 @@ enum {
     NSString *message;
     NSString *action;
     NSString *path;
-    if (@available(macOS 13, *)) {
+    if (@available(macOS 13, *) || @available(macOS 14, *)) {
         message = @"System window restoration has been disabled, which prevents iTerm2 from respecting this setting. Disable ”System Settings > Desktop & Dock > Close windows when quitting an application“ to enable window restoration.";
         action = @"Open System Settings";
         path = @"/System/Library/PreferencePanes/Dock.prefPane";


### PR DESCRIPTION
TL;DR: I believe the "Window Restoration" help window has the outdated text for macOS 14, but not macOS 13.

---

I don't have much (any) experience with Objective-C or Apple app dev, so apologies ahead of time if I'm way off base with anything:

I noticed on my Mac Book (macOS 14.3 (I know I need to update)) that the "Window Restoration Disabled" help window references `System Preferences > General > ...`. Which, based on conditional, should be `Desktop & Dock` for macOS `>= 13`.

I'm guessing https://github.com/gnachman/iTerm2/commit/f5617a1089541f1bdcb4edcbbfec54a492304188#diff-3a2c028b85d15b2ff41c606edba92e67d8e1fd252936a12ee185ed859005c809R779 was "reverted" since the message was incorrect for macOS 13, after the change to 14. 

So I'm further guessing `@available(macOS 13, *)` behaves more like `ver < 14 && ver >= 13.0.0` or `ver ~> 13.0` instead of just `ver >= 13.0.0` or `ver ~> 13`. 

So I just extended the conditional to include `macOS 14`, to see if that fixes it.

I haven't tried building it myself yet, so sorry for submitting before testing, but hoping to try in the next morning when I have a moment. But figured on the off-chance the small change is correct, can at least post.

![Screenshot 2024-05-02 at 11 34 56 PM](https://github.com/gnachman/iTerm2/assets/3777891/88ec96f0-cdb7-44d0-9092-bcde2e151fb5)

![Screenshot 2024-05-02 at 11 44 25 PM](https://github.com/gnachman/iTerm2/assets/3777891/78665905-da27-48de-92d1-0cb0b3fcfb5d)
