### PR TITLE
Fix dash in fish_prompt in iterm2_shell_integration.fish

### DIFF
--- a/Resources/shell_integration/iterm2_shell_integration.fish
+++ b/Resources/shell_integration/iterm2_shell_integration.fish
@@ -102,7 +102,7 @@ if begin; status --is-interactive; and not functions -q -- iterm2_status; and te
       # Remove the trailing newline from the original prompt. This is done
       # using the string builtin from fish, but to make sure any escape codes
       # are correctly interpreted, use %b for printf.
-      printf "%b" (string join "\n" (iterm2_fish_prompt))
+      printf "%b" (string join "\n" -- (iterm2_fish_prompt))
 
       iterm2_prompt_end
     end

--- a/Resources/shell_integration/iterm2_shell_integration.fish
+++ b/Resources/shell_integration/iterm2_shell_integration.fish
@@ -90,7 +90,7 @@ if begin; status --is-interactive; and not functions -q -- iterm2_status; and te
       # Remove the trailing newline from the original prompt. This is done
       # using the string builtin from fish, but to make sure any escape codes
       # are correctly interpreted, use %b for printf.
-      printf "%b" (string join "\n" (iterm2_fish_prompt))
+      printf "%b" (string join "\n" -- (iterm2_fish_prompt))
 
       iterm2_prompt_end
     end


### PR DESCRIPTION
Fixed string join in the `fish_prompt` function in the `iterm2_shell_integration.fish` shell script interpreting a dash character contained in the Fish prompt as a command option.

# Issue

When the Fish prompt returned by the function `iterm2_fish_prompt` contains a dash character, the command `string join "\n" (iterm2_fish_prompt)` interprets it as a command option. Therefore it sets an unexpected option or fails with an error like the following:

```
string join: -----: unknown option

~/.shell/iterm2_shell_integration.fish (line 1):
string join "\n" (iterm2_fish_prompt)
^
in command substitution
	called on line 93 of file ~/.shell/iterm2_shell_integration.fish
in function 'fish_prompt'
in command substitution
```

# Fix

Added the "end of options" option (`--`) to the `string join` command just before the `iterm2_fish_prompt` so it cannot be interpreted as another option:

```shell
string join "\n" -- (iterm2_fish_prompt)
```

The whole command now looks like this:

```shell
printf "%b" (string join "\n" -- (iterm2_fish_prompt))
```