### PR TITLE
Use legacy connect method from websockets

### DIFF
--- a/api/library/python/iterm2/iterm2/connection.py
+++ b/api/library/python/iterm2/iterm2/connection.py
@@ -16,6 +16,7 @@ gDisconnectCallbacks = []
 try:
   import websockets.legacy.client
   websockets_client = websockets.legacy.client
+  from websockets.legacy.client import connect
 except:
   websockets_client = websockets.client
 
@@ -361,7 +362,7 @@ class Connection:
 
     def _get_tcp_connect_coro(self):
         """Legacy: connect with tcp socket."""
-        return websockets.connect(_uri(),
+        return connect(_uri(),
                                         ping_interval=None,
                                         extra_headers=_headers(),
                                         subprotocols=_subprotocols())


### PR DESCRIPTION
I wanted to look at the Python API for iterm2; and I tried to use the first sample script from [the documentation](https://iterm2.com/python-api/tutorial/example.html).  However, this script unexpectedly crashed:

```
Traceback (most recent call last):
  File "/Users/roberj15/bin/test.py", line 13, in <module>
    iterm2.run_until_complete(main)
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/Users/roberj15/venv14.1/lib/python3.13/site-packages/iterm2/connection.py", line 506, in run_until_complete
    return Connection().run_until_complete(coro, retry, debug)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/Users/roberj15/venv14.1/lib/python3.13/site-packages/iterm2/connection.py", line 154, in run_until_complete
    return self.run(False, coro, retry, debug)
           ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/roberj15/venv14.1/lib/python3.13/site-packages/iterm2/connection.py", line 239, in run
    result = loop.run_until_complete(self.async_connect(async_main, retry))
  File "/usr/local/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/asyncio/base_events.py", line 721, in run_until_complete
    return future.result()
           ~~~~~~~~~~~~~^^
  File "/Users/roberj15/venv14.1/lib/python3.13/site-packages/iterm2/connection.py", line 414, in async_connect
    async with self._get_connect_coro() as websocket:
               ~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/roberj15/venv14.1/lib/python3.13/site-packages/websockets/asyncio/client.py", line 485, in __aenter__
    return await self
           ^^^^^^^^^^
  File "/Users/roberj15/venv14.1/lib/python3.13/site-packages/websockets/asyncio/client.py", line 442, in __await_impl__
    self.connection = await self.create_connection()
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/roberj15/venv14.1/lib/python3.13/site-packages/websockets/asyncio/client.py", line 368, in create_connection
    _, connection = await loop.create_connection(factory, **kwargs)
                          ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
TypeError: BaseEventLoop.create_connection() got an unexpected keyword argument 'extra_headers'
```

A quick google search implies that recent Python WebSockets (>14) has changed the way connect works; this PR is a blatant copy of [a fix in homeaticip that Google showed me](https://github.com/hahn-th/homematicip-rest-api/commit/3b88e61a3386d2f267d576d7342d20b102490353), which uses the legacy client 'connect' function; but refactored for the iterm2 module's "connection.py" file.

This legacy 'connect' fixes the above crash when using Python websockets > 14.