### PR TITLE
Precompute fast-path eligibility for gang processing

### DIFF
--- a/ModernTests/VT100ScreenTests.swift
+++ b/ModernTests/VT100ScreenTests.swift
@@ -915,6 +915,427 @@ class VT100ScreenTests: XCTestCase {
         }
     }
 
+    // MARK: - Fast path eligibility tests
+
+    /// Helper that tests gang output with a state mutation that affects _fastPathEligible.
+    /// 1. Applies `setup` to force slow path, sends firstTokens, verifies output.
+    /// 2. Applies `restore` to re-enable fast path, sends secondTokens, verifies output.
+    /// The debug assertion in terminalAppendMixedAsciiGang: validates cache consistency.
+    private func gangTestWithSetup(
+        width: Int32 = 10,
+        height: Int32 = 4,
+        initialLines: [String] = [],
+        firstTokens: [String],
+        secondTokens: [String],
+        setup: @escaping (VT100ScreenMutableState) -> Void,
+        restore: @escaping (VT100ScreenMutableState) -> Void,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        // Compute expected output after setup + firstTokens via character-at-a-time
+        let expectedAfterSetup: String = {
+            let s = self.screen(width: width, height: height)
+            s.performBlock(joinedThreads: { _, ms, _ in ms!.maxScrollbackLines = 1000 })
+            appendLines(initialLines, screen: s)
+            s.performBlock(joinedThreads: { _, ms, _ in
+                setup(ms!)
+                for token in firstTokens {
+                    var i = token.startIndex
+                    while i < token.endIndex {
+                        let nl = token.range(of: "\r\n", range: i..<token.endIndex)
+                        if let nl {
+                            ms!.appendString(atCursor: String(token[i..<nl.lowerBound]))
+                            ms!.appendCarriageReturnLineFeed()
+                            i = nl.upperBound
+                        } else {
+                            ms!.appendString(atCursor: String(token[i..<token.endIndex]))
+                            i = token.endIndex
+                        }
+                    }
+                }
+            })
+            return s.compactLineDumpWithDividedHistoryAndContinuationMarks()
+        }()
+
+        // Compute expected output after restore + secondTokens via character-at-a-time
+        let expectedAfterRestore: String = {
+            let s = self.screen(width: width, height: height)
+            s.performBlock(joinedThreads: { _, ms, _ in ms!.maxScrollbackLines = 1000 })
+            appendLines(initialLines, screen: s)
+            s.performBlock(joinedThreads: { _, ms, _ in
+                setup(ms!)
+                for token in firstTokens {
+                    var i = token.startIndex
+                    while i < token.endIndex {
+                        let nl = token.range(of: "\r\n", range: i..<token.endIndex)
+                        if let nl {
+                            ms!.appendString(atCursor: String(token[i..<nl.lowerBound]))
+                            ms!.appendCarriageReturnLineFeed()
+                            i = nl.upperBound
+                        } else {
+                            ms!.appendString(atCursor: String(token[i..<token.endIndex]))
+                            i = token.endIndex
+                        }
+                    }
+                }
+                restore(ms!)
+                for token in secondTokens {
+                    var i = token.startIndex
+                    while i < token.endIndex {
+                        let nl = token.range(of: "\r\n", range: i..<token.endIndex)
+                        if let nl {
+                            ms!.appendString(atCursor: String(token[i..<nl.lowerBound]))
+                            ms!.appendCarriageReturnLineFeed()
+                            i = nl.upperBound
+                        } else {
+                            ms!.appendString(atCursor: String(token[i..<token.endIndex]))
+                            i = token.endIndex
+                        }
+                    }
+                }
+            })
+            return s.compactLineDumpWithDividedHistoryAndContinuationMarks()
+        }()
+
+        // Now test the gang path
+        let screen = self.screen(width: width, height: height)
+        screen.performBlock(joinedThreads: { _, ms, _ in ms!.maxScrollbackLines = 1000 })
+        appendLines(initialLines, screen: screen)
+
+        // Phase 1: setup + gang (should take slow path, assertion validates cache)
+        screen.performBlock(joinedThreads: { _, ms, _ in
+            setup(ms!)
+            ms!.terminalAppendMixedAsciiGang(firstTokens.map { self.makeMixedToken($0) })
+        })
+        let actualAfterSetup = screen.compactLineDumpWithDividedHistoryAndContinuationMarks()
+        XCTAssertEqual(actualAfterSetup, expectedAfterSetup,
+                       "After setup",
+                       file: file, line: line)
+
+        // Phase 2: restore + gang (should re-enable fast path, assertion validates cache)
+        screen.performBlock(joinedThreads: { _, ms, _ in
+            restore(ms!)
+            ms!.terminalAppendMixedAsciiGang(secondTokens.map { self.makeMixedToken($0) })
+        })
+        let actualAfterRestore = screen.compactLineDumpWithDividedHistoryAndContinuationMarks()
+        XCTAssertEqual(actualAfterRestore, expectedAfterRestore,
+                       "After restore",
+                       file: file, line: line)
+    }
+
+    func testGang_insertMode() {
+        gangTestWithSetup(
+            firstTokens: ["hello\r\nworld\r\n"],
+            secondTokens: ["back\r\n"],
+            setup: { $0.insert = true },
+            restore: { $0.insert = false }
+        )
+    }
+
+    func testGang_wraparoundModeOff() {
+        gangTestWithSetup(
+            firstTokens: ["hello\r\nworld\r\n"],
+            secondTokens: ["back\r\n"],
+            setup: { $0.wraparoundMode = false },
+            restore: { $0.wraparoundMode = true }
+        )
+    }
+
+    func testGang_ansiMode() {
+        gangTestWithSetup(
+            firstTokens: ["hello\r\nworld\r\n"],
+            secondTokens: ["back\r\n"],
+            setup: { $0.ansi = true },
+            restore: { $0.ansi = false }
+        )
+    }
+
+    func testGang_altBuffer() {
+        gangTestWithSetup(
+            firstTokens: ["hello\r\nworld\r\n"],
+            secondTokens: ["back\r\n"],
+            setup: { $0.showAltBuffer() },
+            restore: { $0.showPrimaryBuffer() }
+        )
+    }
+
+    func testGang_commandStartCoord() {
+        gangTestWithSetup(
+            firstTokens: ["hello\r\nworld\r\n"],
+            secondTokens: ["back\r\n"],
+            setup: { ms in
+                ms.setCoordinateOfCommandStart(VT100GridAbsCoord(x: 0, y: 0))
+            },
+            restore: { ms in
+                ms.setCommandStartCoordWithoutSideEffects(VT100GridAbsCoord(x: -1, y: 0))
+            }
+        )
+    }
+
+    func testGang_lineDrawingMode() {
+        gangTestWithSetup(
+            firstTokens: ["hello\r\nworld\r\n"],
+            secondTokens: ["back\r\n"],
+            setup: { $0.setCharacterSet(0, usesLineDrawingMode: true) },
+            restore: { $0.setCharacterSet(0, usesLineDrawingMode: false) }
+        )
+    }
+
+    func testGang_loggingEnabled() {
+        gangTestWithSetup(
+            firstTokens: ["hello\r\nworld\r\n"],
+            secondTokens: ["back\r\n"],
+            setup: { ms in
+                let config = VT100MutableScreenConfiguration()
+                config.loggingEnabled = true
+                ms.setConfig(config)
+            },
+            restore: { ms in
+                let config = VT100MutableScreenConfiguration()
+                config.loggingEnabled = false
+                ms.setConfig(config)
+            }
+        )
+    }
+
+    func testGang_publishing() {
+        gangTestWithSetup(
+            firstTokens: ["hello\r\nworld\r\n"],
+            secondTokens: ["back\r\n"],
+            setup: { ms in
+                let config = VT100MutableScreenConfiguration()
+                config.publishing = true
+                ms.setConfig(config)
+            },
+            restore: { ms in
+                let config = VT100MutableScreenConfiguration()
+                config.publishing = false
+                ms.setConfig(config)
+            }
+        )
+    }
+
+    func testGang_expectations() {
+        gangTestWithSetup(
+            firstTokens: ["hello\r\nworld\r\n"],
+            secondTokens: ["back\r\n"],
+            setup: { ms in
+                let expect = iTermExpect(dry: false)
+                _ = expect.expectRegularExpression("never_match_this_xyz",
+                                                   after: nil,
+                                                   deadline: nil,
+                                                   willExpect: nil,
+                                                   completion: nil)
+                ms.updateExpect(from: expect)
+            },
+            restore: { ms in
+                let expect = iTermExpect(dry: false)
+                ms.updateExpect(from: expect)
+            }
+        )
+    }
+
+    func testGang_printBuffer() {
+        // Print buffer mode redirects output to a buffer instead of the screen,
+        // so we can't use the standard reference-comparison helper. Instead we
+        // verify the cache assertion doesn't fire and that screen output resumes
+        // correctly after leaving print buffer mode.
+        let screen = self.screen(width: 10, height: 4)
+        screen.performBlock(joinedThreads: { _, ms, _ in
+            ms!.maxScrollbackLines = 1000
+        })
+
+        // Enter print buffer mode, send a gang (should take slow path, assertion validates cache)
+        screen.performBlock(joinedThreads: { _, ms, _ in
+            ms!.terminalBeginRedirectingToPrintBuffer()
+            ms!.terminalAppendMixedAsciiGang(["hello\r\nworld\r\n"].map { self.makeMixedToken($0) })
+        })
+        // Nothing should appear on screen since output went to print buffer
+        let afterPrint = screen.compactLineDumpWithDividedHistoryAndContinuationMarks()!
+        XCTAssert(!afterPrint.contains("hello"),
+                  "Print buffer output should not appear on screen: \(afterPrint)")
+
+        // Exit print buffer mode, send another gang (should re-enable fast path)
+        screen.performBlock(joinedThreads: { _, ms, _ in
+            ms!.terminalPrintBuffer()
+            ms!.terminalAppendMixedAsciiGang(["back\r\n"].map { self.makeMixedToken($0) })
+        })
+        // "back" should now appear on screen
+        let afterRestore = screen.compactLineDumpWithDividedHistoryAndContinuationMarks()!
+        XCTAssert(afterRestore.contains("back"),
+                  "Expected 'back' on screen after leaving print mode: \(afterRestore)")
+    }
+
+    func testGang_multipleConditions() {
+        gangTestWithSetup(
+            firstTokens: ["hello\r\nworld\r\n"],
+            secondTokens: ["back\r\n"],
+            setup: { ms in
+                ms.insert = true
+                ms.ansi = true
+                let config = VT100MutableScreenConfiguration()
+                config.publishing = true
+                ms.setConfig(config)
+            },
+            restore: { ms in
+                ms.insert = false
+                ms.ansi = false
+                let config = VT100MutableScreenConfiguration()
+                config.publishing = false
+                ms.setConfig(config)
+            }
+        )
+    }
+
+    func testGang_expectationConsumedByMatch() {
+        // Tests the P2 fix: when an expectation matches during trigger evaluation,
+        // it's removed from the expectations list, causing haveTriggersOrExpectations
+        // to flip false. The cache must be recomputed so subsequent gangs take the fast path.
+        //
+        // Flow:
+        // 1. Install expectation matching "hello" → _fastPathEligible becomes false
+        // 2. Gang "hello\r\n" → slow path, trigger eval matches and consumes expectation,
+        //    evaluateTriggers: recomputes _fastPathEligible → should become true
+        // 3. Gang "world\r\n" → assertion validates cache is true (no more expectations)
+        let screen = self.screen(width: 10, height: 4)
+        screen.performBlock(joinedThreads: { _, ms, _ in
+            ms!.maxScrollbackLines = 1000
+        })
+
+        // Install an expectation that matches "hello"
+        screen.performBlock(joinedThreads: { _, ms, _ in
+            let expect = iTermExpect(dry: false)
+            _ = expect.expectRegularExpression("hello",
+                                               after: nil,
+                                               deadline: nil,
+                                               willExpect: nil,
+                                               completion: nil)
+            ms!.updateExpect(from: expect)
+        })
+
+        // Send text that matches the expectation via the slow path.
+        // The slow path evaluates triggers, which matches and consumes the expectation.
+        // After evaluateTriggers: returns, _fastPathEligible should be recomputed to true.
+        screen.performBlock(joinedThreads: { _, ms, _ in
+            ms!.terminalAppendMixedAsciiGang(["hello\r\n"].map { self.makeMixedToken($0) })
+        })
+
+        // Send another gang. The debug assertion validates that _fastPathEligible
+        // matches _computeFastPathEligible (i.e., the cache was correctly updated
+        // when the expectation was consumed). If the P2 fix is missing, this assertion
+        // would fire because the cache would still say false while the computation
+        // would return true (no more expectations).
+        screen.performBlock(joinedThreads: { _, ms, _ in
+            ms!.terminalAppendMixedAsciiGang(["world\r\n"].map { self.makeMixedToken($0) })
+        })
+
+        let actual = screen.compactLineDumpWithDividedHistoryAndContinuationMarks()!
+        // Both "hello" and "world" should appear on the grid.
+        XCTAssert(actual.contains("hello"), "Expected 'hello' in grid: \(actual)")
+        XCTAssert(actual.contains("world"), "Expected 'world' in grid: \(actual)")
+    }
+
+    func testGang_expectationExpiredByDeadline() {
+        // Tests the self-healing recompute: when an expectation expires by deadline
+        // (not by matching), the cache goes stale because expiry is lazy (only checked
+        // when expectationsIsEmpty is queried). The self-healing recompute at the top
+        // of terminalAppendMixedAsciiGang: corrects this before the debug assertion.
+        let screen = self.screen(width: 10, height: 4)
+        screen.performBlock(joinedThreads: { _, ms, _ in
+            ms!.maxScrollbackLines = 1000
+        })
+
+        // Install an expectation with a deadline in the past
+        screen.performBlock(joinedThreads: { _, ms, _ in
+            let expect = iTermExpect(dry: false)
+            let pastDeadline = Date(timeIntervalSinceNow: -1)
+            _ = expect.expectRegularExpression("never_match_xyz",
+                                               after: nil,
+                                               deadline: pastDeadline,
+                                               willExpect: nil,
+                                               completion: nil)
+            ms!.updateExpect(from: expect)
+        })
+
+        // At this point _fastPathEligible is false (expectations present).
+        // The deadline has already passed but expiry hasn't been processed yet.
+        // The self-healing recompute in terminalAppendMixedAsciiGang: should
+        // detect the expiry and update the cache before the debug assertion.
+        screen.performBlock(joinedThreads: { _, ms, _ in
+            ms!.terminalAppendMixedAsciiGang(["hello\r\n"].map { self.makeMixedToken($0) })
+        })
+
+        // Send a second gang to confirm fast path is re-enabled after expiry.
+        screen.performBlock(joinedThreads: { _, ms, _ in
+            ms!.terminalAppendMixedAsciiGang(["world\r\n"].map { self.makeMixedToken($0) })
+        })
+
+        let actual = screen.compactLineDumpWithDividedHistoryAndContinuationMarks()!
+        XCTAssert(actual.contains("hello"), "Expected 'hello' in grid: \(actual)")
+        XCTAssert(actual.contains("world"), "Expected 'world' in grid: \(actual)")
+    }
+
+    func testGang_postTriggerActions() {
+        // Tests that _postTriggerActions going non-empty (via a prompt-detecting trigger)
+        // and then being drained (via executePostTriggerActions) correctly invalidates
+        // _fastPathEligible at both transitions.
+        //
+        // Key timing: in performBlock (not token executor), evaluateTriggers: calls
+        // executePostTriggerActions immediately after trigger eval. So the drain happens
+        // within the same gang call that fires the trigger. We verify by:
+        // 1. Gang with trigger match → actions queued AND drained in same call
+        // 2. Remove triggers
+        // 3. Gang "after\r\n" → assertion validates cache is consistent post-drain
+        // 4. Gang "verify\r\n" → second assertion confirms fast path re-enabled
+        let screen = self.screen(width: 10, height: 4)
+        screen.performBlock(joinedThreads: { _, ms, _ in
+            ms!.maxScrollbackLines = 1000
+        })
+
+        // Configure a prompt-detecting trigger that matches "prompt>"
+        let triggerDict: [String: Any] = [
+            "regex": "prompt>",
+            "action": "iTermShellPromptTrigger"
+        ]
+        screen.performBlock(joinedThreads: { _, ms, _ in
+            let config = VT100MutableScreenConfiguration()
+            config.triggerProfileDicts = [triggerDict]
+            ms!.setConfig(config)
+        })
+
+        // Send text matching the trigger. The slow path processes this:
+        // - terminalLineFeed → clearTriggerLine → evaluateTriggers:
+        //   - trigger matches → _postTriggerActions gets action → recompute (false)
+        //   - _tokenExecutor.isExecutingToken is false (performBlock context)
+        //   - executePostTriggerActions drains queue → recompute fires
+        // After this gang, _postTriggerActions is already empty again.
+        screen.performBlock(joinedThreads: { _, ms, _ in
+            ms!.terminalAppendMixedAsciiGang(["prompt>\r\n"].map { self.makeMixedToken($0) })
+        })
+
+        // Remove triggers so only _postTriggerActions state matters for eligibility.
+        screen.performBlock(joinedThreads: { _, ms, _ in
+            let config = VT100MutableScreenConfiguration()
+            config.triggerProfileDicts = []
+            ms!.setConfig(config)
+        })
+
+        // This gang validates the cache is consistent after the drain transition.
+        // The assertion checks _fastPathEligible matches _computeFastPathEligible.
+        screen.performBlock(joinedThreads: { _, ms, _ in
+            ms!.terminalAppendMixedAsciiGang(["after\r\n"].map { self.makeMixedToken($0) })
+        })
+
+        // A second gang confirms fast path eligibility is stable.
+        screen.performBlock(joinedThreads: { _, ms, _ in
+            ms!.terminalAppendMixedAsciiGang(["verify\r\n"].map { self.makeMixedToken($0) })
+        })
+
+        let actual = screen.compactLineDumpWithDividedHistoryAndContinuationMarks()!
+        XCTAssert(actual.contains("after"), "Expected 'after' in output: \(actual)")
+        XCTAssert(actual.contains("verify"), "Expected 'verify' in output: \(actual)")
+    }
+
     func testDropFirstBlock() {
         let screen = self.screen(width: 8, height: 8)
         session.configuration.maxScrollbackLines = 6

--- a/sources/VT100ScreenMutableState+Private.h
+++ b/sources/VT100ScreenMutableState+Private.h
@@ -57,6 +57,9 @@ iTermTriggerScopeProvider> {
     iTermKittyImageController *_kittyImageController;
     // When YES, terminal input is collected into printBuffer for ANSI print commands.
     BOOL _collectInputForPrinting;
+    // Precomputed fast-path eligibility. Recomputed at each state-mutation point.
+    // Access on mutation queue only
+    BOOL _fastPathEligible;
 }
 
 @property (atomic) BOOL hadCommand;
@@ -66,6 +69,9 @@ iTermTriggerScopeProvider> {
 // VT100ScreenMutableState objects (for example, when detaching in tmux mode).
 @property (class, atomic, readwrite) BOOL performingJoinedBlock;
 @property (nonatomic) BOOL allowNextReport;
+
+- (BOOL)_computeFastPathEligible;
+- (void)_recomputeFastPathEligible;
 
 - (iTermEventuallyConsistentIntervalTree *)mutableIntervalTree;
 - (iTermEventuallyConsistentIntervalTree *)mutableSavedIntervalTree;

--- a/sources/VT100ScreenMutableState+Resizing.m
+++ b/sources/VT100ScreenMutableState+Resizing.m
@@ -1371,7 +1371,7 @@ static void SwapInt(int *a, int *b) {
                    newTop:newTop
                  delegate:delegate];
     [altScreenLineBuffer endResizing];
-    self.commandStartCoord = [self startCoordOfCurrentCommand];
+    [self setCommandStartCoordWithoutSideEffects:[self startCoordOfCurrentCommand]];
     [self sanityCheckIntervalsFrom:oldSize note:@"post-hoc"];
     DLog(@"After:\n%@", [self.currentGrid compactLineDumpWithContinuationMarks]);
     DLog(@"Cursor at %d,%d", self.currentGrid.cursorX, self.currentGrid.cursorY);

--- a/sources/VT100ScreenMutableState+TerminalDelegate.m
+++ b/sources/VT100ScreenMutableState+TerminalDelegate.m
@@ -232,6 +232,12 @@ typedef struct {
 }
 
 - (void)terminalAppendMixedAsciiGang:(NSArray<VT100Token *> *)tokens {
+    // Self-healing recompute: catch staleness from lazy expiry of expectations
+    // (deadlines pass without notification). Only runs on the slow path so
+    // the fast path stays a single ivar read.
+    if (!_fastPathEligible) {
+        [self _recomputeFastPathEligible];
+    }
 #if DEBUG
     ITAssertWithMessage(_fastPathEligible == [self _computeFastPathEligible],
                         @"Stale _fastPathEligible: cached=%d computed=%d",

--- a/sources/VT100Terminal.m
+++ b/sources/VT100Terminal.m
@@ -547,8 +547,11 @@ static const int kMaxScreenRows = 4096;
 }
 
 - (void)setCharset:(int)charset {
-    self.dirty = YES;
-    _charset = charset;
+    if (_charset != charset) {
+        self.dirty = YES;
+        _charset = charset;
+        [_delegate terminalActiveCharsetDidChangeTo:charset];
+    }
 }
 
 - (void)setCursorMode:(BOOL)cursorMode {

--- a/sources/VT100TerminalDelegate.h
+++ b/sources/VT100TerminalDelegate.h
@@ -435,6 +435,7 @@ typedef NS_ENUM(NSUInteger, VT100TerminalProtectedMode) {
 - (void)terminalWraparoundModeDidChangeTo:(BOOL)newValue;
 - (void)terminalTypeDidChange;
 - (void)terminalInsertModeDidChangeTo:(BOOL)newValue;
+- (void)terminalActiveCharsetDidChangeTo:(int)charset;
 
 - (NSString *)terminalProfileName;
 


### PR DESCRIPTION
Summary                                                                                                           

- Cache fast-path eligibility as a boolean ivar (_fastPathEligible) instead of evaluating ~11 conditions on every gang processing call
- Invalidate the cache at each state-mutation point (mode changes, trigger updates, expectations, print buffer, etc.) with self-healing recompute for lazy expectation expiry
- Debug assertions validate cache consistency on every gang call
- 14 tests cover all invalidation paths
- Performance benchmarks for gang processing throughput

10 XCTest measure iterations x100 gang calls of 100 lines (10,000 lines per iteration, 1,000,000 lines total per test).
| Branch | Time |
|-----|-----|
| Master (inline checks) | 44.774s |
| Fastpath (cached boolean) | 3.679s  |