### PR TITLE
Correct misspelling of 'session'

### DIFF
--- a/api/library/python/iterm2/docs/examples/current_preset.rst
+++ b/api/library/python/iterm2/docs/examples/current_preset.rst
@@ -6,7 +6,7 @@ Get Selected Color Preset
 =========================
 
 This script prints to stdout the name of the color preset the current
-sesssion is using, or `None` if none of them matches.
+session is using, or `None` if none of them matches.
 
 To see the output you can either run `pip3 install iterm2` and then execute
 this script from the command line or run it from the **Scripts** menu and view

--- a/sources/iTermEditKeyActionWindowController.m
+++ b/sources/iTermEditKeyActionWindowController.m
@@ -479,7 +479,7 @@ const CGFloat sideMarginWidth = 40;
     (void)[_comboView selectItemWithTag:self.action];
 
     _applyButton = [[NSPopUpButton alloc] initWithFrame:NSZeroRect pullsDown:NO];
-    [_applyButton addItemWithTitle:@"Apply to current sesssion"];
+    [_applyButton addItemWithTitle:@"Apply to current session"];
     _applyButton.menu.itemArray.lastObject.tag = iTermActionApplyModeCurrentSession;
     [_applyButton addItemWithTitle:@"Apply to all sessions"];
     _applyButton.menu.itemArray.lastObject.tag = iTermActionApplyModeAllSessions;
@@ -487,7 +487,7 @@ const CGFloat sideMarginWidth = 40;
     _applyButton.menu.itemArray.lastObject.tag = iTermActionApplyModeUnfocusedSessions;
     [_applyButton addItemWithTitle:@"Apply to all sessions in window"];
     _applyButton.menu.itemArray.lastObject.tag = iTermActionApplyModeAllInWindow;
-    [_applyButton addItemWithTitle:@"Apply to all sesssions in tab"];
+    [_applyButton addItemWithTitle:@"Apply to all sessions in tab"];
     _applyButton.menu.itemArray.lastObject.tag = iTermActionApplyModeAllInTab;
     [_applyButton addItemWithTitle:@"Apply to broadcasted-to sessions"];
     _applyButton.menu.itemArray.lastObject.tag = iTermActionApplyModeBroadcasting;

--- a/sources/iTermOpenQuicklyModel.m
+++ b/sources/iTermOpenQuicklyModel.m
@@ -164,7 +164,7 @@ static const double kProfileNameMultiplierForWindowItem = 0.08;
     return term.window.title ?: @"";
 }
 
-// Returns a function PTYSession -> (Feature name, Feature value) that gives the value which most distinguishes sesssions from one another.
+// Returns a function PTYSession -> (Feature name, Feature value) that gives the value which most distinguishes sessions from one another.
 - (iTermTuple<NSString *, NSString *> *(^)(PTYSession *))detailFunctionForSessions:(NSArray<PTYSession *> *)sessions {
     iTermTuple<NSString *, NSString *> *(^pwd)(PTYSession *) = ^iTermTuple<NSString *, NSString *> *(PTYSession *session) {
         return [iTermTuple tupleWithObject:@"Directory" andObject:session.variablesScope.path];


### PR DESCRIPTION
Two changes are to comments, but the others appear in Settings/Shortcuts when you add an action and select 'Alert on Next Mark'. "session" is misspelled "sesssion".

![Screenshot 2024-11-04 at 9 58 08 AM](https://github.com/user-attachments/assets/a740982a-1e34-4315-a64c-a3bed6508536)

![Screenshot 2024-11-04 at 9 59 27 AM](https://github.com/user-attachments/assets/554f5be8-f2d4-447e-8143-a23114be61cc)
