### PR TITLE
Fix maximizing window on title bar double click when system-wide action is set to "Fill"

### DIFF
--- a/sources/NSWindow+iTerm.m
+++ b/sources/NSWindow+iTerm.m
@@ -24,7 +24,7 @@ void *const iTermDeclineFirstResponderAssociatedObjectKey = (void *)"iTermDeclin
         [self performMiniaturize:nil];
         return;
     }
-    if (doubleClickAction == nil || [doubleClickAction isEqualToString:@"Maximize"]) {
+    if (doubleClickAction == nil || [doubleClickAction isEqualToString:@"Maximize"] || [doubleClickAction isEqualToString:@"Fill"]) {
         [self performZoom:nil];
         return;
     }


### PR DESCRIPTION
In macOS Sequoia, there’s a new feature that allows users to double-click a window's title bar to make the window fill the screen (rather than just "zoom" it as in older macOS versions).
<img width="827" alt="Screenshot 2025-05-26 at 16 22 12" src="https://github.com/user-attachments/assets/117b4d92-a7ce-4d9b-9514-873856290d0d" />

However, when this option is selected, the double-click title bar to maximize feature in iTerm2 stops working. This PR fixes that by checking whether the `AppleActionOnDoubleClick` system-wide user default maybe contains the new "Fill" option when deciding what to do after a title bar double-click.