### PR TITLE
Fix horizontal scrolling in preferences

### DIFF
--- a/sources/ProfilePreferencesViewController.m
+++ b/sources/ProfilePreferencesViewController.m
@@ -219,6 +219,10 @@ NSString *const kProfileSessionHotkeyDidChange = @"kProfileSessionHotkeyDidChang
             [flippedView addSubview:view];
             [flippedView flipSubviews];
 
+            NSScroller *verticalScroller = [scrollView verticalScroller];
+            CGFloat scrollbarWidth = NSWidth([verticalScroller frame]);
+            flippedView.frame = NSMakeRect(flippedView.frame.origin.x, flippedView.frame.origin.y, view.frame.size.width - scrollbarWidth, flippedView.frame.size.height);
+
             [scrollView setDocumentView:flippedView];
             [sizeRememberingView addSubview:scrollView];
 


### PR DESCRIPTION
This prevents the instances of `NSScrollView` under Preferences > Profiles (General, Terminal, Advanced) from being able to be horizontally elastically scrolled. This is achieved by subtracting the width of the scroll bar from the view.

This related code only prevents the animation:
`scrollView.horizontalScrollElasticity = NSScrollElasticityNone;`