### PR TITLE
fix: Python examples doc line break

### DIFF
--- a/api/library/python/iterm2/docs/examples/index.rst
+++ b/api/library/python/iterm2/docs/examples/index.rst
@@ -96,6 +96,7 @@ Here are a collection of working scripts for you to crib from. While they are ca
 :doc:`set_title_forever` — Demonstrates setting a session's name. Also demonstrates a script that's meant to be run from the command line that will launch iTerm2 and wait until it's able to connect before proceeding.
 
 :doc:`launch_and_run` — Demonstrates launching iTerm2 from the command line (if needed) and creating a new window that runs a command.
+
 :doc:`runcommand` — Demonstrates running a command and capturing its output.
 
 ----


### PR DESCRIPTION
This PR fixes the line break in the Python Examples doc. Please see below:

<img width="772" alt="image" src="https://github.com/user-attachments/assets/18e4c08b-2515-4fa0-83ba-3d01dcb3660a" />
