### PR TITLE
Fix typo in custom command `displayName`

### DIFF
--- a/sources/ProfilesGeneralPreferencesViewController.m
+++ b/sources/ProfilesGeneralPreferencesViewController.m
@@ -253,7 +253,7 @@ static NSString *const iTermProfilePreferencesUpdateSessionName = @"iTermProfile
 
     info = [self defineControl:_customCommand
                            key:KEY_COMMAND_LINE
-                   displayName:@"Profile custom ommand"
+                   displayName:@"Profile custom command"
                           type:kPreferenceInfoTypeStringTextField];
     info.shouldBeEnabled = ^BOOL {
         __strong __typeof(weakSelf) strongSelf = self;


### PR DESCRIPTION
This typo isn't visible in the UI, but shows up when searching the preferences pane:

<img width="1132" alt="Screenshot 2024-05-29 at 9 44 19 AM" src="https://github.com/gnachman/iTerm2/assets/745333/329a14d3-7924-4c2f-a24d-fe0c61487fc0">
