### PR TITLE
fix parse error while using third-party llm api

### DIFF
--- a/sources/LLMModernProtocol.swift
+++ b/sources/LLMModernProtocol.swift
@@ -172,9 +172,9 @@ struct CompletionsMessage: Codable, Equatable {
 struct LLMModernResponseParser: LLMResponseParser {
     struct ModernResponse: Codable, LLM.AnyResponse {
         var isStreamingResponse: Bool { false }
-        var id: String
-        var object: String
-        var created: Int
+        var id: String?
+        var object: String?
+        var created: Int?
         var model: String?
         var choices: [Choice]
         var usage: Usage?  // see issue 12134

--- a/sources/LegacyOpenAI.swift
+++ b/sources/LegacyOpenAI.swift
@@ -34,10 +34,10 @@ struct LegacyBodyRequestBuilder {
 struct LLMLegacyResponseParser: LLMResponseParser {
     struct LegacyResponse: Codable, LLM.AnyResponse {
         var isStreamingResponse: Bool { false }
-        var id: String
-        var object: String
-        var created: Int
-        var model: String
+        var id: String?
+        var object: String?
+        var created: Int?
+        var model: String?
         var choices: [Choice]
         var usage: Usage?
 


### PR DESCRIPTION
While using qwen2.5-max

```
Failed to decode API response: keyNotFound(CodingKeys(stringValue: "id", intValue: nil), Swift.DecodingError.Context(codingPath: [], debugDescription: "No value associated with key CodingKeys(stringValue: \"id\", intValue: nil) (\"id\").", underlyingError: nil)). Data is: {"choices":[{"message":{"role":"assistant","content":"echo Hello"},"index":0,"finish_reason":"stop"}],"usage":{"completion_tokens":6,"prompt_tokens":48,"total_tokens":54,"cache_creation_input_tokens":null,"cache_read_input_tokens":null}}
```