### PR TITLE
Fixed powerline pdf glyph rendering

### DIFF
--- a/sources/iTermBoxDrawingBezierCurveFactory.m
+++ b/sources/iTermBoxDrawingBezierCurveFactory.m
@@ -555,7 +555,6 @@ offset:(CGPoint)offset {
                   color:(CGColorRef)color
             antialiased:(BOOL)antialiased 
                  offset:(CGPoint)offset {
-    
     NSImage *image = [self imageForPDFNamed:pdfName
                                    cellSize:cellSize
                                 antialiased:antialiased
@@ -646,7 +645,7 @@ color:(NSColor *)color {
     [self drawPDFWithName:name
                   options:(iTermPowerlineDrawingOptions)options.unsignedIntegerValue
                  cellSize:adjustedCellSize
-                  stretch:NO
+                  stretch:YES
                     color:color
               antialiased:YES
                    offset:offset];

--- a/sources/iTermBoxDrawingBezierCurveFactory.m
+++ b/sources/iTermBoxDrawingBezierCurveFactory.m
@@ -496,20 +496,34 @@ offset:(CGPoint)offset {
 
     NSString *path = [[NSBundle bundleForClass:self] pathForResource:pdfName ofType:@"pdf"];
     NSImage *image;
+    NSImageRep *imageRep;
+    
     if (path) {
         NSData* pdfData = [NSData dataWithContentsOfFile:path];
-        NSPDFImageRep *pdfImageRep = [NSPDFImageRep imageRepWithData:pdfData];
-        image = [[NSImage alloc] initWithSize:NSMakeSize(cellSize.width * 2,
-                                                         cellSize.height * 2)];
-        [image addRepresentation:pdfImageRep];
+        imageRep = [NSPDFImageRep imageRepWithData:pdfData];
     } else {
         path = [[NSBundle bundleForClass:self] pathForResource:pdfName ofType:@"eps"];
         NSData *data = [NSData dataWithContentsOfFile:path];
-        NSEPSImageRep *epsImageRep = [NSEPSImageRep imageRepWithData:data];
-        image = [[NSImage alloc] initWithSize:NSMakeSize(cellSize.width * 2,
-                                                         cellSize.height * 2)];
-        [image addRepresentation:epsImageRep];
+        imageRep = [NSEPSImageRep imageRepWithData:data];
     }
+
+    double cellProportion = cellSize.width / cellSize.height;
+    double imageProportion = imageRep.size.width / imageRep.size.height;
+
+    int cellWidth;
+    int cellHeight;
+    if (imageProportion > cellProportion) { // the image is wider than the cell
+        cellWidth = cellSize.width * 2;
+        cellHeight = cellWidth * imageRep.size.height / imageRep.size.width;
+    } else {
+        cellHeight = cellSize.height * 2;
+        cellWidth = cellHeight * imageRep.size.width / imageRep.size.height;
+    }
+    
+    image = [[NSImage alloc] initWithSize:NSMakeSize(cellWidth,
+                                                     cellHeight)];
+    [image addRepresentation:imageRep];
+
     return image;
 }
 
@@ -541,6 +555,7 @@ offset:(CGPoint)offset {
                   color:(CGColorRef)color
             antialiased:(BOOL)antialiased 
                  offset:(CGPoint)offset {
+    
     NSImage *image = [self imageForPDFNamed:pdfName
                                    cellSize:cellSize
                                 antialiased:antialiased


### PR DESCRIPTION
Hello.

Some time ago the builtin powerline glyph rendering was broken and the glyphs are rendered full-size even when the scaled option is set to NO.

I couldn't find the commit that actually broke the rendering but I could fix it so that the glyphs render correctly again.

The before-after image:
![iterm-pr-demo](https://github.com/user-attachments/assets/8f4ed201-b0b8-4834-8b37-2bc46511b45a)

P.S. Thank you for the awesome terminal! :)