### PR TITLE
Add "Move Tab to New Window" menu item

### DIFF
--- a/Interfaces/MainMenu.xib
+++ b/Interfaces/MainMenu.xib
@@ -1579,6 +1579,12 @@ DQ
                                                             <action selector="moveTabLeft:" target="-1" id="1410"/>
                                                         </connections>
                                                     </menuItem>
+                                                    <menuItem title="Move Tab to New Window" keyEquivalent="t" identifier="Move Tab to New Window" id="5Oz-oa-SHX">
+                                                        <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="moveTabToNewWindow:" target="-1" id="eLK-fH-7Oo"/>
+                                                        </connections>
+                                                    </menuItem>
                                                     <menuItem title="Move Tab Right" keyEquivalent="]" identifier="Move Tab Right" id="1408">
                                                         <modifierMask key="keyEquivalentModifierMask" shift="YES" option="YES" command="YES"/>
                                                         <connections>

--- a/sources/PseudoTerminal.m
+++ b/sources/PseudoTerminal.m
@@ -10887,6 +10887,8 @@ typedef NS_ENUM(NSUInteger, iTermBroadcastCommand) {
                item.action == @selector(previousAnnotation:) ||
                item.action == @selector(clearBuffer:)) {
         return !self.currentSession.isBrowserSession;
+    } else if (item.action == @selector(moveTabToNewWindow:)) {
+        return [_contentView.tabView numberOfTabViewItems] > 1;
     }
 
     return result;


### PR DESCRIPTION
Adds a menu item to Window → Tab → Move Tab to move a tab to a new window. It calls the existing selector in PseudoTerminal that's used by the tab title contextual menu, but now that it's in the menu bar, there's a keyboard shortcut for it!

This action is similar to existing tab management menu items in Safari, Chrome, and others. (I also added a default shortcut that I *think* is commonly assigned by them, and didn't have any base conflicts in the default iTerm shortcuts that I could find?)

Also extended `validateMenuItem` to disable the item unless there's more than one tab in the active window.

(Been a minute since I mucked around on macOS! Let me know if there's anything I'm missing.)

## UI

Before | After
--- | ---
![before](https://github.com/user-attachments/assets/4a043612-ffc0-4956-bc65-a92b5cc2e420) | ![after](https://github.com/user-attachments/assets/a11b28d3-2978-40fa-8d74-f3cfa9c9b632)