### PR TITLE
Fix memory leak in metalGetGlyphKeysData

### DIFF
--- a/sources/iTermMetalPerFrameState.m
+++ b/sources/iTermMetalPerFrameState.m
@@ -1676,9 +1676,7 @@ static int iTermEmitGlyphsAndSetAttributes(iTermMetalPerFrameState *self,
             attributes[_cursorInfo.coord.x].foregroundColor.w = 1;
         }
     }
-    if (bidiInfo) {
-        CTVectorDestroy(&positions);
-    }
+    CTVectorDestroy(&positions);
 }
 
 - (BOOL)useThinStrokesWithAttributes:(iTermMetalGlyphAttributes *)attributes {


### PR DESCRIPTION
This commit fixes a leak in metalGetGlyphKeysData due to the `positions` vector, which is always allocated, only being freed when the `bidiInfo` argument is not null. The fix is to always free the `positions` vector.

https://gitlab.com/gnachman/iterm2/-/issues/12029