### PR TITLE
Move Tab to New Window: conditionally enable the menu item

### DIFF
--- a/sources/PseudoTerminal.m
+++ b/sources/PseudoTerminal.m
@@ -10887,6 +10887,8 @@ typedef NS_ENUM(NSUInteger, iTermBroadcastCommand) {
                item.action == @selector(previousAnnotation:) ||
                item.action == @selector(clearBuffer:)) {
         return !self.currentSession.isBrowserSession;
+    } else if (item.action == @selector(moveTabToNewWindow:)) {
+        return [_contentView.tabView numberOfTabViewItems] > 1;
     }
 
     return result;


### PR DESCRIPTION
(A cherry-pick of 2fb1f24ff7417c33b2d08861ecbb39fc7329b3ca from https://github.com/gnachman/iTerm2/pull/521)

Enable "Move Tab to New Window" only when there's > 1 tab in the active window