### PR TITLE
Fix deadlock in whilePaused when re-entered via nested runloop

### DIFF
--- a/sources/TokenExecutor.swift
+++ b/sources/TokenExecutor.swift
@@ -409,6 +409,12 @@ private class TokenExecutorImpl {
     // Runs block synchronously while token executor is stopped.
     func whilePaused(_ block: () -> (), onExecutorQueue: Bool) {
         dispatchPrecondition(condition: .onQueue(.main))
+        if iTermGCD.joined {
+            // Already joined (likely re-entrant via a nested runloop). Avoid deadlock by reusing
+            // the existing join instead of creating a new one.
+            block()
+            return
+        }
         if gDebugLogging.boolValue { DLog("Incr pending pauses if \(iTermPreferences.maximizeThroughput())") }
         var unpauser = iTermPreferences.maximizeThroughput() ? nil : TokenExecutor.globalPause()
 


### PR DESCRIPTION
## Summary

Fixes a potential deadlock in `whilePaused` when re-entered via a nested runloop.

## The Problem

When `whilePaused` is called, the following sequence occurs:

1. Main queue schedules async block on mutation queue
2. Main queue waits on `sema2`
3. Mutation queue runs async block: signals `sema2`, sets `iTermGCD.joined = true`, waits on `sema`
4. Main queue receives `sema2`, runs the block parameter
5. Inside the block, `reallyPerformBlockWithJoinedThreads` sets `gPerformingJoinedBlock = true`

There is a window between steps 4 and 5 where `iTermGCD.joined` is true but `gPerformingJoinedBlock` is false. If code in step 4 triggers a nested runloop that causes another join attempt, the existing `gPerformingJoinedBlock` check will not catch it.

Without this fix, the nested `whilePaused` call would schedule another async block on the mutation queue and wait on a new semaphore. But the mutation queue is blocked waiting on `sema` from step 3, so the new async block never runs, and main queue waits forever—deadlock.

## The Fix

Check `iTermGCD.joined` at the start of `whilePaused`. If true, we are already in a joined state (mutation queue is paused), so just run the block directly and return. This complements the existing `gPerformingJoinedBlock` checks, providing defense-in-depth for the narrow window before that flag is set.
