### PR TITLE
Zero-copy sync for single partial line blocks

### DIFF
--- a/ModernTests/LineBlockTests.swift
+++ b/ModernTests/LineBlockTests.swift
@@ -3146,27 +3146,9 @@ extension LineBlock {
     }
 }
 
-// MARK: - Incremental Merge Tests
+// MARK: - Zero-Copy Merge Tests
 
-class LineBlockIncrementalMergeTests: XCTestCase {
-
-    // Helper to create a partial-line block with given content
-    private func makePartialLineBlock(_ string: String, capacity: Int32 = 1024) -> LineBlock {
-        let block = LineBlock(rawBufferSize: capacity, absoluteBlockNumber: 0)
-        let lineString = makeLineString(string, eol: EOL_SOFT)
-        let result = block.appendLineString(lineString, width: Int32(80))
-        precondition(result, "Failed to append line string")
-        return block
-    }
-
-    // Helper to create a hard-line block (not partial)
-    private func makeHardLineBlock(_ string: String, capacity: Int32 = 1024) -> LineBlock {
-        let block = LineBlock(rawBufferSize: capacity, absoluteBlockNumber: 0)
-        let lineString = makeLineString(string, eol: EOL_HARD)
-        let result = block.appendLineString(lineString, width: Int32(80))
-        precondition(result, "Failed to append line string")
-        return block
-    }
+class LineBlockZeroCopyMergeTests: XCTestCase {
 
     // Helper to create a line string
     private func makeLineString(_ string: String,
@@ -3195,647 +3177,571 @@ class LineBlockIncrementalMergeTests: XCTestCase {
     }
 
     // Helper to append partial content to a block
-    private func appendPartial(_ string: String, to block: LineBlock) {
+    private func appendPartialASCII(_ block: LineBlock, _ string: String, width: Int32 = 80) {
         let lineString = makeLineString(string, eol: EOL_SOFT)
-        let result = block.appendLineString(lineString, width: Int32(80))
+        let result = block.appendLineString(lineString, width: width)
         precondition(result, "Failed to append partial line string")
     }
 
     // Helper to append hard line to a block
-    private func appendHardLine(_ string: String, to block: LineBlock) {
+    private func appendHardASCII(_ block: LineBlock, _ string: String, width: Int32 = 80) {
         let lineString = makeLineString(string, eol: EOL_HARD)
-        let result = block.appendLineString(lineString, width: Int32(80))
+        let result = block.appendLineString(lineString, width: width)
         precondition(result, "Failed to append hard line string")
     }
 
-    // MARK: - A. Eligibility Tests (canIncrementalMergeFromProgenitor)
+    // MARK: - A. Eligibility Tests (canZeroCopyMergeFromProgenitor)
 
-    func testCanIncrementalMerge_BasicEligibility() {
-        // Given: Original with partial line, copy made, then original appends partial
-        let original = makePartialLineBlock("abc")
-        let copy = original.cowCopy()
-        appendPartial("def", to: original)
+    func testCanZeroCopyMerge_BasicEligibility() {
+        // A single partial line block should be eligible after cowCopy + progenitor mutation.
+        let progenitor = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendPartialASCII(progenitor, "Hello")
 
-        // Then: Copy should be eligible for incremental merge
-        XCTAssertTrue(copy.canIncrementalMergeFromProgenitor)
+        let copy = progenitor.cowCopy()
+
+        // The progenitor must mutate to detach ownership from the copy.
+        appendPartialASCII(progenitor, "!")
+
+        XCTAssertTrue(copy.canZeroCopyMergeFromProgenitor(),
+                      "Single partial line block should be eligible for zero-copy merge")
     }
 
-    func testCanIncrementalMerge_IneligibleWhenNewLineAdded() {
-        // Given: Original with partial line, copy made, then original adds hard line
-        let original = makePartialLineBlock("abc")
-        let copy = original.cowCopy()
-        appendHardLine("def", to: original)
+    func testCanZeroCopyMerge_EligibleAfterAppend() {
+        // Appending more partial data to the progenitor should keep eligibility.
+        let progenitor = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendPartialASCII(progenitor, "Hello")
 
-        // Then: Copy should not be eligible (new line added, not partial append)
-        XCTAssertFalse(copy.canIncrementalMergeFromProgenitor)
+        let copy = progenitor.cowCopy()
+
+        // Append more data to the progenitor (triggers validMutationCertificate).
+        appendPartialASCII(progenitor, " World")
+
+        XCTAssertTrue(copy.canZeroCopyMergeFromProgenitor(),
+                      "Progenitor with partial-line appends should remain eligible")
     }
 
-    func testCanIncrementalMerge_IneligibleWhenLastLinePopped() {
-        // Given: Original with partial line, copy made, then original pops and appends
-        let original = makePartialLineBlock("abc")
-        let copy = original.cowCopy()
-        _ = original.popLastLine(width: 80)
-        appendPartial("xyz", to: original)
+    func testCanZeroCopyMerge_IneligibleWhenNewLineAdded() {
+        // Adding a new raw line to the progenitor should break eligibility.
+        let progenitor = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendPartialASCII(progenitor, "Hello")
 
-        // Then: Copy should not be eligible (pop is not append-only)
-        XCTAssertFalse(copy.canIncrementalMergeFromProgenitor)
+        let copy = progenitor.cowCopy()
+
+        // Complete the line and add a new one.
+        appendHardASCII(progenitor, " done")
+
+        XCTAssertFalse(copy.canZeroCopyMergeFromProgenitor(),
+                       "Should be ineligible after progenitor adds a new line")
     }
 
-    func testCanIncrementalMerge_IneligibleWhenNoProgenitor() {
-        // Given: A block with no progenitor
-        let block = makePartialLineBlock("abc")
+    func testCanZeroCopyMerge_IneligibleWhenNotPartial() {
+        // A complete (non-partial) single line should not be eligible.
+        let progenitor = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendHardASCII(progenitor, "Complete")
 
-        // Then: Should not be eligible (no progenitor)
-        XCTAssertFalse(block.canIncrementalMergeFromProgenitor)
+        let copy = progenitor.cowCopy()
+
+        XCTAssertFalse(copy.canZeroCopyMergeFromProgenitor(),
+                       "Should be ineligible when progenitor line is not partial")
     }
 
-    func testCanIncrementalMerge_IneligibleWhenProgenitorInvalidated() {
-        // Given: Original with partial line, copy made, then original invalidated
-        let original = makePartialLineBlock("abc")
-        let copy = original.cowCopy()
-        appendPartial("def", to: original)
-        original.invalidate()
+    func testCanZeroCopyMerge_IneligibleWhenNoProgenitor() {
+        // A block with no progenitor should not be eligible.
+        let block = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendPartialASCII(block, "Hello")
 
-        // Then: Copy should not be eligible (progenitor invalidated)
-        XCTAssertFalse(copy.canIncrementalMergeFromProgenitor)
+        XCTAssertFalse(block.canZeroCopyMergeFromProgenitor(),
+                       "Should be ineligible with no progenitor")
     }
 
-    func testCanIncrementalMerge_IneligibleWithMultipleRawLines() {
-        // Given: Block with multiple raw lines (even if last is partial)
-        let original = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
-        appendHardLine("line1", to: original)
-        appendPartial("line2", to: original)
+    func testCanZeroCopyMerge_IneligibleWhenBufferRelocated() {
+        // If the character buffer was relocated, zero-copy merge should be ineligible.
+        let progenitor = LineBlock(rawBufferSize: 16, absoluteBlockNumber: 0)
+        appendPartialASCII(progenitor, "Hi")
 
-        let copy = original.cowCopy()
-        appendPartial("more", to: original)
+        let copy = progenitor.cowCopy()
 
-        // Then: Should not be eligible (multiple raw lines)
-        XCTAssertFalse(copy.canIncrementalMergeFromProgenitor)
+        // Both should share the same buffer after cowCopy.
+        XCTAssertTrue(copy.sharesCharacterBuffer(with: progenitor))
+
+        // Force a resize that should relocate the buffer.
+        progenitor.changeBufferSize(1024 * 1024)
+
+        // Append to verify the mutation works.
+        appendPartialASCII(progenitor, "X")
+
+        // They still share the same iTermCharacterBuffer object (not cloned by zero-copy path).
+        XCTAssertTrue(copy.sharesCharacterBuffer(with: progenitor),
+                      "Buffer object should still be shared — zero-copy skips clone")
+
+        // But if the internal pointer was relocated, canZeroCopyMerge should detect it.
+        // On macOS, growing from 16 to 1M typically relocates.
+        // We can't assert on the result because realloc behavior is platform-specific,
+        // but we verify the flag is checked correctly by canZeroCopyMergeFromProgenitor.
     }
 
-    func testCanIncrementalMerge_IneligibleWhenNotPartial() {
-        // Given: Block with hard EOL line, copy made
-        let original = makeHardLineBlock("abc")
-        let copy = original.cowCopy()
+    // MARK: - B. Merge Mechanics
 
-        // Then: Should not be eligible (not partial)
-        XCTAssertFalse(copy.canIncrementalMergeFromProgenitor)
+    func testZeroCopyMerge_SharedBufferIdentity() {
+        // After cowCopy, the copy and progenitor should share the same buffer object.
+        let progenitor = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendPartialASCII(progenitor, "Hello")
+
+        let copy = progenitor.cowCopy()
+
+        XCTAssertTrue(copy.sharesCharacterBuffer(with: progenitor),
+                      "Copy and progenitor should share the same character buffer")
     }
 
-    func testCanIncrementalMerge_IneligibleWhenNoGrowth() {
-        // Given: Original with partial line, copy made, no append
-        let original = makePartialLineBlock("abc")
-        let copy = original.cowCopy()
+    func testZeroCopyMerge_BufferStaysSharedAfterAppend() {
+        // After appending to the progenitor, buffer should still be shared.
+        let progenitor = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendPartialASCII(progenitor, "Hello")
 
-        // Then: Should not be eligible (progenitor didn't grow)
-        XCTAssertFalse(copy.canIncrementalMergeFromProgenitor)
+        let copy = progenitor.cowCopy()
+
+        // Append more partial data (triggers validMutationCertificate with zero-copy path).
+        appendPartialASCII(progenitor, " World")
+
+        XCTAssertTrue(copy.sharesCharacterBuffer(with: progenitor),
+                      "Buffer should remain shared after partial-line append")
     }
 
-    // MARK: - B. Character Data Tests
+    func testZeroCopyMerge_CLLUpdatedCorrectly() {
+        // After zeroCopyMerge, the copy's content should reflect the progenitor's updates.
+        let progenitor = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendPartialASCII(progenitor, "Hello")
 
-    func testIncrementalMerge_CopiesOnlyDelta() {
-        // Given: Original with partial line "abc", copy made, then append "def"
-        let original = makePartialLineBlock("abc")
-        let copy = original.cowCopy()
-        appendPartial("def", to: original)
+        let copy = progenitor.cowCopy()
 
-        // When: Copy length before merge
-        XCTAssertEqual(copy.length(ofRawLine: 0), 3)
+        // Append more data to progenitor.
+        appendPartialASCII(progenitor, " World")
 
-        // And: Incremental merge
-        copy.incrementalMergeFromProgenitor()
+        // Perform zero-copy merge.
+        XCTAssertTrue(copy.canZeroCopyMergeFromProgenitor())
+        copy.zeroCopyMergeFromProgenitor()
 
-        // Then: Copy should have full content
-        XCTAssertEqual(copy.length(ofRawLine: 0), 6)
-        let content = copy.screenCharArray(forRawLine: 0).stringValue
-        XCTAssertEqual(content, "abcdef")
+        // The copy should now see the full content.
+        let rawLine = copy.screenCharArray(forRawLine: 0)
+        XCTAssertEqual(rawLine.stringValue.trimmingCharacters(in: CharacterSet(charactersIn: "\0")),
+                       "Hello World",
+                       "After zero-copy merge, copy should see updated content")
     }
 
-    func testIncrementalMerge_MultipleAppends() {
-        // Given: Original with "a", copy made, then multiple appends
-        let original = makePartialLineBlock("a")
-        let copy = original.cowCopy()
-        appendPartial("b", to: original)
-        appendPartial("c", to: original)
-        appendPartial("d", to: original)
+    func testZeroCopyMerge_MetadataUpdated() {
+        // Verify metadata is updated during zero-copy merge.
+        let progenitor = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendPartialASCII(progenitor, "Hello")
 
-        // When: Incremental merge
-        copy.incrementalMergeFromProgenitor()
+        let copy = progenitor.cowCopy()
 
-        // Then: Copy should have all appended content
-        XCTAssertEqual(copy.screenCharArray(forRawLine: 0).stringValue, "abcd")
+        appendPartialASCII(progenitor, " World")
+
+        copy.zeroCopyMergeFromProgenitor()
+
+        // Verify the copy has 1 raw line and it's partial.
+        XCTAssertEqual(copy.numRawLines(), 1)
+        XCTAssertTrue(copy.hasPartial())
     }
 
-    func testIncrementalMerge_BufferResize() {
-        // Given: Original with buffer large enough to hold all data
-        // The progenitor can grow, and the copy will resize its buffer during merge
-        let original = LineBlock(rawBufferSize: 200, absoluteBlockNumber: 0)
-        appendPartial("abc", to: original)
-        let copy = original.cowCopy()
+    func testZeroCopyMerge_CacheInvalidated() {
+        // After zero-copy merge, wrapped line cache should be invalidated.
+        let progenitor = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendPartialASCII(progenitor, "Hello", width: 4)
 
-        // Append more content to the progenitor
-        let largeAppend = String(repeating: "x", count: 100)
-        appendPartial(largeAppend, to: original)
+        let copy = progenitor.cowCopy()
 
-        // When: Incremental merge
-        copy.incrementalMergeFromProgenitor()
+        // The copy should have a cached numlines for width=4.
+        let linesBefore = copy.getNumLines(withWrapWidth: 4)
+        XCTAssertEqual(linesBefore, 2) // "Hello" wraps to 2 lines at width 4
 
-        // Then: Copy should have full content (buffer resized)
-        XCTAssertEqual(copy.length(ofRawLine: 0), 103)
+        // Append more data to progenitor.
+        appendPartialASCII(progenitor, "ABCD", width: 4)
+
+        // Merge.
+        copy.zeroCopyMergeFromProgenitor()
+
+        // The copy should now have more wrapped lines (cache was invalidated).
+        let linesAfter = copy.getNumLines(withWrapWidth: 4)
+        XCTAssertGreaterThan(linesAfter, linesBefore,
+                             "After merge with more data, wrapped line count should increase")
     }
 
-    // MARK: - C. Metadata Tests
+    // MARK: - C. Multi-cycle
 
-    func testIncrementalMerge_RTLFlagMerged() {
-        // Given: Original with non-RTL content, copy made, then append RTL content
-        let original = makePartialLineBlock("abc")
-        let copy = original.cowCopy()
+    func testZeroCopyMerge_MultipleMergeCycles() {
+        // Append -> merge -> append -> merge should work correctly.
+        let progenitor = LineBlock(rawBufferSize: 4096, absoluteBlockNumber: 0)
+        appendPartialASCII(progenitor, "A")
 
-        // Append with RTL flag
-        let rtlLineString = makeLineString("test", eol: EOL_SOFT, rtlFound: true)
-        _ = original.appendLineString(rtlLineString, width: Int32(80))
+        let copy = progenitor.cowCopy()
 
-        // When: Incremental merge
-        copy.incrementalMergeFromProgenitor()
+        // Cycle 1: append + merge
+        appendPartialASCII(progenitor, "B")
+        XCTAssertTrue(copy.canZeroCopyMergeFromProgenitor())
+        copy.zeroCopyMergeFromProgenitor()
 
-        // Then: Copy should have RTL flag set (verify by checking the raw line metadata)
-        // We check the metadata timestamp to verify the merge happened properly
-        let sca = copy.screenCharArray(forRawLine: 0)
-        XCTAssertNotNil(sca)
-        // After merge, the content should be "abctest"
-        XCTAssertEqual(sca.stringValue, "abctest")
+        let rawLine1 = copy.screenCharArray(forRawLine: 0)
+        XCTAssertTrue(rawLine1.stringValue.hasPrefix("AB"))
+
+        // Cycle 2: append + merge
+        appendPartialASCII(progenitor, "C")
+        XCTAssertTrue(copy.canZeroCopyMergeFromProgenitor(),
+                      "Should be eligible for second zero-copy merge cycle")
+        copy.zeroCopyMergeFromProgenitor()
+
+        let rawLine2 = copy.screenCharArray(forRawLine: 0)
+        XCTAssertTrue(rawLine2.stringValue.hasPrefix("ABC"))
+
+        // Cycle 3: append + merge
+        appendPartialASCII(progenitor, "D")
+        XCTAssertTrue(copy.canZeroCopyMergeFromProgenitor())
+        copy.zeroCopyMergeFromProgenitor()
+
+        let rawLine3 = copy.screenCharArray(forRawLine: 0)
+        XCTAssertTrue(rawLine3.stringValue.hasPrefix("ABCD"))
+
+        // Buffer should still be shared after all cycles.
+        XCTAssertTrue(copy.sharesCharacterBuffer(with: progenitor))
     }
 
-    // MARK: - D. Cache Invalidation Tests
-
-    func testIncrementalMerge_WrappedLineCacheInvalidated() {
-        // Given: Original with long partial line, copy made
-        let longString = String(repeating: "x", count: 100)
-        let original = makePartialLineBlock(longString)
-        let width: Int32 = 80
-
-        // Prime the cache
-        _ = original.getNumLines(withWrapWidth: width)
-        XCTAssertTrue(original.hasCachedNumLines(forWidth: width))
-
-        let copy = original.cowCopy()
-
-        // Append more content
-        appendPartial(String(repeating: "y", count: 50), to: original)
-
-        // When: Incremental merge
-        copy.incrementalMergeFromProgenitor()
-
-        // Then: Getting numLines should give correct value (cache was invalidated)
-        let numLines = copy.getNumLines(withWrapWidth: width)
-        XCTAssertEqual(numLines, 2)  // 150 chars at width 80 = 2 lines
-    }
-
-    // MARK: - E. DWC Tests
-
-    func testIncrementalMerge_DWCFlagPropagated() {
-        // Given: Original without DWC, copy made, then DWC appended
-        let original = makePartialLineBlock("abc")
-        XCTAssertFalse(original.mayHaveDoubleWidthCharacter)
-
-        let copy = original.cowCopy()
-
-        // Set DWC flag and append
-        original.mayHaveDoubleWidthCharacter = true
-        appendPartial("def", to: original)
-
-        // When: Incremental merge
-        copy.incrementalMergeFromProgenitor()
-
-        // Then: Copy should have DWC flag set
-        XCTAssertTrue(copy.mayHaveDoubleWidthCharacter)
-    }
-
-    // MARK: - F. LineBuffer Integration Tests
-
-    func testIncrementalMerge_LineBufferIntegration() {
-        // Given: Source LineBuffer with partial line
+    func testZeroCopyMerge_LineBufferIntegration() {
+        // End-to-end test with LineBuffer.
         let source = LineBuffer()
-        let s1 = screenCharArrayWithDefaultStyle("abc", eol: EOL_SOFT)
-        source.append(s1, width: 80)
+        source.setMaxLines(1000)
+        let width = Int32(80)
 
-        // Create a copy (dest)
-        let dest = source.copy()
+        // Append a partial line to the source.
+        let helloLS = makeLineString("Hello", eol: EOL_SOFT)
+        let helloSCA = helloLS.screenCharArray(bidi: nil)
+        source.appendLine(helloSCA.line,
+                          length: helloSCA.length,
+                          partial: true,
+                          width: width,
+                          metadata: helloSCA.metadata,
+                          continuation: helloSCA.continuation)
 
-        // Append more to source
-        let s2 = screenCharArrayWithDefaultStyle("def", eol: EOL_SOFT)
-        source.append(s2, width: 80)
+        // Create a copy and merge.
+        let copy = LineBuffer()
+        copy.setMaxLines(1000)
+        copy.forceMerge(from: source)
 
-        // When: Merge dest from source
-        dest.merge(from: source)
+        // Verify initial state.
+        XCTAssertEqual(copy.numLines(withWidth: width), 1)
 
-        // Then: Dest should have the full content
-        let line = dest.wrappedLine(at: 0, width: 80)
-        XCTAssertEqual(line.stringValue, "abcdef")
+        // Append more partial data to the source.
+        let worldLS = makeLineString(" World", eol: EOL_SOFT)
+        let worldSCA = worldLS.screenCharArray(bidi: nil)
+        source.appendLine(worldSCA.line,
+                          length: worldSCA.length,
+                          partial: true,
+                          width: width,
+                          metadata: worldSCA.metadata,
+                          continuation: worldSCA.continuation)
+
+        // Merge again — should use zero-copy merge path.
+        copy.forceMerge(from: source)
+
+        // Verify the copy now has the updated content.
+        XCTAssertEqual(copy.numLines(withWidth: width), 1)
+        let line = copy.wrappedLine(at: 0, width: width)
+        XCTAssertTrue(line.stringValue.hasPrefix("Hello World"),
+                      "After merge, copy should see 'Hello World' but got '\(line.stringValue)'")
     }
 
-    func testIncrementalMerge_MultipleMergeCycles() {
-        // Given: Source LineBuffer with partial line
-        let source = LineBuffer()
-        let s1 = screenCharArrayWithDefaultStyle("a", eol: EOL_SOFT)
-        source.append(s1, width: 80)
+    // MARK: - D. Fallback
 
-        let dest = source.copy()
+    func testZeroCopyMerge_FallsBackOnNonAppendMutation() {
+        // A non-append mutation should break zero-copy sharing.
+        let progenitor = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendPartialASCII(progenitor, "Hello")
 
-        // When: Multiple append+merge cycles
-        for char in "bcdefghij" {
-            let sca = screenCharArrayWithDefaultStyle(String(char), eol: EOL_SOFT)
-            source.append(sca, width: 80)
-            dest.merge(from: source)
-        }
+        let copy = progenitor.cowCopy()
 
-        // Then: Dest should have all content
-        let line = dest.wrappedLine(at: 0, width: 80)
-        XCTAssertEqual(line.stringValue, "abcdefghij")
+        // Remove the last raw line (a non-append mutation).
+        progenitor.removeLastRawLine()
+
+        XCTAssertFalse(copy.canZeroCopyMergeFromProgenitor(),
+                       "Should be ineligible after non-append mutation")
+
+        // The buffer should no longer be shared.
+        XCTAssertFalse(copy.sharesCharacterBuffer(with: progenitor),
+                       "Buffer should be cloned after non-append mutation")
     }
 
-    // MARK: - G. Edge Cases
+    func testZeroCopyMerge_FallsBackOnDropLines() {
+        // dropLines should break zero-copy sharing.
+        let progenitor = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendHardASCII(progenitor, "Line1")
+        appendPartialASCII(progenitor, "Line2")
 
-    func testIncrementalMerge_ProgenitorUnchangedAfterMerge() {
-        // Given: Original with partial line, copy made, append
-        let original = makePartialLineBlock("abc")
-        let copy = original.cowCopy()
-        appendPartial("def", to: original)
-
-        let originalContent = original.screenCharArray(forRawLine: 0).stringValue
-
-        // When: Incremental merge
-        copy.incrementalMergeFromProgenitor()
-
-        // Then: Original should be unchanged
-        XCTAssertEqual(original.screenCharArray(forRawLine: 0).stringValue, originalContent)
+        // This block has 2 raw lines, so cowCopy won't set zero-copy flag
+        // (requires cll_entries==1). Verify ineligibility.
+        let copy = progenitor.cowCopy()
+        XCTAssertFalse(copy.canZeroCopyMergeFromProgenitor(),
+                       "Multi-line block should not be eligible for zero-copy merge")
     }
 
-    func testIncrementalMerge_ExactCapacity() {
-        // Given: Original with buffer size 10, append to exactly fill it
-        let original = LineBlock(rawBufferSize: 10, absoluteBlockNumber: 0)
-        appendPartial("abc", to: original)
-        let copy = original.cowCopy()
-        appendPartial("defghij", to: original)  // Exactly fills to 10
+    func testZeroCopyMerge_FallsBackOnSetPartial() {
+        // Changing partial status should break zero-copy sharing.
+        let progenitor = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendPartialASCII(progenitor, "Hello")
 
-        // When: Incremental merge
-        copy.incrementalMergeFromProgenitor()
+        let copy = progenitor.cowCopy()
 
-        // Then: Should have exactly 10 characters
-        XCTAssertEqual(copy.length(ofRawLine: 0), 10)
+        // Change partial status.
+        progenitor.setPartial(false)
+
+        XCTAssertFalse(copy.canZeroCopyMergeFromProgenitor(),
+                       "Should be ineligible after setPartial changes the line state")
     }
 
-    func testIncrementalMerge_SetPartialInvalidatesFlag() {
-        // Given: Original with partial line, copy made
-        let original = makePartialLineBlock("abc")
-        let copy = original.cowCopy()
+    // MARK: - E. Copy Mutation Invariant (regression guard for #1)
 
-        // When: setPartial is called (changing the value)
-        original.setPartial(false)
+    func testZeroCopyCopy_CompletePartialLineBreaksSharing() {
+        // A copied block with _zeroCopyShared=YES must clone the buffer
+        // before writing when it completes the existing partial line with
+        // a hard append (the "completing a partial" guard in reallyAppendLine).
+        let progenitor = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendPartialASCII(progenitor, "Hello")
 
-        // Then: Should not be eligible for incremental merge
-        XCTAssertFalse(copy.canIncrementalMergeFromProgenitor)
+        let copy = progenitor.cowCopy()
+        XCTAssertTrue(copy.sharesCharacterBuffer(with: progenitor))
+
+        // Completing the partial line with a hard append triggers the
+        // mutation guard, which must clone the buffer and clear
+        // _zeroCopyShared before writing.
+        appendHardASCII(copy, "Goodbye")
+
+        XCTAssertFalse(copy.sharesCharacterBuffer(with: progenitor),
+                       "Copy must clone buffer before mutating via append")
+
+        // Progenitor content and structure must be untouched.
+        let progenitorLine = progenitor.screenCharArray(forRawLine: 0)
+        XCTAssertEqual(progenitorLine.stringValue, "Hello",
+                       "Progenitor content must not be corrupted by copy mutation")
+        XCTAssertEqual(progenitor.numRawLines(), 1,
+                       "Progenitor raw line count must be unchanged")
+        XCTAssertEqual(progenitor.rawSpaceUsed(), Int32(5),
+                       "Progenitor raw space must be unchanged")
     }
 
-    func testIncrementalMerge_RemoveLastRawLineInvalidatesFlag() {
-        // Given: Original with partial line, copy made
-        let original = makePartialLineBlock("abc")
-        let copy = original.cowCopy()
+    // NOTE: No test for extend-partial (appending partial to existing partial).
+    // The extend-partial path intentionally has no _zeroCopyShared guard because
+    // the progenitor uses it in the hot loop. Copies are never mutated via
+    // partial-extend in production (they are read-only between syncs).
 
-        // When: removeLastRawLine is called
-        original.removeLastRawLine()
-        appendPartial("xyz", to: original)
+    func testZeroCopyCopy_RemoveLastRawLineBreaksSharing() {
+        let progenitor = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendPartialASCII(progenitor, "Hello")
 
-        // Then: Should not be eligible for incremental merge
-        XCTAssertFalse(copy.canIncrementalMergeFromProgenitor)
+        let copy = progenitor.cowCopy()
+        XCTAssertTrue(copy.sharesCharacterBuffer(with: progenitor))
+
+        copy.removeLastRawLine()
+
+        XCTAssertFalse(copy.sharesCharacterBuffer(with: progenitor),
+                       "removeLastRawLine must clone buffer and break sharing")
+
+        // Progenitor content and structure must be untouched.
+        let progenitorLine = progenitor.screenCharArray(forRawLine: 0)
+        XCTAssertEqual(progenitorLine.stringValue, "Hello",
+                       "Progenitor content must not be corrupted")
+        XCTAssertEqual(progenitor.numRawLines(), 1)
+        XCTAssertEqual(progenitor.rawSpaceUsed(), Int32(5))
     }
 
-    func testIncrementalMerge_DropLinesInvalidatesFlag() {
-        // Given: Block with long partial line content, copy made
-        // 200 chars at width 80 = 3 wrapped lines (80+80+40)
-        let testBlock = makePartialLineBlock(String(repeating: "x", count: 200))
-        let testCopy = testBlock.cowCopy()
+    func testZeroCopyCopy_SetPartialBreaksSharing() {
+        let progenitor = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendPartialASCII(progenitor, "Hello")
 
-        // Verify initial state
-        XCTAssertTrue(testBlock.hasPartial())
-        XCTAssertEqual(testBlock.numRawLines(), 1)
+        let copy = progenitor.cowCopy()
+        XCTAssertTrue(copy.sharesCharacterBuffer(with: progenitor))
 
-        // When: dropLines is called (should invalidate flag)
-        // Note: dropping a line from a block changes _firstEntry or _startOffset
+        copy.setPartial(false)
+
+        XCTAssertFalse(copy.sharesCharacterBuffer(with: progenitor),
+                       "setPartial must clone buffer and break sharing")
+
+        // Progenitor content and structure must be untouched.
+        let progenitorLine = progenitor.screenCharArray(forRawLine: 0)
+        XCTAssertEqual(progenitorLine.stringValue, "Hello",
+                       "Progenitor content must not be corrupted")
+        XCTAssertEqual(progenitor.numRawLines(), 1)
+        XCTAssertEqual(progenitor.rawSpaceUsed(), Int32(5))
+    }
+
+    func testZeroCopyCopy_PopLastLineBreaksSharing() {
+        let progenitor = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendPartialASCII(progenitor, "Hello")
+
+        let copy = progenitor.cowCopy()
+        XCTAssertTrue(copy.sharesCharacterBuffer(with: progenitor))
+
+        _ = copy.popLastLine(width: 80)
+
+        XCTAssertFalse(copy.sharesCharacterBuffer(with: progenitor),
+                       "popLastLine must clone buffer and break sharing")
+
+        // Progenitor content and structure must be untouched.
+        let progenitorLine = progenitor.screenCharArray(forRawLine: 0)
+        XCTAssertEqual(progenitorLine.stringValue, "Hello",
+                       "Progenitor content must not be corrupted")
+        XCTAssertEqual(progenitor.numRawLines(), 1)
+        XCTAssertEqual(progenitor.rawSpaceUsed(), Int32(5))
+    }
+
+    func testZeroCopyCopy_DropLinesBreaksSharing() {
+        // Need a long partial line so dropLines has wrapped lines to drop.
+        let progenitor = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendPartialASCII(progenitor, String(repeating: "x", count: 200))
+
+        let copy = progenitor.cowCopy()
+        XCTAssertTrue(copy.sharesCharacterBuffer(with: progenitor))
+
         var dropped: Int32 = 0
-        _ = testBlock.dropLines(1, withWidth: 80, chars: &dropped)
+        _ = copy.dropLines(1, withWidth: 80, chars: &dropped)
 
-        // Then: Should not be eligible for incremental merge (drop invalidates flag)
-        // After dropping 1 wrapped line at width 80, the block still has the same raw line
-        // but with a different bufferStartOffset
-        XCTAssertFalse(testCopy.canIncrementalMergeFromProgenitor)
+        XCTAssertFalse(copy.sharesCharacterBuffer(with: progenitor),
+                       "dropLines must clone buffer and break sharing")
+
+        // Progenitor content and structure must be untouched.
+        let progenitorLine = progenitor.screenCharArray(forRawLine: 0)
+        XCTAssertEqual(progenitorLine.stringValue, String(repeating: "x", count: 200),
+                       "Progenitor content must not be corrupted")
+        XCTAssertEqual(progenitor.numRawLines(), 1)
+        XCTAssertEqual(progenitor.rawSpaceUsed(), Int32(200))
     }
 
-    func testCanIncrementalMerge_IneligibleWhenPartialLineCompleted() {
-        // Given: Original with partial line, copy made
-        let original = makePartialLineBlock("abc")
-        let copy = original.cowCopy()
+    // MARK: - F. Sync Cycle Flow Tests (contract guard for #3)
 
-        // When: Append hard EOL to complete the line (partial -> non-partial)
-        appendHardLine("def", to: original)
+    func testZeroCopy_SyncCycleCopyIsReadOnly() {
+        // Mimics real sync cycles: source mutates, copy merges, repeat.
+        // Verifies the copy is only updated via merge, never direct mutation.
+        let source = LineBuffer()
+        source.setMaxLines(1000)
+        let width = Int32(80)
 
-        // Then: Should not be eligible for incremental merge
-        // Even though we "appended" to the existing partial line, completing it
-        // with a hard EOL means the copy would still think it's partial, so
-        // incremental merge must be disallowed.
-        XCTAssertFalse(copy.canIncrementalMergeFromProgenitor)
-    }
+        let initialLS = makeLineString("start", eol: EOL_SOFT)
+        let initialSCA = initialLS.screenCharArray(bidi: nil)
+        source.appendLine(initialSCA.line, length: initialSCA.length,
+                          partial: true, width: width,
+                          metadata: initialSCA.metadata,
+                          continuation: initialSCA.continuation)
 
-    func testCanIncrementalMerge_IneligibleWhenCopyMutated() {
-        // Given: Original with partial line, copy made
-        let original = makePartialLineBlock("abc")
-        let copy = original.cowCopy()
+        let dest = LineBuffer()
+        dest.setMaxLines(1000)
+        dest.forceMerge(from: source)
 
-        // When: Copy is mutated (appends its own content, diverging from original)
-        appendPartial("xyz", to: copy)
-
-        // And: Original also appends (would normally be eligible for incremental merge)
-        appendPartial("def", to: original)
-
-        // Then: Copy should not be eligible because it has diverged
-        // (its buffer was cloned when it mutated, so it no longer shares with progenitor)
-        XCTAssertFalse(copy.canIncrementalMergeFromProgenitor)
-    }
-
-    func testIncrementalMerge_SecondAppendDoesNotClone() {
-        // This test verifies that after the first append (which clones because
-        // the progenitor has clients), subsequent appends do NOT clone because
-        // the clients have been transferred away.
-
-        // Given: Original with partial line
-        let original = makePartialLineBlock("abc")
-
-        // And: A copy is made (original now has clients)
-        let copy = original.cowCopy()
-        XCTAssertEqual(original.numberOfClients, 1, "Original should have 1 client after cowCopy")
-
-        // When: Original appends (triggers clone, copy becomes owner of old buffer)
-        appendPartial("def", to: original)
-
-        // Then: Original should have no clients (they were transferred to copy)
-        XCTAssertEqual(original.numberOfClients, 0, "Original should have 0 clients after mutation")
-
-        // When: Original appends again
-        appendPartial("ghi", to: original)
-
-        // Then: Original still has no clients (no new cowCopy relationships)
-        XCTAssertEqual(original.numberOfClients, 0, "Original should still have 0 clients")
-
-        // And: Original has the full content
-        XCTAssertEqual(original.screenCharArray(forRawLine: 0).stringValue, "abcdefghi")
-
-        // And: Copy can still do incremental merge for the second append
-        XCTAssertTrue(copy.canIncrementalMergeFromProgenitor)
-
-        // When: We do the incremental merge
-        copy.incrementalMergeFromProgenitor()
-
-        // Then: Copy has all the content (both appends merged)
-        XCTAssertEqual(copy.screenCharArray(forRawLine: 0).stringValue, "abcdefghi")
-    }
-
-    func testIncrementalMerge_RepeatedAppendMergeCyclesAreEfficient() {
-        // This test verifies that repeated append+merge cycles don't cause
-        // repeated deep copies. After the first append, subsequent appends
-        // should be O(1) and merges should copy only the delta.
-
-        // Given: Original with partial line
-        let original = makePartialLineBlock("a")
-        let copy = original.cowCopy()
-
-        // When: First append (triggers the one-time clone)
-        appendPartial("b", to: original)
-        XCTAssertEqual(original.numberOfClients, 0, "Clients transferred after first mutation")
-
-        // Then: Multiple append+merge cycles should all work efficiently
+        // Run 10 sync cycles: source appends, dest merges.
         for i in 0..<10 {
-            // Append to original (should NOT clone - no clients)
-            let char = String(UnicodeScalar(Int(("c" as UnicodeScalar).value) + i)!)
-            appendPartial(char, to: original)
+            let appendLS = makeLineString(String(UnicodeScalar(Int(("A" as UnicodeScalar).value) + i)!),
+                                          eol: EOL_SOFT)
+            let appendSCA = appendLS.screenCharArray(bidi: nil)
+            source.appendLine(appendSCA.line, length: appendSCA.length,
+                              partial: true, width: width,
+                              metadata: appendSCA.metadata,
+                              continuation: appendSCA.continuation)
 
-            // Original still has no clients
-            XCTAssertEqual(original.numberOfClients, 0, "Original should have no clients on iteration \(i)")
+            dest.forceMerge(from: source)
 
-            // Incremental merge should still be possible
-            XCTAssertTrue(copy.canIncrementalMergeFromProgenitor, "Should be able to incremental merge on iteration \(i)")
-
-            // Do the merge
-            copy.incrementalMergeFromProgenitor()
-
-            // Verify content matches
-            XCTAssertEqual(copy.screenCharArray(forRawLine: 0).stringValue,
-                           original.screenCharArray(forRawLine: 0).stringValue,
-                           "Content should match after merge on iteration \(i)")
+            // Post-merge invariant: full unwrapped content matches source.
+            let srcFull = source.unwrappedLine(at: 0)
+            let dstFull = dest.unwrappedLine(at: 0)
+            XCTAssertEqual(srcFull.stringValue, dstFull.stringValue,
+                           "Content mismatch after sync cycle \(i)")
+            XCTAssertEqual(source.numLines(withWidth: width),
+                           dest.numLines(withWidth: width),
+                           "Line count mismatch after sync cycle \(i)")
         }
-
-        // Final verification
-        XCTAssertEqual(original.screenCharArray(forRawLine: 0).stringValue, "abcdefghijkl")
-        XCTAssertEqual(copy.screenCharArray(forRawLine: 0).stringValue, "abcdefghijkl")
     }
 
-    // MARK: - Copy of Copy Tests (A -> B -> C chains)
+    // MARK: - G. Stress Test (serialized merge + mutate, guard for #2)
 
-    func testCopyOfCopy_MiddleAppends_LeafCanMerge() {
-        // Scenario: A -> B -> C, then B appends. Can C merge from B?
+    func testZeroCopy_RepeatedMergeMutateStress() {
+        // Repeatedly mutate source and merge to dest under the same
+        // serialization model used in production (sequential, not concurrent).
+        // Asserts structural invariants after each merge.
+        let source = LineBuffer()
+        source.setMaxLines(10000)
+        let width = Int32(80)
 
-        // Given: A with partial line
-        let a = makePartialLineBlock("abc")
+        // Seed with a partial line.
+        let seedLS = makeLineString("seed", eol: EOL_SOFT)
+        let seedSCA = seedLS.screenCharArray(bidi: nil)
+        source.appendLine(seedSCA.line, length: seedSCA.length,
+                          partial: true, width: width,
+                          metadata: seedSCA.metadata,
+                          continuation: seedSCA.continuation)
 
-        // And: B is a copy of A
-        let b = a.cowCopy()
-        XCTAssertTrue(b.progenitor === a)
+        let dest = LineBuffer()
+        dest.setMaxLines(10000)
+        dest.forceMerge(from: source)
 
-        // And: C is a copy of B
-        let c = b.cowCopy()
-        XCTAssertTrue(c.progenitor === b)
+        // Reference buffer built from raw appends (no merge/zero-copy path).
+        // Compared against dest each iteration to verify merge equivalence.
+        let reference = LineBuffer()
+        reference.setMaxLines(10000)
+        reference.appendLine(seedSCA.line, length: seedSCA.length,
+                             partial: true, width: width,
+                             metadata: seedSCA.metadata,
+                             continuation: seedSCA.continuation)
 
-        // When: B appends (B diverges from A, but B only appended)
-        appendPartial("def", to: b)
+        var fullContent = "seed"
 
-        // Then: B should have diverged
-        XCTAssertFalse(b.hasOwner(), "B should have no owner after mutation")
+        for i in 0..<50 {
+            // Append to source (simulates mutation thread).
+            let chunk = String(repeating: String(UnicodeScalar(Int(("a" as UnicodeScalar).value) + (i % 26))!),
+                               count: (i % 5) + 1)
+            fullContent += chunk
+            let chunkLS = makeLineString(chunk, eol: EOL_SOFT)
+            let chunkSCA = chunkLS.screenCharArray(bidi: nil)
+            source.appendLine(chunkSCA.line, length: chunkSCA.length,
+                              partial: true, width: width,
+                              metadata: chunkSCA.metadata,
+                              continuation: chunkSCA.continuation)
 
-        // And: C should be able to merge from B (its progenitor)
-        // because B only did partial appends
-        XCTAssertTrue(c.canIncrementalMergeFromProgenitor,
-                      "C should be able to incrementally merge from B")
+            // Same append to reference (no merge involved).
+            reference.appendLine(chunkSCA.line, length: chunkSCA.length,
+                                 partial: true, width: width,
+                                 metadata: chunkSCA.metadata,
+                                 continuation: chunkSCA.continuation)
 
-        // When: C merges from B
-        c.incrementalMergeFromProgenitor()
+            // Merge (simulates main thread sync).
+            dest.forceMerge(from: source)
 
-        // Then: C should have B's content
-        XCTAssertEqual(c.screenCharArray(forRawLine: 0).stringValue, "abcdef")
+            // Structural invariants:
+            // 1. Line count matches across all three buffers.
+            XCTAssertEqual(source.numLines(withWidth: width),
+                           dest.numLines(withWidth: width),
+                           "Line count diverged (dest) at iteration \(i)")
+            XCTAssertEqual(source.numLines(withWidth: width),
+                           reference.numLines(withWidth: width),
+                           "Line count diverged (reference) at iteration \(i)")
+
+            // 2. Full unwrapped content matches across all three buffers.
+            let srcFull = source.unwrappedLine(at: 0)
+            let dstFull = dest.unwrappedLine(at: 0)
+            let refFull = reference.unwrappedLine(at: 0)
+            XCTAssertEqual(srcFull.stringValue, dstFull.stringValue,
+                           "Content diverged (dest vs source) at iteration \(i)")
+            XCTAssertEqual(dstFull.stringValue, refFull.stringValue,
+                           "Content diverged (dest vs reference) at iteration \(i)")
+
+            // 3. Full content matches expected accumulation.
+            XCTAssertEqual(srcFull.stringValue, fullContent,
+                           "Source doesn't match expected at iteration \(i)")
+        }
     }
 
-    func testCopyOfCopy_RootAppends_CascadeMerge() {
-        // Scenario: A -> B -> C, then A appends. Can we cascade merge B then C?
+    // MARK: - H. Buffer Resize Tests
 
-        // Given: Chain A -> B -> C
-        let a = makePartialLineBlock("abc")
-        let b = a.cowCopy()
-        let c = b.cowCopy()
-
-        // When: A appends
-        appendPartial("def", to: a)
-
-        // Then: B should be able to merge from A
-        XCTAssertTrue(b.canIncrementalMergeFromProgenitor)
-
-        // When: B merges from A
-        b.incrementalMergeFromProgenitor()
-        XCTAssertEqual(b.screenCharArray(forRawLine: 0).stringValue, "abcdef")
-
-        // Then: C should still be able to merge from B
-        // (B's incremental merge is conceptually an append, so B._appendOnlySinceLastCopy stays YES)
-        XCTAssertTrue(c.canIncrementalMergeFromProgenitor,
-                      "C should be able to merge from B after B merged from A")
-
-        // When: C merges from B
-        c.incrementalMergeFromProgenitor()
-
-        // Then: C should have the full content
-        XCTAssertEqual(c.screenCharArray(forRawLine: 0).stringValue, "abcdef")
-    }
-
-    func testCopyOfCopy_MiddleDoesNonAppend_LeafCannotMerge() {
-        // Scenario: A -> B -> C, then B does a non-append mutation.
-        // C should NOT be able to incrementally merge from B.
-
-        // Given: Chain A -> B -> C
-        let a = makePartialLineBlock("abc")
-        let b = a.cowCopy()
-        let c = b.cowCopy()
-
-        // When: B does a non-append mutation (setPartial changes is_partial)
-        b.setPartial(false)  // Complete the partial line
-        b.setPartial(true)   // Make it partial again (but flag is now NO)
-
-        // And: B appends (after the non-append mutation)
-        appendPartial("def", to: b)
-
-        // Then: C should NOT be able to incrementally merge
-        // because B did a non-append mutation
-        XCTAssertFalse(c.canIncrementalMergeFromProgenitor,
-                       "C should not be able to merge because B did non-append mutation")
-    }
-
-    func testCopyOfCopy_RootAppendsTwice_CascadeStillWorks() {
-        // Scenario: A -> B -> C, A appends, B merges, A appends again, B merges again, C merges
-
-        // Given: Chain A -> B -> C
-        let a = makePartialLineBlock("a")
-        let b = a.cowCopy()
-        let c = b.cowCopy()
-
-        // When: First round - A appends, B merges
-        appendPartial("b", to: a)
-        XCTAssertTrue(b.canIncrementalMergeFromProgenitor)
-        b.incrementalMergeFromProgenitor()
-        XCTAssertEqual(b.screenCharArray(forRawLine: 0).stringValue, "ab")
-
-        // And: Second round - A appends again, B merges again
-        appendPartial("c", to: a)
-        XCTAssertTrue(b.canIncrementalMergeFromProgenitor)
-        b.incrementalMergeFromProgenitor()
-        XCTAssertEqual(b.screenCharArray(forRawLine: 0).stringValue, "abc")
-
-        // Then: C should be able to merge all at once from B
-        XCTAssertTrue(c.canIncrementalMergeFromProgenitor)
-        c.incrementalMergeFromProgenitor()
-        XCTAssertEqual(c.screenCharArray(forRawLine: 0).stringValue, "abc")
-    }
-
-    func testCopyOfCopy_BothMiddleAndRootAppend_LeafMergesFromMiddle() {
-        // Scenario: A -> B -> C, both A and B append (different content).
-        // C should merge from B (its progenitor), not A.
-
-        // Given: Chain A -> B -> C
-        let a = makePartialLineBlock("abc")
-        let b = a.cowCopy()
-        let c = b.cowCopy()
-
-        // When: B appends first (diverges from A)
-        appendPartial("BBB", to: b)
-
-        // And: A appends different content
-        appendPartial("AAA", to: a)
-
-        // Then: C's progenitor is B, so C should merge from B
-        XCTAssertTrue(c.canIncrementalMergeFromProgenitor)
-        c.incrementalMergeFromProgenitor()
-
-        // C should have B's content, not A's
-        XCTAssertEqual(c.screenCharArray(forRawLine: 0).stringValue, "abcBBB")
-        XCTAssertEqual(b.screenCharArray(forRawLine: 0).stringValue, "abcBBB")
-        XCTAssertEqual(a.screenCharArray(forRawLine: 0).stringValue, "abcAAA")
-    }
-
-    func testCopyOfCopy_LongChain_AllCanMerge() {
-        // Scenario: A -> B -> C -> D -> E, A appends, all merge in sequence
-
-        // Given: Long chain
-        let a = makePartialLineBlock("a")
-        let b = a.cowCopy()
-        let c = b.cowCopy()
-        let d = c.cowCopy()
-        let e = d.cowCopy()
-
-        // When: A appends
-        appendPartial("bcdef", to: a)
-
-        // Then: Each can merge from its progenitor in sequence
-        XCTAssertTrue(b.canIncrementalMergeFromProgenitor)
-        b.incrementalMergeFromProgenitor()
-        XCTAssertEqual(b.screenCharArray(forRawLine: 0).stringValue, "abcdef")
-
-        XCTAssertTrue(c.canIncrementalMergeFromProgenitor)
-        c.incrementalMergeFromProgenitor()
-        XCTAssertEqual(c.screenCharArray(forRawLine: 0).stringValue, "abcdef")
-
-        XCTAssertTrue(d.canIncrementalMergeFromProgenitor)
-        d.incrementalMergeFromProgenitor()
-        XCTAssertEqual(d.screenCharArray(forRawLine: 0).stringValue, "abcdef")
-
-        XCTAssertTrue(e.canIncrementalMergeFromProgenitor)
-        e.incrementalMergeFromProgenitor()
-        XCTAssertEqual(e.screenCharArray(forRawLine: 0).stringValue, "abcdef")
-    }
-
-    func testCopyOfCopy_MiddleDiverges_CannotMergeFromRoot() {
-        // Scenario: A -> B -> C, B diverges (appends), then tries to merge from A.
-        // B should NOT be able to incrementally merge because B._hasDiverged = YES.
-
-        // Given: Chain A -> B -> C
-        let a = makePartialLineBlock("abc")
-        let b = a.cowCopy()
-        let _ = b.cowCopy()  // C exists but we focus on B
-
-        // When: B appends (diverges)
-        appendPartial("def", to: b)
-
-        // And: A also appends
-        appendPartial("ghi", to: a)
-
-        // Then: B should NOT be able to incrementally merge from A
-        // because B diverged (cloned its buffer for its own mutation)
-        XCTAssertFalse(b.canIncrementalMergeFromProgenitor,
-                       "B should not be able to merge from A because B diverged")
-    }
-
-    // MARK: - Buffer Resize Tests
-
-    func testIncrementalMerge_AppendExceedsBufferSize_StillEligible() {
-        // This tests the case where appending a partial line to a block with
-        // only a partial line exceeds the buffer size. The block should resize
-        // internally rather than failing and causing LineBuffer to pop/reappend,
-        // which would set _appendOnlySinceLastCopy = NO.
-
-        // Given: A LineBuffer with content
+    func testZeroCopyMerge_AppendExceedsBufferSize_MergeStillWorks() {
+        // When appending a partial line that exceeds the block's buffer,
+        // LineBuffer should resize in place rather than pop/reappend.
+        // The resize may relocate the buffer (for small allocations below
+        // the VM-backed threshold), which disables zero-copy merge but the
+        // fallback path handles it correctly.
         let source = LineBuffer()
         source.setMaxLines(1000)
 
@@ -3843,42 +3749,23 @@ class LineBlockIncrementalMergeTests: XCTestCase {
         let initial = screenCharArrayWithDefaultStyle("abc", eol: EOL_SOFT)
         source.append(initial, width: 80)
 
-        // Get the block to check its state
-        let originalBlock = source.testOnlyBlock(at: 0)
-
         // Make a copy of the LineBuffer
         let dest = source.copy()
-        let copyBlock = dest.testOnlyBlock(at: 0)
 
-        // Verify the copy relationship
-        XCTAssertTrue(copyBlock.progenitor === originalBlock)
-
-        // When: We append content that exceeds the block's buffer space
-        // The default block size is 8192, so we need to append more than that
-        // This simulates the scenario where a partial line keeps growing
+        // Append content that exceeds the block's buffer space.
+        // The default block size is 8192, so 10000 exceeds it.
         let longAppend = String(repeating: "x", count: 10000)
         let longSCA = screenCharArrayWithDefaultStyle(longAppend, eol: EOL_SOFT)
         source.append(longSCA, width: 80)
 
-        // Debug: Check the original block's state
-        let originalContent = originalBlock.screenCharArray(forRawLine: 0).stringValue
-        let originalLength = originalBlock.length(ofRawLine: 0)
-
-        // Then: The copy block should still allow incremental merge
-        // If the bug exists, _appendOnlySinceLastCopy will be NO because
-        // LineBuffer had to pop and reappend the line
-        XCTAssertTrue(copyBlock.canIncrementalMergeFromProgenitor,
-                      "Copy should be eligible for incremental merge. " +
-                      "appendOnlySinceLastCopy=\(originalBlock.appendOnlySinceLastCopy), " +
-                      "originalLength=\(originalLength), originalContent=\(originalContent.prefix(50))...")
-
-        // Merge and verify content
+        // Merge — uses zero-copy if buffer wasn't relocated, fallback otherwise.
+        // Either way, the content must be correct.
         dest.merge(from: source)
 
         // Get the full unwrapped line
         let fullLine = dest.unwrappedLine(at: 0)
         let expectedContent = "abc" + longAppend
-        XCTAssertEqual(fullLine.stringValue.count, expectedContent.count,
-                       "Content length mismatch")
+        XCTAssertEqual(fullLine.stringValue, expectedContent,
+                       "Content mismatch after buffer resize")
     }
 }

--- a/ModernTests/LineBlockTests.swift
+++ b/ModernTests/LineBlockTests.swift
@@ -3153,7 +3153,8 @@ class LineBlockZeroCopyMergeTests: XCTestCase {
     // Helper to create a line string
     private func makeLineString(_ string: String,
                                 eol: Int32 = EOL_HARD,
-                                rtlFound: Bool = false) -> iTermLineString {
+                                rtlFound: Bool = false,
+                                lineStringMetadata: iTermLineStringMetadata? = nil) -> iTermLineString {
         let content = { () -> any iTermString in
             if let data = string.data(using: .ascii) {
                 return iTermASCIIString(data: data, style: screen_char_t(), ea: nil)
@@ -3171,7 +3172,8 @@ class LineBlockZeroCopyMergeTests: XCTestCase {
         return iTermLineString(content: content,
                                eol: eol,
                                continuation: continuation,
-                               metadata: iTermLineStringMetadata(timestamp: 0, rtlFound: ObjCBool(rtlFound)),
+                               metadata: lineStringMetadata ?? iTermLineStringMetadata(timestamp: 0,
+                                                                                       rtlFound: ObjCBool(rtlFound)),
                                bidi: nil,
                                dirty: false)
     }
@@ -3221,28 +3223,55 @@ class LineBlockZeroCopyMergeTests: XCTestCase {
     }
 
     func testCanZeroCopyMerge_IneligibleWhenNewLineAdded() {
-        // Adding a new raw line to the progenitor should break eligibility.
+        // Adding a second raw line to the progenitor should break eligibility
+        // (canZeroCopyMergeFromProgenitor requires cll_entries == 1).
         let progenitor = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
         appendPartialASCII(progenitor, "Hello")
 
         let copy = progenitor.cowCopy()
 
-        // Complete the line and add a new one.
-        appendHardASCII(progenitor, " done")
+        // Use append-only operations: close the first line with a hard append,
+        // then start a second raw line with a partial append.
+        appendHardASCII(progenitor, "!")
+        appendPartialASCII(progenitor, "Next")
 
+        XCTAssertEqual(progenitor.numRawLines(), 2,
+                       "Progenitor must have 2 raw lines after append-only newline creation")
+        XCTAssertTrue(progenitor.hasPartial(),
+                      "Second raw line should be partial after append")
         XCTAssertFalse(copy.canZeroCopyMergeFromProgenitor(),
-                       "Should be ineligible after progenitor adds a new line")
+                       "Should be ineligible when progenitor has more than 1 raw line")
     }
 
     func testCanZeroCopyMerge_IneligibleWhenNotPartial() {
-        // A complete (non-partial) single line should not be eligible.
+        // Verifies that setPartial(false) breaks zero-copy eligibility.
+        // setPartial(false) calls cloneCharacterBufferIfZeroCopyShared (because
+        // shareCount > 1), which clones the buffer and resets
+        // _appendOnlySinceLastCopy to NO. Both conditions are checked before
+        // the is_partial flag in canZeroCopyMergeFromProgenitor, so the
+        // ineligibility is driven by buffer-identity divergence. The buffer
+        // sharing assertion below pins this safety-critical side-effect.
         let progenitor = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
-        appendHardASCII(progenitor, "Complete")
+        appendPartialASCII(progenitor, "Complete")
 
         let copy = progenitor.cowCopy()
+        XCTAssertTrue(copy.hasOwner(), "Copy should start with owner linkage")
+
+        // Progenitor append clears copy.owner through mutation certificate flow.
+        appendPartialASCII(progenitor, "!")
+        XCTAssertFalse(copy.hasOwner(), "Owner linkage must be cleared before eligibility check")
+
+        // setPartial(false) clones the shared buffer and resets _appendOnlySinceLastCopy.
+        progenitor.setPartial(false)
+        XCTAssertFalse(progenitor.sharesCharacterBuffer(with: copy),
+                       "setPartial(false) must clone the shared buffer")
+        XCTAssertEqual(progenitor.numRawLines(), 1,
+                       "Progenitor should still have exactly one raw line")
+        XCTAssertFalse(progenitor.hasPartial(),
+                       "Progenitor line must be complete after setPartial(false)")
 
         XCTAssertFalse(copy.canZeroCopyMergeFromProgenitor(),
-                       "Should be ineligible when progenitor line is not partial")
+                       "setPartial(false) must break zero-copy eligibility")
     }
 
     func testCanZeroCopyMerge_IneligibleWhenNoProgenitor() {
@@ -3254,30 +3283,82 @@ class LineBlockZeroCopyMergeTests: XCTestCase {
                        "Should be ineligible with no progenitor")
     }
 
-    func testCanZeroCopyMerge_IneligibleWhenBufferRelocated() {
-        // If the character buffer was relocated, zero-copy merge should be ineligible.
+    func testCanZeroCopyMerge_IneligibleWhenOwnerNotDetached() {
+        // canZeroCopyMergeFromProgenitor checks self.owner != nil first.
+        // A fresh cowCopy still has owner == progenitor; the progenitor must
+        // mutate (via validMutationCertificate) to detach ownership before a
+        // merge is safe. Verify that an undetached copy is rejected.
+        let progenitor = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendPartialASCII(progenitor, "Hello")
+
+        let copy = progenitor.cowCopy()
+        XCTAssertTrue(copy.hasOwner(), "Fresh cowCopy must have owner linkage")
+
+        // No progenitor mutation — owner is still attached.
+        XCTAssertFalse(copy.canZeroCopyMergeFromProgenitor(),
+                       "Must be ineligible while copy.owner != nil")
+    }
+
+    func testCanZeroCopyMerge_IneligibleWhenCopyHasClients() {
+        // canZeroCopyMergeFromProgenitor also checks self.clients.count > 0.
+        // If the copy has itself been cowCopied (acquiring clients), it holds
+        // a CLL shared with its own clients, so zero-copy merge into it is unsafe.
+        let progenitor = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendPartialASCII(progenitor, "Hello")
+
+        let copy = progenitor.cowCopy()
+        // Detach owner so that check doesn't fire first.
+        appendPartialASCII(progenitor, "!")
+        XCTAssertFalse(copy.hasOwner(), "Owner must be detached before eligibility check")
+
+        // Give the copy a client by cowCopying it.
+        let grandchild = copy.cowCopy()
+        _ = grandchild  // keep alive
+
+        XCTAssertFalse(copy.canZeroCopyMergeFromProgenitor(),
+                       "Must be ineligible when copy has clients (clients.count > 0)")
+    }
+
+    func testCanZeroCopyMerge_IneligibleWhenProgenitorInvalidated() {
+        // A progenitor that has been invalidated (removed from the line buffer)
+        // must make its copies ineligible for zero-copy merge.
+        let progenitor = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendPartialASCII(progenitor, "Hello")
+
+        let copy = progenitor.cowCopy()
+        // Detach owner so that check doesn't fire first.
+        appendPartialASCII(progenitor, "!")
+        XCTAssertFalse(copy.hasOwner(), "Owner must be detached before eligibility check")
+        XCTAssertTrue(copy.canZeroCopyMergeFromProgenitor(),
+                      "Precondition: must be eligible before invalidation")
+
+        progenitor.invalidate()
+
+        XCTAssertFalse(copy.canZeroCopyMergeFromProgenitor(),
+                       "Must be ineligible when progenitor has been invalidated")
+    }
+
+    func testCanZeroCopyMerge_ResizeClonesBeforeRealloc() {
+        // realloc may relocate the buffer at any size (no in-place guarantee
+        // exists in the C standard, POSIX, or Apple's libmalloc).
+        // changeBufferSize clones the shared buffer first to avoid a
+        // use-after-free for concurrent readers. This breaks sharing.
         let progenitor = LineBlock(rawBufferSize: 16, absoluteBlockNumber: 0)
         appendPartialASCII(progenitor, "Hi")
 
         let copy = progenitor.cowCopy()
-
-        // Both should share the same buffer after cowCopy.
         XCTAssertTrue(copy.sharesCharacterBuffer(with: progenitor))
 
-        // Force a resize that should relocate the buffer.
-        progenitor.changeBufferSize(1024 * 1024)
+        // Any resize on a shared buffer triggers clone-before-resize.
+        progenitor.changeBufferSize(1024)
 
-        // Append to verify the mutation works.
-        appendPartialASCII(progenitor, "X")
+        XCTAssertFalse(copy.sharesCharacterBuffer(with: progenitor),
+                       "Resize must clone shared buffer to avoid use-after-free")
 
-        // They still share the same iTermCharacterBuffer object (not cloned by zero-copy path).
-        XCTAssertTrue(copy.sharesCharacterBuffer(with: progenitor),
-                      "Buffer object should still be shared — zero-copy skips clone")
-
-        // But if the internal pointer was relocated, canZeroCopyMerge should detect it.
-        // On macOS, growing from 16 to 1M typically relocates.
-        // We can't assert on the result because realloc behavior is platform-specific,
-        // but we verify the flag is checked correctly by canZeroCopyMergeFromProgenitor.
+        // Progenitor content must be intact after clone + resize.
+        let progenitorLine = progenitor.screenCharArray(forRawLine: 0)
+        XCTAssertEqual(progenitorLine.stringValue, "Hi",
+                       "Progenitor content must survive clone + resize")
     }
 
     // MARK: - B. Merge Mechanics
@@ -3323,9 +3404,10 @@ class LineBlockZeroCopyMergeTests: XCTestCase {
 
         // The copy should now see the full content.
         let rawLine = copy.screenCharArray(forRawLine: 0)
-        XCTAssertEqual(rawLine.stringValue.trimmingCharacters(in: CharacterSet(charactersIn: "\0")),
-                       "Hello World",
+        XCTAssertEqual(rawLine.stringValue, "Hello World",
                        "After zero-copy merge, copy should see updated content")
+        XCTAssertFalse(rawLine.stringValue.contains("\0"),
+                       "Merged content must not contain hidden NULs")
     }
 
     func testZeroCopyMerge_MetadataUpdated() {
@@ -3334,14 +3416,34 @@ class LineBlockZeroCopyMergeTests: XCTestCase {
         appendPartialASCII(progenitor, "Hello")
 
         let copy = progenitor.cowCopy()
+        let before = copy.screenCharArray(forRawLine: 0).metadata
+        XCTAssertEqual(before.timestamp, 0,
+                       "Baseline metadata timestamp should be default value")
+        XCTAssertFalse(before.rtlFound.boolValue,
+                       "Baseline metadata rtlFound should be false")
 
-        appendPartialASCII(progenitor, " World")
+        let updatedMetadata = iTermLineStringMetadata(timestamp: 4242, rtlFound: true)
+        let update = makeLineString(" World",
+                                    eol: EOL_SOFT,
+                                    lineStringMetadata: updatedMetadata)
+        XCTAssertTrue(progenitor.appendLineString(update, width: 80),
+                      "Precondition: appending metadata update should succeed")
 
         copy.zeroCopyMergeFromProgenitor()
 
-        // Verify the copy has 1 raw line and it's partial.
+        // Verify structure, content, and metadata were updated.
         XCTAssertEqual(copy.numRawLines(), 1)
         XCTAssertTrue(copy.hasPartial())
+        let afterSCA = copy.screenCharArray(forRawLine: 0)
+        XCTAssertEqual(afterSCA.stringValue, "Hello World",
+                       "Merged raw line content must reflect progenitor append")
+        XCTAssertEqual(afterSCA.eol, EOL_SOFT,
+                       "Merged line EOL must match progenitor continuation type")
+        let after = afterSCA.metadata
+        XCTAssertEqual(after.timestamp, updatedMetadata.timestamp,
+                       "Merged metadata timestamp must match progenitor update")
+        XCTAssertEqual(after.rtlFound.boolValue, updatedMetadata.rtlFound.boolValue,
+                       "Merged metadata rtlFound must match progenitor update")
     }
 
     func testZeroCopyMerge_CacheInvalidated() {
@@ -3361,10 +3463,12 @@ class LineBlockZeroCopyMergeTests: XCTestCase {
         // Merge.
         copy.zeroCopyMergeFromProgenitor()
 
-        // The copy should now have more wrapped lines (cache was invalidated).
+        // "HelloABCD" at width 4 wraps as Hell|oABC|D = 3 lines.
         let linesAfter = copy.getNumLines(withWrapWidth: 4)
-        XCTAssertGreaterThan(linesAfter, linesBefore,
-                             "After merge with more data, wrapped line count should increase")
+        XCTAssertEqual(linesAfter, 3,
+                       "\"HelloABCD\" at width 4 must wrap to exactly 3 lines")
+        XCTAssertEqual(linesAfter - linesBefore, 1,
+                       "Cache must reflect the 1-line increase from appending \"ABCD\"")
     }
 
     // MARK: - C. Multi-cycle
@@ -3382,7 +3486,8 @@ class LineBlockZeroCopyMergeTests: XCTestCase {
         copy.zeroCopyMergeFromProgenitor()
 
         let rawLine1 = copy.screenCharArray(forRawLine: 0)
-        XCTAssertTrue(rawLine1.stringValue.hasPrefix("AB"))
+        XCTAssertEqual(rawLine1.stringValue, "AB")
+        XCTAssertFalse(rawLine1.stringValue.contains("\0"))
 
         // Cycle 2: append + merge
         appendPartialASCII(progenitor, "C")
@@ -3391,7 +3496,8 @@ class LineBlockZeroCopyMergeTests: XCTestCase {
         copy.zeroCopyMergeFromProgenitor()
 
         let rawLine2 = copy.screenCharArray(forRawLine: 0)
-        XCTAssertTrue(rawLine2.stringValue.hasPrefix("ABC"))
+        XCTAssertEqual(rawLine2.stringValue, "ABC")
+        XCTAssertFalse(rawLine2.stringValue.contains("\0"))
 
         // Cycle 3: append + merge
         appendPartialASCII(progenitor, "D")
@@ -3399,10 +3505,130 @@ class LineBlockZeroCopyMergeTests: XCTestCase {
         copy.zeroCopyMergeFromProgenitor()
 
         let rawLine3 = copy.screenCharArray(forRawLine: 0)
-        XCTAssertTrue(rawLine3.stringValue.hasPrefix("ABCD"))
+        XCTAssertEqual(rawLine3.stringValue, "ABCD")
+        XCTAssertFalse(rawLine3.stringValue.contains("\0"))
 
         // Buffer should still be shared after all cycles.
         XCTAssertTrue(copy.sharesCharacterBuffer(with: progenitor))
+    }
+
+    func testZeroCopyMerge_50CyclesExactEquality() {
+        // 50 append→merge cycles at the LineBlock level with exact equality
+        // checked after each. Bridges the gap between the 3-cycle test above
+        // and the 50/100-cycle LineBuffer-level tests in sections G and I.11.
+        let progenitor = LineBlock(rawBufferSize: 4096, absoluteBlockNumber: 0)
+        appendPartialASCII(progenitor, "0")
+
+        let copy = progenitor.cowCopy()
+        var expected = "0"
+
+        for i in 0..<50 {
+            let ch = String(UnicodeScalar(Int(("A" as UnicodeScalar).value) + (i % 26))!)
+            appendPartialASCII(progenitor, ch)
+            expected += ch
+
+            XCTAssertTrue(copy.canZeroCopyMergeFromProgenitor(),
+                          "Cycle \(i): must be eligible")
+            copy.zeroCopyMergeFromProgenitor()
+
+            let line = copy.screenCharArray(forRawLine: 0)
+            XCTAssertEqual(line.stringValue, expected,
+                           "Cycle \(i): content mismatch")
+            XCTAssertFalse(line.stringValue.contains("\0"),
+                           "Cycle \(i): hidden NULs")
+        }
+
+        XCTAssertTrue(copy.sharesCharacterBuffer(with: progenitor),
+                      "Buffer must remain shared across all 50 cycles")
+        XCTAssertEqual(copy.testCharacterBufferShareCount(), 2)
+        XCTAssertEqual(copy.numRawLines(), 1)
+        XCTAssertTrue(copy.hasPartial())
+    }
+
+    func testZeroCopyMerge_StressWithResizeAndDropFallbacks() {
+        // Five phases of 10 zero-copy cycles each, separated by resize
+        // fallbacks that break sharing. After each resize, a fresh
+        // cowCopy re-enters zero-copy mode. A final dropLines fallback
+        // permanently breaks eligibility. Exact content at every step.
+        let progenitor = LineBlock(rawBufferSize: 2048, absoluteBlockNumber: 0)
+        appendPartialASCII(progenitor, "0")
+        var expected = "0"
+        var nextBufferSize: Int32 = 3072
+
+        for phase in 0..<5 {
+            autoreleasepool {
+                let copy = progenitor.cowCopy()
+
+                // Detach: append triggers validMutationCertificate which
+                // clears copy.owner via the zero-copy path.
+                let tag = String(phase)
+                appendPartialASCII(progenitor, tag)
+                expected += tag
+
+                // 10 zero-copy merge cycles
+                for step in 0..<10 {
+                    let ch = String(UnicodeScalar(
+                        Int(("a" as UnicodeScalar).value) + ((phase * 10 + step) % 26))!)
+                    appendPartialASCII(progenitor, ch)
+                    expected += ch
+
+                    XCTAssertTrue(copy.canZeroCopyMergeFromProgenitor(),
+                                  "Phase \(phase) step \(step): must be eligible")
+                    copy.zeroCopyMergeFromProgenitor()
+
+                    let line = copy.screenCharArray(forRawLine: 0)
+                    XCTAssertEqual(line.stringValue, expected,
+                                   "Phase \(phase) step \(step): content mismatch")
+                    XCTAssertFalse(line.stringValue.contains("\0"),
+                                   "Phase \(phase) step \(step): hidden NULs")
+                }
+
+                XCTAssertTrue(copy.sharesCharacterBuffer(with: progenitor),
+                              "Phase \(phase): must share after zero-copy cycles")
+
+                // Force resize fallback — clone-before-realloc breaks sharing.
+                progenitor.changeBufferSize(nextBufferSize)
+                nextBufferSize += 1024
+
+                XCTAssertFalse(copy.sharesCharacterBuffer(with: progenitor),
+                               "Phase \(phase): resize must break sharing")
+                XCTAssertEqual(copy.screenCharArray(forRawLine: 0).stringValue, expected,
+                               "Phase \(phase): copy content preserved after resize")
+                // copy goes out of scope — next phase creates a fresh one
+            }
+        }
+
+        // Final phase: dropLines permanently breaks eligibility.
+        // Content is now 56 chars: "0" + 5x(tag + 10 letters).
+        autoreleasepool {
+            let copy = progenitor.cowCopy()
+            appendPartialASCII(progenitor, "!")
+            expected += "!"
+
+            XCTAssertTrue(copy.canZeroCopyMergeFromProgenitor(),
+                          "Final: must be eligible before dropLines")
+            copy.zeroCopyMergeFromProgenitor()
+            XCTAssertEqual(copy.screenCharArray(forRawLine: 0).stringValue, expected,
+                           "Final: content before drop")
+
+            // Drop 1 wrapped line at width 5 (drops first 5 chars: "00abc").
+            var charsDropped: Int32 = 0
+            let dropped = progenitor.dropLines(1, withWidth: 5, chars: &charsDropped)
+            XCTAssertEqual(dropped, 1, "Must drop exactly 1 wrapped line")
+            XCTAssertEqual(charsDropped, 5, "Must drop 5 chars at width 5")
+
+            let postDropExpected = String(expected.dropFirst(Int(charsDropped)))
+
+            XCTAssertFalse(copy.sharesCharacterBuffer(with: progenitor),
+                           "dropLines must break sharing")
+            XCTAssertFalse(copy.canZeroCopyMergeFromProgenitor(),
+                           "dropLines must permanently break eligibility")
+            XCTAssertEqual(copy.screenCharArray(forRawLine: 0).stringValue, expected,
+                           "Copy must retain full pre-drop content")
+            XCTAssertEqual(progenitor.screenCharArray(forRawLine: 0).stringValue,
+                           postDropExpected,
+                           "Progenitor must have exact post-drop content")
+        }
     }
 
     func testZeroCopyMerge_LineBufferIntegration() {
@@ -3439,14 +3665,29 @@ class LineBlockZeroCopyMergeTests: XCTestCase {
                           metadata: worldSCA.metadata,
                           continuation: worldSCA.continuation)
 
+        // Verify that the pending update is eligible for zero-copy merge.
+        let sourceBlock = source.testOnlyBlock(at: 0)
+        let copyBlockBefore = copy.testOnlyBlock(at: 0)
+        XCTAssertTrue(copyBlockBefore.canZeroCopyMergeFromProgenitor(),
+                      "Second merge should be zero-copy eligible before forceMerge")
+        XCTAssertTrue(copyBlockBefore.sharesCharacterBuffer(with: sourceBlock),
+                      "Source/copy should share the character buffer before second merge")
+
         // Merge again — should use zero-copy merge path.
         copy.forceMerge(from: source)
 
         // Verify the copy now has the updated content.
         XCTAssertEqual(copy.numLines(withWidth: width), 1)
         let line = copy.wrappedLine(at: 0, width: width)
-        XCTAssertTrue(line.stringValue.hasPrefix("Hello World"),
-                      "After merge, copy should see 'Hello World' but got '\(line.stringValue)'")
+        XCTAssertEqual(line.stringValue, "Hello World",
+                       "After merge, copy should exactly match merged content")
+        XCTAssertFalse(line.stringValue.contains("\0"),
+                       "Merged line must not contain embedded NULs")
+
+        // After zero-copy merge, sharing should remain intact.
+        let copyBlockAfter = copy.testOnlyBlock(at: 0)
+        XCTAssertTrue(copyBlockAfter.sharesCharacterBuffer(with: sourceBlock),
+                      "Zero-copy merge should preserve shared character buffer")
     }
 
     // MARK: - D. Fallback
@@ -3470,38 +3711,67 @@ class LineBlockZeroCopyMergeTests: XCTestCase {
     }
 
     func testZeroCopyMerge_FallsBackOnDropLines() {
-        // dropLines should break zero-copy sharing.
+        // dropLines on the progenitor must break zero-copy sharing and
+        // eligibility. Start with a single partial line (zero-copy eligible),
+        // then drop wrapped lines to exercise the fallback.
         let progenitor = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
-        appendHardASCII(progenitor, "Line1")
-        appendPartialASCII(progenitor, "Line2")
+        // "HelloWorld" at width 5 wraps to 2 wrapped lines: Hello|World
+        appendPartialASCII(progenitor, "HelloWorld", width: 5)
 
-        // This block has 2 raw lines, so cowCopy won't set zero-copy flag
-        // (requires cll_entries==1). Verify ineligibility.
         let copy = progenitor.cowCopy()
+
+        // Progenitor must mutate first to detach copy from owner graph.
+        appendPartialASCII(progenitor, "!", width: 5)
+
+        XCTAssertTrue(copy.sharesCharacterBuffer(with: progenitor),
+                      "Must share buffer before dropLines")
+        XCTAssertTrue(copy.canZeroCopyMergeFromProgenitor(),
+                      "Must be eligible before dropLines")
+
+        // Drop 1 wrapped line from the progenitor.
+        var charsDropped: Int32 = 0
+        let linesDropped = progenitor.dropLines(1, withWidth: 5, chars: &charsDropped)
+        XCTAssertEqual(linesDropped, 1, "Must drop exactly 1 wrapped line")
+        XCTAssertEqual(charsDropped, 5, "Must drop 5 chars (\"Hello\")")
+
+        // Sharing and eligibility must be broken.
+        XCTAssertFalse(copy.sharesCharacterBuffer(with: progenitor),
+                       "dropLines must clone shared buffer")
         XCTAssertFalse(copy.canZeroCopyMergeFromProgenitor(),
-                       "Multi-line block should not be eligible for zero-copy merge")
+                       "Must be ineligible after dropLines (bufferStartOffset != 0)")
+
+        // Copy still reflects the pre-drop content.
+        XCTAssertEqual(copy.screenCharArray(forRawLine: 0).stringValue, "HelloWorld",
+                       "Copy must retain pre-drop content")
     }
 
     func testZeroCopyMerge_FallsBackOnSetPartial() {
-        // Changing partial status should break zero-copy sharing.
+        // setPartial(false) on a progenitor with a shared buffer calls
+        // cloneCharacterBufferIfZeroCopyShared, cloning the buffer and
+        // resetting _appendOnlySinceLastCopy to NO. The buffer sharing
+        // assertion below pins this safety-critical side-effect.
         let progenitor = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
         appendPartialASCII(progenitor, "Hello")
 
         let copy = progenitor.cowCopy()
+        XCTAssertTrue(copy.sharesCharacterBuffer(with: progenitor),
+                      "Must share buffer before setPartial(false)")
 
-        // Change partial status.
+        // setPartial(false) clones the shared buffer and resets _appendOnlySinceLastCopy.
         progenitor.setPartial(false)
+        XCTAssertFalse(progenitor.sharesCharacterBuffer(with: copy),
+                       "setPartial(false) must clone the shared buffer")
 
         XCTAssertFalse(copy.canZeroCopyMergeFromProgenitor(),
-                       "Should be ineligible after setPartial changes the line state")
+                       "setPartial(false) must break zero-copy eligibility")
     }
 
     // MARK: - E. Copy Mutation Invariant (regression guard for #1)
 
     func testZeroCopyCopy_CompletePartialLineBreaksSharing() {
-        // A copied block with _zeroCopyShared=YES must clone the buffer
-        // before writing when it completes the existing partial line with
-        // a hard append (the "completing a partial" guard in reallyAppendLine).
+        // A copied block sharing a buffer (shareCount > 1) must clone before
+        // writing when it completes the existing partial line with a hard
+        // append (the "completing a partial" guard in reallyAppendLine).
         let progenitor = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
         appendPartialASCII(progenitor, "Hello")
 
@@ -3509,8 +3779,8 @@ class LineBlockZeroCopyMergeTests: XCTestCase {
         XCTAssertTrue(copy.sharesCharacterBuffer(with: progenitor))
 
         // Completing the partial line with a hard append triggers the
-        // mutation guard, which must clone the buffer and clear
-        // _zeroCopyShared before writing.
+        // mutation guard, which clones the buffer (decrementing shareCount)
+        // before writing.
         appendHardASCII(copy, "Goodbye")
 
         XCTAssertFalse(copy.sharesCharacterBuffer(with: progenitor),
@@ -3527,9 +3797,9 @@ class LineBlockZeroCopyMergeTests: XCTestCase {
     }
 
     // NOTE: No test for extend-partial (appending partial to existing partial).
-    // The extend-partial path intentionally has no _zeroCopyShared guard because
-    // the progenitor uses it in the hot loop. Copies are never mutated via
-    // partial-extend in production (they are read-only between syncs).
+    // The extend-partial path has no mutation guard because the progenitor uses
+    // it in the hot loop. Copies are never mutated via partial-extend in
+    // production (they are read-only between syncs).
 
     func testZeroCopyCopy_RemoveLastRawLineBreaksSharing() {
         let progenitor = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
@@ -3611,6 +3881,100 @@ class LineBlockZeroCopyMergeTests: XCTestCase {
                        "Progenitor content must not be corrupted")
         XCTAssertEqual(progenitor.numRawLines(), 1)
         XCTAssertEqual(progenitor.rawSpaceUsed(), Int32(200))
+    }
+
+    func testZeroCopyCopy_NoUnnecessaryCloneAfterOtherSideClones() {
+        // Regression test for reviewer feedback: with a boolean flag, both
+        // sides would clone even when only one needed to. With refcounting,
+        // once one side clones (dropping shareCount to 1), the other side
+        // sees shareCount == 1 and skips the clone.
+        let progenitor = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendPartialASCII(progenitor, "Hello")
+
+        let copy = progenitor.cowCopy()
+        XCTAssertTrue(copy.sharesCharacterBuffer(with: progenitor),
+                      "After cowCopy, buffer should be shared")
+
+        // Copy clones away (e.g., via removeLastRawLine).
+        copy.removeLastRawLine()
+        XCTAssertFalse(copy.sharesCharacterBuffer(with: progenitor),
+                       "After copy mutation, buffers should differ")
+
+        // Now the progenitor is the sole owner of the original buffer.
+        // A mutation on the progenitor should NOT clone — it already owns
+        // the buffer exclusively (shareCount == 1). Pin the buffer identity
+        // before and after to prove no unnecessary clone occurred.
+        let identityBefore = progenitor.testCharacterBufferIdentity()
+        progenitor.removeLastRawLine()
+        XCTAssertEqual(progenitor.testCharacterBufferIdentity(), identityBefore,
+                       "Progenitor must not clone when it is the sole buffer owner (shareCount == 1)")
+        XCTAssertEqual(progenitor.numRawLines(), 0,
+                       "Progenitor should be empty after removeLastRawLine")
+    }
+
+    func testZeroCopyCopy_DeallocWithoutMutationDecrementsShareCount() {
+        // When a copy is deallocated without ever mutating, shareCount must
+        // be decremented so the progenitor doesn't clone unnecessarily.
+        let progenitor = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendPartialASCII(progenitor, "Hello")
+
+        // Create and immediately discard a copy (simulates a sync copy that
+        // is replaced before it ever mutates).
+        autoreleasepool {
+            let copy = progenitor.cowCopy()
+            XCTAssertTrue(copy.sharesCharacterBuffer(with: progenitor),
+                          "After cowCopy, buffer should be shared")
+            XCTAssertEqual(progenitor.testCharacterBufferShareCount(), 2,
+                           "shareCount must be 2 while copy exists")
+            // copy goes out of scope here — dealloc should decrement shareCount.
+        }
+
+        // The progenitor is now the sole owner — shareCount must be back to 1.
+        XCTAssertEqual(progenitor.testCharacterBufferShareCount(), 1,
+                       "After copy dealloc, shareCount must return to 1")
+
+        // removeLastRawLine is a structural edit that consults
+        // cloneCharacterBufferIfZeroCopyShared. At shareCount == 1 it must
+        // operate in-place (no clone). Buffer identity proves this.
+        let identityBefore = progenitor.testCharacterBufferIdentity()
+        progenitor.removeLastRawLine()
+        XCTAssertEqual(progenitor.testCharacterBufferIdentity(), identityBefore,
+                       "Guarded structural edit must not clone at shareCount == 1")
+        XCTAssertEqual(progenitor.numRawLines(), 0,
+                       "removeLastRawLine must have taken effect")
+    }
+
+    func testZeroCopyCopy_MultipleDeallocsDecrementShareCount() {
+        // Creating one copy at a time, then deallocating it, exercises
+        // shareCount going 1→2→1 five times. After each dealloc the
+        // progenitor must be sole owner.
+        let progenitor = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendPartialASCII(progenitor, "Hello")
+
+        let baselineIdentity = progenitor.testCharacterBufferIdentity()
+
+        for i in 0..<5 {
+            autoreleasepool {
+                let copy = progenitor.cowCopy()
+                XCTAssertTrue(copy.sharesCharacterBuffer(with: progenitor))
+                XCTAssertEqual(progenitor.testCharacterBufferShareCount(), 2,
+                               "Round \(i): shareCount must be 2 while copy exists")
+                // copy deallocated here — shareCount should decrement.
+            }
+            // After each dealloc: sole owner, buffer identity unchanged.
+            XCTAssertEqual(progenitor.testCharacterBufferShareCount(), 1,
+                           "Round \(i): shareCount must be 1 after copy dealloc")
+            XCTAssertEqual(progenitor.testCharacterBufferIdentity(), baselineIdentity,
+                           "Round \(i): buffer must not be cloned by dealloc")
+        }
+
+        // Final proof: a guarded structural edit operates in-place (not clone)
+        // because no shareCount leaked across the five cycles.
+        progenitor.removeLastRawLine()
+        XCTAssertEqual(progenitor.testCharacterBufferIdentity(), baselineIdentity,
+                       "Guarded edit must not clone at shareCount == 1")
+        XCTAssertEqual(progenitor.numRawLines(), 0,
+                       "removeLastRawLine must have taken effect")
     }
 
     // MARK: - F. Sync Cycle Flow Tests (contract guard for #3)
@@ -3738,10 +4102,10 @@ class LineBlockZeroCopyMergeTests: XCTestCase {
 
     func testZeroCopyMerge_AppendExceedsBufferSize_MergeStillWorks() {
         // When appending a partial line that exceeds the block's buffer,
-        // LineBuffer should resize in place rather than pop/reappend.
-        // The resize may relocate the buffer (for small allocations below
-        // the VM-backed threshold), which disables zero-copy merge but the
-        // fallback path handles it correctly.
+        // LineBuffer resizes in place. The shared buffer is cloned before
+        // resize to avoid use-after-free from concurrent readers (realloc
+        // has no in-place guarantee). This breaks zero-copy sharing for
+        // that cycle, but the fallback path handles it correctly.
         let source = LineBuffer()
         source.setMaxLines(1000)
 
@@ -3758,8 +4122,8 @@ class LineBlockZeroCopyMergeTests: XCTestCase {
         let longSCA = screenCharArrayWithDefaultStyle(longAppend, eol: EOL_SOFT)
         source.append(longSCA, width: 80)
 
-        // Merge — uses zero-copy if buffer wasn't relocated, fallback otherwise.
-        // Either way, the content must be correct.
+        // Merge — clone-before-resize broke sharing, so this uses the
+        // fallback COW path. Content must still be correct.
         dest.merge(from: source)
 
         // Get the full unwrapped line
@@ -3767,5 +4131,682 @@ class LineBlockZeroCopyMergeTests: XCTestCase {
         let expectedContent = "abc" + longAppend
         XCTAssertEqual(fullLine.stringValue, expectedContent,
                        "Content mismatch after buffer resize")
+    }
+
+    // MARK: - I. Adversarial ShareCount & Buffer Integrity Tests
+
+    // These tests act as an abusive consumer that does obscene things to shared
+    // buffers: hammering shareCount transitions, interleaving mutations on both
+    // sides, forcing reallocs while shared, creating deep copy chains, and
+    // verifying that every invariant holds even when treated with total contempt.
+
+    // MARK: I.1 — ShareCount Accounting
+
+    func testShareCount_FreshBlockStartsAtOne() {
+        let block = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendPartialASCII(block, "Hello")
+
+        XCTAssertEqual(block.testCharacterBufferShareCount(), 1,
+                       "Fresh block must have shareCount == 1")
+        XCTAssertFalse(block.testCharacterBufferIsShared())
+    }
+
+    func testShareCount_CowCopyIncrementsToTwo() {
+        let block = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendPartialASCII(block, "Hello")
+
+        let copy = block.cowCopy()
+
+        // Both point at the same buffer with shareCount == 2.
+        XCTAssertEqual(block.testCharacterBufferShareCount(), 2)
+        XCTAssertEqual(copy.testCharacterBufferShareCount(), 2)
+        XCTAssertTrue(block.testCharacterBufferIsShared())
+    }
+
+    func testShareCount_MultipleCopiesAccumulate() {
+        let block = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendPartialASCII(block, "Hello")
+
+        var copies = [LineBlock]()
+        for _ in 0..<10 {
+            copies.append(block.cowCopy())
+        }
+
+        // Original + 10 copies = shareCount 11.
+        XCTAssertEqual(block.testCharacterBufferShareCount(), 11,
+                       "shareCount must equal 1 + number of zero-copy copies")
+
+        // Every copy sees the same count (they share the same buffer object).
+        for (i, copy) in copies.enumerated() {
+            XCTAssertEqual(copy.testCharacterBufferShareCount(), 11,
+                           "Copy \(i) must agree on shareCount")
+            XCTAssertTrue(copy.sharesCharacterBuffer(with: block))
+        }
+    }
+
+    func testShareCount_DeallocDecrementsExactly() {
+        // cowCopy returns an autoreleased object (name doesn't match
+        // alloc/new/copy/mutableCopy), so dealloc is deferred until the
+        // autorelease pool drains. Create each copy inside its own
+        // autoreleasepool scope so ARC can reclaim it deterministically.
+        let block = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendPartialASCII(block, "Hello")
+
+        // Create 5 copies, each in its own autoreleasepool so the
+        // autorelease entry is drained when the pool ends.
+        var copies = [LineBlock]()
+        for _ in 0..<5 {
+            autoreleasepool {
+                copies.append(block.cowCopy())
+            }
+        }
+        XCTAssertEqual(block.testCharacterBufferShareCount(), 6)
+
+        // Destroy them one by one. We must drain each copy's scope.
+        while !copies.isEmpty {
+            let expected = Int32(copies.count) // after removing one
+            autoreleasepool {
+                copies.removeLast()
+            }
+            XCTAssertEqual(block.testCharacterBufferShareCount(), expected,
+                           "After removing a copy, shareCount should be \(expected)")
+        }
+
+        XCTAssertEqual(block.testCharacterBufferShareCount(), 1,
+                       "After all copies destroyed, shareCount must be 1")
+        XCTAssertFalse(block.testCharacterBufferIsShared())
+    }
+
+    func testShareCount_MutationOnCopyDecrementsAndClones() {
+        let block = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendPartialASCII(block, "Hello")
+
+        let copy = block.cowCopy()
+        XCTAssertEqual(block.testCharacterBufferShareCount(), 2)
+
+        // Mutating the copy clones its buffer (decrementing the shared one).
+        copy.removeLastRawLine()
+
+        // Original's buffer: shareCount back to 1.
+        XCTAssertEqual(block.testCharacterBufferShareCount(), 1)
+        // Copy has a fresh buffer with shareCount == 1.
+        XCTAssertEqual(copy.testCharacterBufferShareCount(), 1)
+        XCTAssertFalse(block.sharesCharacterBuffer(with: copy))
+    }
+
+    func testShareCount_MutationOnOriginalDecrementsAndClones() {
+        let block = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendPartialASCII(block, "Hello")
+
+        let copy = block.cowCopy()
+        let originalBufferIdentity = block.testCharacterBufferIdentity()
+
+        // A non-append mutation on the original should clone.
+        block.setPartial(false)
+
+        // The original got a new buffer.
+        XCTAssertNotEqual(block.testCharacterBufferIdentity(), originalBufferIdentity,
+                          "Original must have cloned its buffer")
+        XCTAssertEqual(block.testCharacterBufferShareCount(), 1)
+        // The copy retains the original buffer, now sole owner.
+        XCTAssertEqual(copy.testCharacterBufferShareCount(), 1)
+    }
+
+    // MARK: I.2 — Interleaved Mutations (Both Sides)
+
+    func testShareCount_BothSidesMutate_NeitherCorrupted() {
+        let block = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendPartialASCII(block, "AAAA")
+
+        let copy = block.cowCopy()
+        XCTAssertTrue(copy.sharesCharacterBuffer(with: block))
+
+        // Mutate the copy first (gets a clone).
+        appendHardASCII(copy, "BBBB")
+        XCTAssertFalse(copy.sharesCharacterBuffer(with: block))
+
+        // Now mutate the original (should NOT clone — it's sole owner now).
+        let identityBefore = block.testCharacterBufferIdentity()
+        block.setPartial(false)
+        let identityAfter = block.testCharacterBufferIdentity()
+        XCTAssertEqual(identityBefore, identityAfter,
+                       "Original must not clone when it's the sole owner")
+
+        // Verify content isolation.
+        let originalLine = block.screenCharArray(forRawLine: 0)
+        XCTAssertEqual(originalLine.stringValue, "AAAA",
+                       "Original content must be untouched")
+
+        let copyLine = copy.screenCharArray(forRawLine: 0)
+        XCTAssertEqual(copyLine.stringValue, "AAAABBBB",
+                       "Copy must contain original partial + hard append")
+        XCTAssertEqual(copy.numRawLines(), 1,
+                       "Copy should have 1 raw line (partial extended with hard)")
+    }
+
+    func testShareCount_OriginalMutatesFirst_CopyMutatesSecond() {
+        let block = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendPartialASCII(block, "XXXX")
+
+        let copy = block.cowCopy()
+
+        // Original mutates first — clones away from the shared buffer.
+        block.removeLastRawLine()
+        XCTAssertEqual(block.testCharacterBufferShareCount(), 1)
+        XCTAssertEqual(copy.testCharacterBufferShareCount(), 1)
+
+        // Copy mutates second — it's sole owner, no clone needed.
+        let copyIdentityBefore = copy.testCharacterBufferIdentity()
+        copy.setPartial(false)
+        XCTAssertEqual(copy.testCharacterBufferIdentity(), copyIdentityBefore,
+                       "Copy must not clone when sole owner")
+    }
+
+    // MARK: I.3 — Realloc Under Sharing (the scary one)
+
+    func testShareCount_ResizeWhileShared_ClonesBeforeRealloc() {
+        // This is the scenario where realloc could relocate memory out from
+        // under a concurrent reader. The mutation guard must clone first.
+        let block = LineBlock(rawBufferSize: 16, absoluteBlockNumber: 0)
+        appendPartialASCII(block, "Hi")
+
+        let copy = block.cowCopy()
+        let sharedBufferIdentity = block.testCharacterBufferIdentity()
+
+        XCTAssertEqual(block.testCharacterBufferShareCount(), 2)
+
+        // Force a resize on the original. This MUST clone before realloc.
+        block.changeBufferSize(8192)
+
+        // The original got a new buffer (cloned then resized).
+        XCTAssertNotEqual(block.testCharacterBufferIdentity(), sharedBufferIdentity,
+                          "Original must have a new buffer after clone+resize")
+        XCTAssertEqual(block.testCharacterBufferShareCount(), 1)
+
+        // The copy retains the original small buffer, untouched.
+        XCTAssertEqual(copy.testCharacterBufferIdentity(), sharedBufferIdentity)
+        XCTAssertEqual(copy.testCharacterBufferShareCount(), 1)
+
+        // Both have correct content.
+        XCTAssertEqual(block.screenCharArray(forRawLine: 0).stringValue, "Hi")
+        XCTAssertEqual(copy.screenCharArray(forRawLine: 0).stringValue, "Hi")
+    }
+
+    func testShareCount_ShrinkToFitWhileShared_ClonesBeforeRealloc() {
+        // Use a buffer just over rawSpaceUsed so the difference is <= 100:
+        // "Tiny" occupies 4 cells, so 104 - 4 = 100, which is not > 100.
+        // shouldOptimizeOutBufferSizeChangeTo: skips the resize only when
+        // (existing - desired) > 100, so the resize proceeds at this size.
+        let block = LineBlock(rawBufferSize: 104, absoluteBlockNumber: 0)
+        appendPartialASCII(block, "Tiny")
+
+        let copy = block.cowCopy()
+        XCTAssertTrue(copy.sharesCharacterBuffer(with: block))
+
+        // shrinkToFit calls changeBufferSize which must clone first.
+        block.shrinkToFit()
+
+        XCTAssertFalse(copy.sharesCharacterBuffer(with: block),
+                       "shrinkToFit must clone shared buffer before resize")
+        XCTAssertEqual(block.screenCharArray(forRawLine: 0).stringValue, "Tiny")
+        XCTAssertEqual(copy.screenCharArray(forRawLine: 0).stringValue, "Tiny")
+    }
+
+    func testShareCount_RepeatedResizeGrowShrinkCycle() {
+        // Grow the buffer repeatedly while copies exist. Each resize clones
+        // the shared buffer before realloc, breaking sharing.
+        let block = LineBlock(rawBufferSize: 64, absoluteBlockNumber: 0)
+        appendPartialASCII(block, "seed")
+
+        for i in 0..<20 {
+            let copy = block.cowCopy()
+            XCTAssertTrue(copy.sharesCharacterBuffer(with: block),
+                          "Iteration \(i): fresh copy must share buffer")
+
+            // Grow — must clone shared buffer before realloc.
+            block.changeBufferSize(Int32(128 + i * 64))
+            XCTAssertFalse(copy.sharesCharacterBuffer(with: block),
+                           "Iteration \(i): resize must break sharing")
+            XCTAssertEqual(block.testCharacterBufferShareCount(), 1,
+                           "Iteration \(i): original must be sole owner of new buffer")
+            XCTAssertEqual(copy.testCharacterBufferShareCount(), 1,
+                           "Iteration \(i): copy must be sole owner of old buffer")
+
+            // Verify content survived.
+            XCTAssertEqual(block.screenCharArray(forRawLine: 0).stringValue, "seed",
+                           "Iteration \(i): content corrupted after resize")
+        }
+    }
+
+    // MARK: I.4 — Deep Copy Chains
+
+    func testShareCount_CopyOfCopy_IndependentShareCounts() {
+        // cowCopy of a cowCopy: the second copy shares the buffer with
+        // the original owner, not the intermediate copy.
+        let original = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendPartialASCII(original, "Root")
+
+        let copy1 = original.cowCopy()
+        XCTAssertEqual(original.testCharacterBufferShareCount(), 2)
+
+        // copy1 hasn't mutated, so its buffer is still the original's.
+        // Making a cowCopy of copy1 should also share the same buffer.
+        let copy2 = copy1.cowCopy()
+
+        // All three share the same buffer.
+        XCTAssertTrue(copy1.sharesCharacterBuffer(with: original))
+        XCTAssertTrue(copy2.sharesCharacterBuffer(with: original))
+        XCTAssertEqual(original.testCharacterBufferShareCount(), 3)
+    }
+
+    func testShareCount_CopyChain_MutateMiddle_IsolatesCorrectly() {
+        let original = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendPartialASCII(original, "Root")
+
+        let copy1 = original.cowCopy()
+        let copy2 = copy1.cowCopy()
+        XCTAssertEqual(original.testCharacterBufferShareCount(), 3)
+
+        // Mutate copy1 — it clones away.
+        copy1.removeLastRawLine()
+
+        // copy1 has its own buffer now.
+        XCTAssertFalse(copy1.sharesCharacterBuffer(with: original))
+        XCTAssertEqual(copy1.testCharacterBufferShareCount(), 1)
+
+        // original and copy2 still share.
+        XCTAssertTrue(copy2.sharesCharacterBuffer(with: original))
+        XCTAssertEqual(original.testCharacterBufferShareCount(), 2)
+
+        // Content check.
+        XCTAssertEqual(original.screenCharArray(forRawLine: 0).stringValue, "Root")
+        XCTAssertEqual(copy2.screenCharArray(forRawLine: 0).stringValue, "Root")
+        XCTAssertEqual(copy1.numRawLines(), 0)
+    }
+
+    // MARK: I.5 — Rapid Create/Destroy Churn
+
+    func testShareCount_RapidCreateDestroyCycle_NoLeaks() {
+        // Hammer the shareCount up and down by creating bursts of copies
+        // that each mutate (forcing clone + shareCount decrement) and then
+        // dealloc. This catches off-by-one errors in the count logic.
+        let block = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendPartialASCII(block, "Stable")
+
+        for round in 0..<5 {
+            let burstSize = (round + 1) * 3  // 3, 6, 9, 12, 15
+
+            // Create a burst of copies.
+            var burst = [LineBlock]()
+            for _ in 0..<burstSize {
+                autoreleasepool {
+                    burst.append(block.cowCopy())
+                }
+            }
+            XCTAssertEqual(block.testCharacterBufferShareCount(), Int32(burstSize + 1),
+                           "Round \(round): shareCount must be burst + 1")
+
+            // Mutate each copy to force clone (decrements shareCount).
+            for (i, copy) in burst.enumerated() {
+                copy.setPartial(false)
+                XCTAssertEqual(block.testCharacterBufferShareCount(), Int32(burstSize - i),
+                               "Round \(round), mutation \(i): shareCount incorrect")
+            }
+
+            XCTAssertEqual(block.testCharacterBufferShareCount(), 1,
+                           "Round \(round): must be sole owner after all copies mutated")
+            burst.removeAll()
+        }
+
+        // Original content must be perfectly intact after all the abuse.
+        XCTAssertEqual(block.screenCharArray(forRawLine: 0).stringValue, "Stable")
+    }
+
+    // MARK: I.6 — Content Integrity Under Every Mutation Path
+
+    func testShareCount_EveryMutationPath_ClonesAndPreservesContent() {
+        // For each mutation that should trigger cloneCharacterBufferIfZeroCopyShared,
+        // verify: (a) sharing breaks, (b) shareCount is correct, (c) content is intact.
+        let mutations: [(String, (LineBlock) -> Void)] = [
+            ("setPartial(false)", { $0.setPartial(false) }),
+            ("removeLastRawLine", { $0.removeLastRawLine() }),
+            ("appendHard", { [self] block in appendHardASCII(block, "X") }),
+            ("appendNewLine", { [self] block in
+                // Complete the existing partial, then add a fresh raw line.
+                // This exercises the "add a new line" branch in
+                // reallyAppendLine (distinct from appendHard which extends
+                // the existing partial with a hard EOL).
+                let rawLinesBefore = block.numRawLines()
+                block.setPartial(false)
+                appendPartialASCII(block, "new")
+                XCTAssertEqual(block.numRawLines(), rawLinesBefore + 1,
+                               "appendNewLine must create a new raw line")
+            }),
+            ("dropLines", { block in
+                // Need wrapped lines to drop. "Hello" at width 2 wraps.
+                var dropped: Int32 = 0
+                _ = block.dropLines(1, withWidth: 2, chars: &dropped)
+            }),
+            ("changeBufferSize", { $0.changeBufferSize(4096) }),
+            // shrinkToFit is tested separately — it goes through ModifyLineBlock
+            // which uses the zero-copy COW path before changeBufferSize clones.
+        ]
+
+        for (name, mutation) in mutations {
+            autoreleasepool {
+                let block = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+                appendPartialASCII(block, "Hello")
+
+                let copy = block.cowCopy()
+                XCTAssertTrue(copy.sharesCharacterBuffer(with: block),
+                              "\(name): must share before mutation")
+                XCTAssertEqual(block.testCharacterBufferShareCount(), 2,
+                               "\(name): shareCount must be 2 before mutation")
+
+                // Apply the mutation to the original.
+                mutation(block)
+
+                // Sharing must be broken.
+                XCTAssertFalse(copy.sharesCharacterBuffer(with: block),
+                               "\(name): must break sharing after mutation")
+
+                // Both sides have shareCount == 1.
+                XCTAssertEqual(block.testCharacterBufferShareCount(), 1,
+                               "\(name): original shareCount must be 1 after mutation")
+                XCTAssertEqual(copy.testCharacterBufferShareCount(), 1,
+                               "\(name): copy shareCount must be 1 after mutation")
+
+                // Copy content is untouched.
+                XCTAssertEqual(copy.screenCharArray(forRawLine: 0).stringValue, "Hello",
+                               "\(name): copy content must be preserved")
+            }
+        }
+    }
+
+    // MARK: I.7 — Append-Only Path (the zero-copy hot path)
+
+    func testShareCount_AppendPartialToSharedBuffer_NoClone() {
+        // The whole point of zero-copy: appending partial data to the progenitor
+        // must NOT clone. It extends the buffer in-place and the copy sees the
+        // new data via zeroCopyMerge. Verify no clone happens.
+        let block = LineBlock(rawBufferSize: 4096, absoluteBlockNumber: 0)
+        appendPartialASCII(block, "Start")
+
+        let copy = block.cowCopy()
+        let sharedIdentity = block.testCharacterBufferIdentity()
+
+        // Append more partial data.
+        appendPartialASCII(block, " more")
+        appendPartialASCII(block, " data")
+        appendPartialASCII(block, " here")
+
+        // Buffer must STILL be shared — no clone on the append-only path.
+        XCTAssertTrue(copy.sharesCharacterBuffer(with: block),
+                      "Partial appends must not clone the shared buffer")
+        XCTAssertEqual(block.testCharacterBufferIdentity(), sharedIdentity,
+                       "Buffer identity must be unchanged after partial appends")
+        XCTAssertEqual(block.testCharacterBufferShareCount(), 2)
+    }
+
+    // MARK: I.8 — The Dealloc Race
+
+    func testShareCount_DeallocWhileOtherSideHoldsReference() {
+        // cowCopy sets copy.owner = progenitor (strong), so the progenitor
+        // cannot dealloc while the copy lives. To actually exercise the
+        // progenitor's dealloc: mutate the copy through ModifyLineBlock
+        // (which clears owner), then let the progenitor's scope end.
+        var copy: LineBlock!
+        weak var weakBlock: LineBlock?
+
+        autoreleasepool {
+            let block = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+            appendPartialASCII(block, "Ephemeral")
+            weakBlock = block
+
+            copy = block.cowCopy()
+            XCTAssertEqual(block.testCharacterBufferShareCount(), 2)
+            XCTAssertTrue(copy.hasOwner(),
+                          "Copy must have owner before mutation")
+
+            // changeBufferSize goes through ModifyLineBlock →
+            // validMutationCertificate which clears copy.owner, breaking
+            // the strong retention path. The zero-copy path in
+            // validMutationCertificate keeps the buffer shared; then
+            // changeBufferSize:cert: calls cloneCharacterBufferIfZeroCopyShared
+            // which clones it.
+            copy.changeBufferSize(2048)
+            XCTAssertFalse(copy.hasOwner(),
+                           "Mutation must clear owner relationship")
+            // block's scope ends here; no strong refs remain → dealloc.
+        }
+
+        // The original must actually be deallocated.
+        XCTAssertNil(weakBlock,
+                     "Original must be deallocated after owner cleared and scope ended")
+
+        // Copy survives with its own independent buffer.
+        XCTAssertEqual(copy.testCharacterBufferShareCount(), 1,
+                       "Surviving copy must be sole owner of its buffer")
+        XCTAssertEqual(copy.screenCharArray(forRawLine: 0).stringValue, "Ephemeral",
+                       "Content must survive progenitor dealloc")
+
+        // A guarded mutation on the survivor must operate in-place.
+        let identityBefore = copy.testCharacterBufferIdentity()
+        copy.removeLastRawLine()
+        XCTAssertEqual(copy.testCharacterBufferIdentity(), identityBefore,
+                       "Guarded edit must not clone on sole-owner survivor")
+    }
+
+    func testShareCount_AllCopiesDieThenOriginalMutates() {
+        let block = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendPartialASCII(block, "Survivor")
+
+        // Create copies that each mutate (cloning their buffer) and then dealloc.
+        // This exercises the shareCount going up and back down repeatedly.
+        for i in 0..<100 {
+            autoreleasepool {
+                let copy = block.cowCopy()
+                // Mutate to force clone (decrements shareCount on shared buffer).
+                copy.setPartial(false)
+                XCTAssertEqual(block.testCharacterBufferShareCount(), 1,
+                               "Iteration \(i): after copy mutation, original must be sole owner")
+                // copy deallocs at end of autoreleasepool.
+            }
+        }
+
+        XCTAssertEqual(block.testCharacterBufferShareCount(), 1,
+                       "After 100 copy-mutate-destroy cycles, must be sole owner")
+
+        // Original content must be perfectly intact.
+        XCTAssertEqual(block.screenCharArray(forRawLine: 0).stringValue, "Survivor")
+    }
+
+    // MARK: I.9 — Mixed Sharing Modes (zero-copy eligible vs. not)
+
+    func testShareCount_MultiLineBlock_NeverIncrementsShareCount() {
+        // Zero-copy sharing only applies to single-partial-line blocks.
+        // A multi-line block's cowCopy must NOT increment shareCount.
+        // Note: copyDeep:NO always shares the buffer *object*, but shareCount
+        // is only incremented for the zero-copy eligible case.
+        let block = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendHardASCII(block, "Line1")
+        appendPartialASCII(block, "Line2")
+
+        XCTAssertEqual(block.testCharacterBufferShareCount(), 1)
+
+        let copy = block.cowCopy()
+
+        // shareCount stays at 1 — zero-copy sharing not active.
+        XCTAssertEqual(block.testCharacterBufferShareCount(), 1,
+                       "Multi-line cowCopy must not increment shareCount")
+        // The buffer objects are the same (copyDeep:NO shares). Standard COW
+        // handles mutation through the mutation certificate, not shareCount.
+        XCTAssertTrue(copy.sharesCharacterBuffer(with: block),
+                      "cowCopy always shares buffer object initially")
+
+        // Mutations that don't touch the buffer (like removeLastRawLine)
+        // may keep the buffer shared — they only modify CLL/metadata.
+        // Mutations that go through ModifyLineBlock (like changeBufferSize)
+        // trigger the full COW clone via validMutationCertificate.
+        copy.changeBufferSize(2048)
+        XCTAssertFalse(copy.sharesCharacterBuffer(with: block),
+                       "After ModifyLineBlock mutation, standard COW must clone the buffer")
+        // shareCount never changed — standard COW doesn't use it.
+        XCTAssertEqual(block.testCharacterBufferShareCount(), 1)
+    }
+
+    func testShareCount_CompletedLineBlock_NeverIncrementsShareCount() {
+        // A block with a single hard (complete) line is not eligible for
+        // zero-copy. shareCount stays at 1, but buffer is shared initially
+        // via copyDeep:NO.
+        let block = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendHardASCII(block, "Done")
+
+        let copy = block.cowCopy()
+
+        XCTAssertEqual(block.testCharacterBufferShareCount(), 1,
+                       "Hard-EOL block's cowCopy must not increment shareCount")
+        // Buffer is shared initially (copyDeep:NO), but standard COW
+        // will clone on first mutation.
+        XCTAssertTrue(copy.sharesCharacterBuffer(with: block),
+                      "cowCopy always shares buffer object initially")
+    }
+
+    // MARK: I.10 — Stress: Alternating Copy/Mutate/Copy
+
+    func testShareCount_AlternatingCopyAndMutate_ShareCountStaysCorrect() {
+        // The pattern: copy, mutate original (clone), copy again (re-share),
+        // mutate copy (clone), repeat. ShareCount bounces between 1 and 2.
+        let block = LineBlock(rawBufferSize: 4096, absoluteBlockNumber: 0)
+        appendPartialASCII(block, "base")
+
+        for i in 0..<25 {
+            autoreleasepool {
+                // Step 1: Make a copy (shareCount -> 2).
+                let copy = block.cowCopy()
+                XCTAssertEqual(block.testCharacterBufferShareCount(), 2,
+                               "Iteration \(i) after cowCopy: shareCount must be 2")
+
+                // Step 2: Mutate the copy (clone away, both -> 1).
+                copy.setPartial(false)
+                XCTAssertEqual(block.testCharacterBufferShareCount(), 1,
+                               "Iteration \(i) after copy mutation: original shareCount must be 1")
+                XCTAssertEqual(copy.testCharacterBufferShareCount(), 1,
+                               "Iteration \(i) after copy mutation: copy shareCount must be 1")
+
+                // copy deallocs here — it has its own buffer, so no effect on original.
+            }
+            XCTAssertEqual(block.testCharacterBufferShareCount(), 1,
+                           "Iteration \(i) after copy dealloc: must be sole owner")
+        }
+
+        XCTAssertEqual(block.screenCharArray(forRawLine: 0).stringValue, "base",
+                       "Content must survive 25 rounds of copy/mutate/destroy")
+    }
+
+    // MARK: I.11 — Zero-Copy Merge Under Adversarial Conditions
+
+    func testZeroCopyMerge_MergeAfterResizeFallsBackCorrectly() {
+        // Exercise fallback through the real LineBuffer merge path.
+        let width = Int32(80)
+        let source = LineBuffer()
+        source.setMaxLines(1000)
+        let dest = LineBuffer()
+        dest.setMaxLines(1000)
+
+        let xSCA = screenCharArrayWithDefaultStyle("x", eol: EOL_SOFT)
+        source.append(xSCA, width: width)
+        dest.forceMerge(from: source)
+
+        // Append keeps the source's last block zero-copy mergeable.
+        let ySCA = screenCharArrayWithDefaultStyle("y", eol: EOL_SOFT)
+        source.append(ySCA, width: width)
+
+        let sourceBlock = source.testOnlyBlock(at: 0)
+        let destBlock = dest.testOnlyBlock(at: 0)
+        XCTAssertTrue(destBlock.canZeroCopyMergeFromProgenitor(),
+                      "Must be zero-copy eligible before resize")
+
+        // Resize source block; force a guaranteed grow so the resize is not
+        // optimized out.
+        sourceBlock.changeBufferSize(sourceBlock.rawBufferSize + 1)
+        XCTAssertFalse(destBlock.canZeroCopyMergeFromProgenitor(),
+                       "Resize must force fallback merge path")
+
+        // Perform merge and verify fallback correctness.
+        dest.forceMerge(from: source)
+        let merged = dest.unwrappedLine(at: 0)
+        XCTAssertEqual(merged.stringValue, "xy",
+                       "Fallback merge must preserve full appended content")
+        XCTAssertFalse(merged.stringValue.contains("\0"),
+                       "Fallback merge output must not contain NULs")
+    }
+
+    func testZeroCopyMerge_ManyMergeCyclesWithGrowingContent() {
+        // Hammer the merge path with many cycles, each appending enough
+        // to require buffer growth. Alternates between zero-copy and fallback.
+        let source = LineBuffer()
+        source.setMaxLines(100000)
+        let width = Int32(80)
+
+        let seedLS = makeLineString(".", eol: EOL_SOFT)
+        let seedSCA = seedLS.screenCharArray(bidi: nil)
+        source.appendLine(seedSCA.line, length: seedSCA.length,
+                          partial: true, width: width,
+                          metadata: seedSCA.metadata,
+                          continuation: seedSCA.continuation)
+
+        let dest = LineBuffer()
+        dest.setMaxLines(100000)
+        dest.forceMerge(from: source)
+
+        var expected = "."
+        var zeroCopyEligibleCycles = 0
+        var fallbackIneligibleCycles = 0
+
+        for i in 0..<100 {
+            // Vary chunk size: sometimes small (zero-copy stays), sometimes huge (forces resize).
+            let chunkSize = (i % 10 == 0) ? 5000 : (i % 3 + 1)
+            let chunk = String(repeating: Character(UnicodeScalar(Int(("a" as UnicodeScalar).value) + (i % 26))!),
+                               count: chunkSize)
+            expected += chunk
+
+            let chunkLS = makeLineString(chunk, eol: EOL_SOFT)
+            let chunkSCA = chunkLS.screenCharArray(bidi: nil)
+            source.appendLine(chunkSCA.line, length: chunkSCA.length,
+                              partial: true, width: width,
+                              metadata: chunkSCA.metadata,
+                              continuation: chunkSCA.continuation)
+
+            // Track which merge path is eligible this cycle.
+            let destBlock = dest.testOnlyBlock(at: 0)
+            if destBlock.canZeroCopyMergeFromProgenitor() {
+                zeroCopyEligibleCycles += 1
+            } else {
+                fallbackIneligibleCycles += 1
+            }
+
+            dest.forceMerge(from: source)
+
+            let line = dest.unwrappedLine(at: 0)
+            XCTAssertEqual(line.stringValue, expected,
+                           "Content mismatch at merge cycle \(i)")
+        }
+
+        XCTAssertGreaterThan(zeroCopyEligibleCycles, 0,
+                             "Expected at least one zero-copy-eligible cycle")
+        XCTAssertGreaterThan(fallbackIneligibleCycles, 0,
+                             "Expected at least one fallback-ineligible cycle")
+    }
+
+    // MARK: I.12 — eraseRTLStatusInAllCharacters Enforcement
+
+    func testEraseRTLStatus_BeforeCopy_Succeeds() {
+        // Calling before any copy should not assert.
+        let block = LineBlock(rawBufferSize: 1024, absoluteBlockNumber: 0)
+        appendPartialASCII(block, "Hello")
+
+        // This must not crash.
+        block.eraseRTLStatusInAllCharacters()
     }
 }

--- a/sources/LineBlock+Private.h
+++ b/sources/LineBlock+Private.h
@@ -58,10 +58,6 @@ NS_ASSUME_NONNULL_BEGIN
     // In progenitor: YES if only partial-line appends occurred since last cowCopy.
     // Reset to YES on cowCopy, set to NO on any non-append mutation.
     BOOL _appendOnlySinceLastCopy;
-
-    // In progenitor: YES if character buffer is shared with a copy via zero-copy.
-    // Append-only mutations are safe; non-append mutations must clone first.
-    BOOL _zeroCopyShared;
 }
 
 // These are synchronized on [LineBlock class]. Sample graph:

--- a/sources/LineBlock+Private.h
+++ b/sources/LineBlock+Private.h
@@ -59,10 +59,9 @@ NS_ASSUME_NONNULL_BEGIN
     // Reset to YES on cowCopy, set to NO on any non-append mutation.
     BOOL _appendOnlySinceLastCopy;
 
-    // In copy: YES if this copy has been mutated (cloned its buffer).
-    // Set when validMutationCertificate clones buffer for a copy (self.owner != nil).
-    // Used to prevent incremental merge for diverged copies.
-    BOOL _hasDiverged;
+    // In progenitor: YES if character buffer is shared with a copy via zero-copy.
+    // Append-only mutations are safe; non-append mutations must clone first.
+    BOOL _zeroCopyShared;
 }
 
 // These are synchronized on [LineBlock class]. Sample graph:

--- a/sources/LineBlock.h
+++ b/sources/LineBlock.h
@@ -287,6 +287,15 @@ void EnableDoubleWidthCharacterLineCache(void);
 - (void)zeroCopyMergeFromProgenitor;
 - (BOOL)sharesCharacterBufferWith:(LineBlock *)other;
 
+// Testing only. Returns the character buffer's shareCount.
+- (int)testCharacterBufferShareCount;
+
+// Testing only. Returns YES when the character buffer's shareCount > 1.
+- (BOOL)testCharacterBufferIsShared;
+
+// Testing only. Returns the identity of the underlying character buffer object.
+- (NSUInteger)testCharacterBufferIdentity;
+
 - (id)copy NS_UNAVAILABLE;
 - (id)copyWithZone:(nullable NSZone *)zone NS_UNAVAILABLE;
 - (LineBlock *)cowCopy;

--- a/sources/LineBlock.h
+++ b/sources/LineBlock.h
@@ -283,11 +283,9 @@ void EnableDoubleWidthCharacterLineCache(void);
 - (void)invalidate;
 - (NSInteger)sizeFromLine:(int)lineNum width:(int)width;
 
-// Incremental merge support: returns YES if the progenitor's only mutations since this
-// cowCopy were partial-line appends, enabling an optimized merge that copies only the delta.
-@property(nonatomic, readonly) BOOL appendOnlySinceLastCopy;
-@property(nonatomic, readonly) BOOL canIncrementalMergeFromProgenitor;
-- (void)incrementalMergeFromProgenitor;
+- (BOOL)canZeroCopyMergeFromProgenitor;
+- (void)zeroCopyMergeFromProgenitor;
+- (BOOL)sharesCharacterBufferWith:(LineBlock *)other;
 
 - (id)copy NS_UNAVAILABLE;
 - (id)copyWithZone:(nullable NSZone *)zone NS_UNAVAILABLE;

--- a/sources/LineBlock.mm
+++ b/sources/LineBlock.mm
@@ -348,8 +348,18 @@ NS_INLINE void iTermLineBlockDidChange(__unsafe_unretained LineBlock *lineBlock,
     return self;
 }
 
-// NOTE: You must not acquire a lock in dealloc. Assume it is reentrant.
+// NOTE: dealloc may be called reentrantly (releasing the lock can trigger another dealloc).
+// gLineBlockMutex is a recursive_mutex, so reentrant acquisition is safe.
 - (void)dealloc {
+    // If this block shares a character buffer with another block (shareCount > 1),
+    // decrement the count so the surviving block knows it is the sole owner
+    // and can skip unnecessary clones on mutation.
+    if (_characterBuffer.isShared) {
+        std::lock_guard<std::recursive_mutex> lock(gLineBlockMutex);
+        if (_characterBuffer.isShared) {
+            [_characterBuffer decrementShareCount];
+        }
+    }
     if ([self deinitializeClients]) {
         if (cumulative_line_lengths) {
             free((void *)cumulative_line_lengths);
@@ -778,6 +788,16 @@ static int iTermLineBlockNumberOfFullLinesImpl(const screen_char_t *buffer,
     return result;
 }
 
+// Clone the character buffer if it is shared (shareCount > 1), ensuring
+// exclusive ownership before a non-append mutation. The check-and-clone
+// is atomic under gLineBlockMutex.
+- (void)cloneCharacterBufferIfZeroCopyShared {
+    std::lock_guard<std::recursive_mutex> lock(gLineBlockMutex);
+    if (_characterBuffer.isShared) {
+        _characterBuffer = [_characterBuffer cloneAndDecrementShareCount];
+    }
+}
+
 - (BOOL)reallyAppendLine:(const screen_char_t *)buffer
                   length:(int)length
                  partial:(BOOL)partial
@@ -817,10 +837,7 @@ static int iTermLineBlockNumberOfFullLinesImpl(const screen_char_t *buffer,
         // If completing the line (hard EOL), the copy still thinks it's partial,
         // so zero-copy sharing must end and append tracking is invalidated.
         if (!partial) {
-            if (_zeroCopyShared) {
-                _characterBuffer = [_characterBuffer clone];
-                _zeroCopyShared = NO;
-            }
+            [self cloneCharacterBufferIfZeroCopyShared];
             _appendOnlySinceLastCopy = NO;
         }
         // update the numlines cache with the new number of full lines that the updated line has.
@@ -855,10 +872,7 @@ static int iTermLineBlockNumberOfFullLinesImpl(const screen_char_t *buffer,
 #endif
     } else {
         // add a new line
-        if (_zeroCopyShared) {
-            _characterBuffer = [_characterBuffer clone];
-            _zeroCopyShared = NO;
-        }
+        [self cloneCharacterBufferIfZeroCopyShared];
         _appendOnlySinceLastCopy = NO;
         didFindRTL = lineMetadata.rtlFound;
         [self _appendCumulativeLineLength:(space_used + length)
@@ -1502,10 +1516,7 @@ int OffsetOfWrappedLine(const screen_char_t* p, int n, int length, int width, BO
 }
 
 - (void)removeLastRawLine {
-    if (_zeroCopyShared) {
-        _characterBuffer = [_characterBuffer clone];
-        _zeroCopyShared = NO;
-    }
+    [self cloneCharacterBufferIfZeroCopyShared];
     _appendOnlySinceLastCopy = NO;
     if (cll_entries == _firstEntry) {
         return;
@@ -1554,10 +1565,7 @@ int OffsetOfWrappedLine(const screen_char_t* p, int n, int length, int width, BO
                      metadata:(out iTermImmutableMetadata *)metadataPtr
                  continuation:(screen_char_t *)continuationPtr
                          cert:(id<iTermLineBlockMutationCertificate>)cert {
-    if (_zeroCopyShared) {
-        _characterBuffer = [_characterBuffer clone];
-        _zeroCopyShared = NO;
-    }
+    [self cloneCharacterBufferIfZeroCopyShared];
     _appendOnlySinceLastCopy = NO;
     if (cll_entries == _firstEntry) {
         // There is no last line to pop.
@@ -1753,8 +1761,8 @@ int OffsetOfWrappedLine(const screen_char_t* p, int n, int length, int width, BO
 }
 
 - (int)offsetOfRawLine:(int)linenum {
-    if (linenum == 0) {
-        return 0;
+    if (linenum == _firstEntry) {
+        return self.bufferStartOffset;
     } else {
         return cumulative_line_lengths[linenum - 1];
     }
@@ -1770,8 +1778,8 @@ int OffsetOfWrappedLine(const screen_char_t* p, int n, int length, int width, BO
 
 - (const screen_char_t*)rawLine:(int)linenum {
     int start;
-    if (linenum == 0) {
-        start = 0;
+    if (linenum == _firstEntry) {
+        start = self.bufferStartOffset;
     } else {
         start = cumulative_line_lengths[linenum - 1];
     }
@@ -1805,6 +1813,14 @@ int OffsetOfWrappedLine(const screen_char_t* p, int n, int length, int width, BO
 - (void)changeBufferSize:(int)capacity cert:(id<iTermLineBlockMutationCertificate>)cert {
     ITAssertWithMessage(capacity >= [self rawSpaceUsed], @"Truncating used space");
     capacity = MAX(1, capacity);
+    // realloc may relocate the buffer at any size. Neither the C standard,
+    // POSIX, nor Apple's libmalloc guarantee in-place extension — even for
+    // large VM-backed allocations (large_try_realloc_in_place can fail when
+    // adjacent VM is already mapped). Clone before resize to avoid a
+    // use-after-free for concurrent readers (e.g., search) holding raw
+    // pointers into the old buffer. Resizes are logarithmic, so the total
+    // copy cost is bounded by O(final_size).
+    [self cloneCharacterBufferIfZeroCopyShared];
     [cert setRawBufferCapacity:capacity];
     cached_numlines_width = -1;
 }
@@ -1817,10 +1833,7 @@ int OffsetOfWrappedLine(const screen_char_t* p, int n, int length, int width, BO
     if (partial == is_partial) {
         return;
     }
-    if (_zeroCopyShared) {
-        _characterBuffer = [_characterBuffer clone];
-        _zeroCopyShared = NO;
-    }
+    [self cloneCharacterBufferIfZeroCopyShared];
     _appendOnlySinceLastCopy = NO;
     is_partial = partial;
     iTermLineBlockDidChange(self, "set partial");
@@ -1840,10 +1853,7 @@ int OffsetOfWrappedLine(const screen_char_t* p, int n, int length, int width, BO
 }
 
 - (int)dropLines:(int)orig_n withWidth:(int)width chars:(int *)charsDropped {
-    if (_zeroCopyShared) {
-        _characterBuffer = [_characterBuffer clone];
-        _zeroCopyShared = NO;
-    }
+    [self cloneCharacterBufferIfZeroCopyShared];
     _appendOnlySinceLastCopy = NO;
     // Note that there's no mutation certificate because we aren't touching the character buffer.
     [_metadataArray willMutate];
@@ -1928,6 +1938,8 @@ int OffsetOfWrappedLine(const screen_char_t* p, int n, int length, int width, BO
 }
 
 - (void)eraseRTLStatusInAllCharacters {
+    ITAssertWithMessage(!self.hasBeenCopied,
+                        @"eraseRTLStatusInAllCharacters called after copy — not CoW safe");
     if (cll_entries == 0) {
         return;
     }
@@ -1987,6 +1999,7 @@ int OffsetOfWrappedLine(const screen_char_t* p, int n, int length, int width, BO
 }
 
 - (BOOL)canZeroCopyMergeFromProgenitor {
+    std::lock_guard<std::recursive_mutex> lock(gLineBlockMutex);
     if (!_progenitor || _progenitor.invalidated) {
         return NO;
     }
@@ -2017,18 +2030,11 @@ int OffsetOfWrappedLine(const screen_char_t* p, int n, int length, int width, BO
     if (!_progenitor->_appendOnlySinceLastCopy) {
         return NO;
     }
-    if ([_progenitor->_characterBuffer wasRelocated]) {
-        return NO;
-    }
     return YES;
 }
 
 - (void)zeroCopyMergeFromProgenitor {
-    // Merge is thread-confined to the main thread and intentionally does not
-    // take gLineBlockMutex. The mutex protects the COW ownership graph
-    // (cowCopy/validMutationCertificate on the mutation thread); the merge
-    // path is serialized with mutations at a higher level (screen lock).
-    ITAssertWithMessage(NSThread.isMainThread, @"Zero-copy merge must run on the main thread");
+    std::lock_guard<std::recursive_mutex> lock(gLineBlockMutex);
     ITAssertWithMessage(self.owner == nil, @"Zero-copy merge requires ownership detach (owner should be nil)");
     ITAssertWithMessage(self.clients.count == 0, @"Zero-copy merge requires no clients (CLL must be unshared)");
 
@@ -2050,13 +2056,24 @@ int OffsetOfWrappedLine(const screen_char_t* p, int n, int length, int width, BO
 
     // Reset progenitor tracking
     _progenitor->_appendOnlySinceLastCopy = YES;
-    [_progenitor->_characterBuffer clearRelocationFlag];
 
     iTermLineBlockDidChange(self, "zero-copy merge");
 }
 
 - (BOOL)sharesCharacterBufferWith:(LineBlock *)other {
     return _characterBuffer == other->_characterBuffer;
+}
+
+- (int)testCharacterBufferShareCount {
+    return _characterBuffer.testShareCount;
+}
+
+- (BOOL)testCharacterBufferIsShared {
+    return _characterBuffer.isShared;
+}
+
+- (NSUInteger)testCharacterBufferIdentity {
+    return (NSUInteger)_characterBuffer;
 }
 
 - (int)_lineRawOffset:(int) anIndex {
@@ -2723,16 +2740,14 @@ crossBlockResultCount:(NSInteger *)crossBlockResultCount {
         const NSUInteger numberOfClients = myClients.count;
 
         // Perform copy-on-write copying.
-        if (_zeroCopyShared) {
-            // Zero-copy path: buffer stays shared, only clone the CLL.
-            // In production, only the progenitor enters this branch (copies
-            // are read-only between syncs). If a copy does enter here, the
-            // buffer clone is deferred to the mutation guard in the calling
-            // method (reallyAppendLine, removeLastRawLine, etc.).
-            // Invariant enforced by "Copy Mutation Invariant" tests in
-            // LineBlockZeroCopyMergeTests.
+        if (_characterBuffer.isShared) {
+            // Zero-copy path: buffer is shared with a copy (shareCount > 1).
+            // Keep sharing — only clone the CLL. The buffer clone is deferred
+            // to the mutation guard (cloneCharacterBufferIfZeroCopyShared) in
+            // the calling method if a non-append mutation occurs.
             iTermAssignToConstPointer((void **)&cumulative_line_lengths, iTermMemdup(self->cumulative_line_lengths, cll_capacity, sizeof(int)));
         } else {
+            // Standard COW: clone buffer + CLL.
             const ptrdiff_t offset = self.bufferStartOffset;
             _characterBuffer = [_characterBuffer clone];
             [self setBufferStartOffset:offset];
@@ -2804,12 +2819,11 @@ crossBlockResultCount:(NSInteger *)crossBlockResultCount {
     _appendOnlySinceLastCopy = YES;
 
     // Enable zero-copy sharing when eligible: single partial line, no drops.
-    // Both progenitor and copy get the flag so that mutation guards on either
-    // side will clone the buffer before writing.
+    // Increment the buffer's shareCount so mutation guards on either side
+    // know to clone before writing. The copy already holds the same
+    // _characterBuffer pointer (from copyDeep:NO).
     if (cll_entries == 1 && is_partial && _firstEntry == 0 && self.bufferStartOffset == 0) {
-        _zeroCopyShared = YES;
-        copy->_zeroCopyShared = YES;
-        [_characterBuffer clearRelocationFlag];
+        [_characterBuffer incrementShareCount];
     }
 
     return copy;

--- a/sources/LineBlock.mm
+++ b/sources/LineBlock.mm
@@ -789,19 +789,7 @@ static int iTermLineBlockNumberOfFullLinesImpl(const screen_char_t *buffer,
     int space_used = [self rawSpaceUsed];
     int free_space = _characterBuffer.size - space_used - self.bufferStartOffset;
     if (length > free_space) {
-        // Special case: if we're appending a partial line to a block that contains
-        // only one partial line, resize the buffer instead of failing. This allows
-        // incremental merge to work by keeping _appendOnlySinceLastCopy = YES.
-        // Without this optimization, LineBuffer would pop the line and reappend it,
-        // which sets _appendOnlySinceLastCopy = NO.
-        if (partial && is_partial && cll_entries == _firstEntry + 1 && _firstEntry == 0 && self.bufferStartOffset == 0) {
-            const int newCapacity = space_used + length;
-            [self changeBufferSize:newCapacity cert:cert];
-            // Recalculate free space after resize
-            free_space = _characterBuffer.size - space_used - self.bufferStartOffset;
-        } else {
-            return NO;
-        }
+        return NO;
     }
     // A line block could hold up to maxint empty lines but that makes
     // -dictionary return a very large serialized state.
@@ -826,9 +814,13 @@ static int iTermLineBlockNumberOfFullLinesImpl(const screen_char_t *buffer,
     if (is_partial && !(!partial && length == 0)) {
         // append to an existing line
         ITAssertWithMessage(cll_entries > 0, @"is_partial but has no entries");
-        // If completing the line (hard EOL), invalidate incremental merge eligibility
-        // since the copy will still think it's partial.
+        // If completing the line (hard EOL), the copy still thinks it's partial,
+        // so zero-copy sharing must end and append tracking is invalidated.
         if (!partial) {
+            if (_zeroCopyShared) {
+                _characterBuffer = [_characterBuffer clone];
+                _zeroCopyShared = NO;
+            }
             _appendOnlySinceLastCopy = NO;
         }
         // update the numlines cache with the new number of full lines that the updated line has.
@@ -863,6 +855,10 @@ static int iTermLineBlockNumberOfFullLinesImpl(const screen_char_t *buffer,
 #endif
     } else {
         // add a new line
+        if (_zeroCopyShared) {
+            _characterBuffer = [_characterBuffer clone];
+            _zeroCopyShared = NO;
+        }
         _appendOnlySinceLastCopy = NO;
         didFindRTL = lineMetadata.rtlFound;
         [self _appendCumulativeLineLength:(space_used + length)
@@ -1506,6 +1502,10 @@ int OffsetOfWrappedLine(const screen_char_t* p, int n, int length, int width, BO
 }
 
 - (void)removeLastRawLine {
+    if (_zeroCopyShared) {
+        _characterBuffer = [_characterBuffer clone];
+        _zeroCopyShared = NO;
+    }
     _appendOnlySinceLastCopy = NO;
     if (cll_entries == _firstEntry) {
         return;
@@ -1554,6 +1554,10 @@ int OffsetOfWrappedLine(const screen_char_t* p, int n, int length, int width, BO
                      metadata:(out iTermImmutableMetadata *)metadataPtr
                  continuation:(screen_char_t *)continuationPtr
                          cert:(id<iTermLineBlockMutationCertificate>)cert {
+    if (_zeroCopyShared) {
+        _characterBuffer = [_characterBuffer clone];
+        _zeroCopyShared = NO;
+    }
     _appendOnlySinceLastCopy = NO;
     if (cll_entries == _firstEntry) {
         // There is no last line to pop.
@@ -1813,6 +1817,10 @@ int OffsetOfWrappedLine(const screen_char_t* p, int n, int length, int width, BO
     if (partial == is_partial) {
         return;
     }
+    if (_zeroCopyShared) {
+        _characterBuffer = [_characterBuffer clone];
+        _zeroCopyShared = NO;
+    }
     _appendOnlySinceLastCopy = NO;
     is_partial = partial;
     iTermLineBlockDidChange(self, "set partial");
@@ -1832,6 +1840,10 @@ int OffsetOfWrappedLine(const screen_char_t* p, int n, int length, int width, BO
 }
 
 - (int)dropLines:(int)orig_n withWidth:(int)width chars:(int *)charsDropped {
+    if (_zeroCopyShared) {
+        _characterBuffer = [_characterBuffer clone];
+        _zeroCopyShared = NO;
+    }
     _appendOnlySinceLastCopy = NO;
     // Note that there's no mutation certificate because we aren't touching the character buffer.
     [_metadataArray willMutate];
@@ -1974,104 +1986,77 @@ int OffsetOfWrappedLine(const screen_char_t* p, int n, int length, int width, BO
     return _progenitor == _owner;
 }
 
-- (BOOL)appendOnlySinceLastCopy {
-    return _appendOnlySinceLastCopy;
-}
-
-- (BOOL)canIncrementalMergeFromProgenitor {
+- (BOOL)canZeroCopyMergeFromProgenitor {
     if (!_progenitor || _progenitor.invalidated) {
         return NO;
     }
-    // If copy has diverged (was mutated), we can't do incremental merge
-    // because its buffer no longer matches the sync-time state.
-    if (_hasDiverged) {
+    if (self.owner != nil || self.clients.count > 0) {
+        return NO;
+    }
+    if (_characterBuffer != _progenitor->_characterBuffer) {
+        return NO;
+    }
+    if (_progenitor->cll_entries != 1) {
+        return NO;
+    }
+    if (!_progenitor->is_partial) {
+        return NO;
+    }
+    if (cll_entries != 1) {
+        return NO;
+    }
+    if (!is_partial) {
+        return NO;
+    }
+    if (_progenitor->_firstEntry != 0) {
+        return NO;
+    }
+    if (_progenitor.bufferStartOffset != 0) {
         return NO;
     }
     if (!_progenitor->_appendOnlySinceLastCopy) {
         return NO;
     }
-    // Both must have exactly one raw line, both partial, no drops
-    if (cll_entries != _firstEntry + 1 ||
-        _progenitor->cll_entries != _progenitor->_firstEntry + 1) {
+    if ([_progenitor->_characterBuffer wasRelocated]) {
         return NO;
     }
-    if (!is_partial || !_progenitor->is_partial) {
-        return NO;
-    }
-    if (_firstEntry != 0 || self.bufferStartOffset != 0) {
-        return NO;
-    }
-    // Progenitor must have grown
-    const int progenitorLen = _progenitor->cumulative_line_lengths[_progenitor->_firstEntry] - _progenitor.bufferStartOffset;
-    const int myLen = cumulative_line_lengths[_firstEntry] - self.bufferStartOffset;
-    return progenitorLen > myLen;
+    return YES;
 }
 
-- (void)incrementalMergeFromProgenitor {
-    std::lock_guard<std::recursive_mutex> lock(gLineBlockMutex);
+- (void)zeroCopyMergeFromProgenitor {
+    // Merge is thread-confined to the main thread and intentionally does not
+    // take gLineBlockMutex. The mutex protects the COW ownership graph
+    // (cowCopy/validMutationCertificate on the mutation thread); the merge
+    // path is serialized with mutations at a higher level (screen lock).
+    ITAssertWithMessage(NSThread.isMainThread, @"Zero-copy merge must run on the main thread");
+    ITAssertWithMessage(self.owner == nil, @"Zero-copy merge requires ownership detach (owner should be nil)");
+    ITAssertWithMessage(self.clients.count == 0, @"Zero-copy merge requires no clients (CLL must be unshared)");
 
-    LineBlock *progenitor = _progenitor;
-    const int progenitorLen = progenitor->cumulative_line_lengths[progenitor->_firstEntry] - progenitor.bufferStartOffset;
-    const int myLen = cumulative_line_lengths[_firstEntry] - self.bufferStartOffset;
-    const int appendedLen = progenitorLen - myLen;
+    // Update CLL from progenitor (one int for single-line case)
+    cumulative_line_lengths[0] = _progenitor->cumulative_line_lengths[0];
+    cll_entries = _progenitor->cll_entries;
+    is_partial = _progenitor->is_partial;
 
-    // Get private buffers (clones OLD shared state = data at sync point)
-    id<iTermLineBlockMutationCertificate> cert = [self validMutationCertificate];
-
-    // Resize if needed
-    if (_characterBuffer.size < progenitorLen) {
-        [cert setRawBufferCapacity:progenitorLen];
-    }
-
-    // Copy only appended characters
-    memcpy(cert.mutableRawBuffer + myLen,
-           progenitor->_characterBuffer.pointer + progenitor.bufferStartOffset + myLen,
-           appendedLen * sizeof(screen_char_t));
-
-    // Update cumulative line length
-    cert.mutableCumulativeLineLengths[_firstEntry] = progenitorLen;
-
-    // Sync metadata from progenitor
-    // We need to extract the metadata for just the appended portion.
-    // The progenitor's metadata covers the entire line; we need to sync:
-    // - timestamp (use progenitor's current timestamp)
-    // - rtlFound (OR with progenitor's flag)
-    // - externalAttributes (extract slice for appended range)
-    // - continuation (use progenitor's current continuation)
+    // Copy metadata
+    _metadataArray = [_progenitor->_metadataArray cowCopy];
     [_metadataArray willMutate];
-    const LineBlockMetadata *progenitorMeta = [progenitor->_metadataArray metadataAtIndex:progenitor->_firstEntry];
 
-    // Create metadata for the appended portion by extracting from progenitor
-    iTermImmutableMetadata progenitorLineMeta = iTermMetadataMakeImmutable(progenitorMeta->lineMetadata);
+    // Copy flags
+    _mayHaveDoubleWidthCharacter = _progenitor->_mayHaveDoubleWidthCharacter;
 
-    // Extract external attributes for just the appended range [myLen, progenitorLen)
-    iTermMetadata appendedMeta;
-    iTermMetadataInitCopyingSubrange(&appendedMeta, &progenitorLineMeta, myLen, appendedLen);
-    iTermImmutableMetadata immutableAppendedMeta = iTermMetadataMakeImmutable(appendedMeta);
-
-    // Merge metadata using appendToLastLine which handles:
-    // - timestamp update
-    // - rtlFound OR
-    // - external attributes concatenation with position adjustment
-    // - continuation update
-    // - Cache invalidation (number_of_wrapped_lines=0, DWC cache=nil, bidi_info=nil)
-    [_metadataArray appendToLastLine:&immutableAppendedMeta
-                      originalLength:myLen
-                    additionalLength:appendedLen
-                        continuation:progenitorMeta->continuation];
-
-    iTermMetadataRelease(appendedMeta);
-
-    // Invalidate caches that appendToLastLine doesn't handle
+    // Invalidate caches
+    cached_numlines_width = -1;
     _numberOfFullLinesCache.clear();
-    cached_numlines_width = -1;  // Force recomputation of wrapped line count
 
-    // Sync DWC flag (sticky - once set, stays set)
-    if (progenitor->_mayHaveDoubleWidthCharacter) {
-        _mayHaveDoubleWidthCharacter = YES;
-    }
+    // Reset progenitor tracking
+    _progenitor->_appendOnlySinceLastCopy = YES;
+    [_progenitor->_characterBuffer clearRelocationFlag];
 
-    iTermLineBlockDidChange(self, "incremental merge");
+    iTermLineBlockDidChange(self, "zero-copy merge");
+}
+
+- (BOOL)sharesCharacterBufferWith:(LineBlock *)other {
+    return _characterBuffer == other->_characterBuffer;
 }
 
 - (int)_lineRawOffset:(int) anIndex {
@@ -2738,16 +2723,23 @@ crossBlockResultCount:(NSInteger *)crossBlockResultCount {
         const NSUInteger numberOfClients = myClients.count;
 
         // Perform copy-on-write copying.
-        const ptrdiff_t offset = self.bufferStartOffset;
-        _characterBuffer = [_characterBuffer clone];
-        [self setBufferStartOffset:offset];
-        iTermAssignToConstPointer((void **)&cumulative_line_lengths, iTermMemdup(self->cumulative_line_lengths, cll_capacity, sizeof(int)));
+        if (_zeroCopyShared) {
+            // Zero-copy path: buffer stays shared, only clone the CLL.
+            // In production, only the progenitor enters this branch (copies
+            // are read-only between syncs). If a copy does enter here, the
+            // buffer clone is deferred to the mutation guard in the calling
+            // method (reallyAppendLine, removeLastRawLine, etc.).
+            // Invariant enforced by "Copy Mutation Invariant" tests in
+            // LineBlockZeroCopyMergeTests.
+            iTermAssignToConstPointer((void **)&cumulative_line_lengths, iTermMemdup(self->cumulative_line_lengths, cll_capacity, sizeof(int)));
+        } else {
+            const ptrdiff_t offset = self.bufferStartOffset;
+            _characterBuffer = [_characterBuffer clone];
+            [self setBufferStartOffset:offset];
+            iTermAssignToConstPointer((void **)&cumulative_line_lengths, iTermMemdup(self->cumulative_line_lengths, cll_capacity, sizeof(int)));
+        }
 
         if (self.owner != nil) {
-            // This copy is diverging from its progenitor by mutating.
-            // Mark it so incremental merge knows not to use it.
-            _hasDiverged = YES;
-
             // I am no longer a client. Remove myself from my owner's client list.
             [self.owner.clients removeObjectsPassingTest:^BOOL(id block) {
                 return block == self;
@@ -2810,6 +2802,15 @@ crossBlockResultCount:(NSInteger *)crossBlockResultCount {
 
     // Reset append tracking - new copies start clean
     _appendOnlySinceLastCopy = YES;
+
+    // Enable zero-copy sharing when eligible: single partial line, no drops.
+    // Both progenitor and copy get the flag so that mutation guards on either
+    // side will clone the buffer before writing.
+    if (cll_entries == 1 && is_partial && _firstEntry == 0 && self.bufferStartOffset == 0) {
+        _zeroCopyShared = YES;
+        copy->_zeroCopyShared = YES;
+        [_characterBuffer clearRelocationFlag];
+    }
 
     return copy;
 }

--- a/sources/LineBuffer.m
+++ b/sources/LineBuffer.m
@@ -662,6 +662,28 @@ static int RawNumLines(LineBuffer* buffer, int width) {
                      width:width
                   metadata:metadataObj
               continuation:continuation]) {
+        // Fast path: resize in place for single partial line blocks.
+        // This avoids the O(N) pop+reappend which would set _appendOnlySinceLastCopy = NO
+        // and break zero-copy merge eligibility.
+        if ([block hasPartial] &&
+            [block startOffset] == 0 &&
+            [block numRawLines] == 1) {
+            num_wrapped_lines_width = -1;
+            int space_used = [block rawSpaceUsed];
+            if (partial) {
+                [block changeBufferSize:space_used + length + block_size];
+            } else {
+                [block changeBufferSize:space_used + length];
+            }
+            BOOL ok __attribute__((unused)) =
+            [block appendLine:buffer
+                       length:length
+                      partial:partial
+                        width:width
+                     metadata:metadataObj
+                 continuation:continuation];
+            ITAssertWithMessage(ok, @"append after resize-in-place can't fail");
+        } else {
         // It's going to be complicated. Invalidate the number of wrapped lines
         // cache.
         num_wrapped_lines_width = -1;
@@ -729,6 +751,7 @@ static int RawNumLines(LineBuffer* buffer, int width) {
                  metadata:metadataObj
              continuation:continuation];
         ITAssertWithMessage(ok, @"append can't fail here");
+        }
     } else if (num_wrapped_lines_width == width) {
         // Straightforward addition of a line to an existing block. Update the
         // wrapped lines cache.
@@ -2192,48 +2215,53 @@ NS_INLINE int TotalNumberOfRawLines(LineBuffer *self) {
         stage1 = [_lineBlocks dumpWidths:commonWidths];
     }
 
-    // Drop blocks from the end until we get to one that is in sync or can be incrementally merged.
-    // Note that if the first block has experienced drops but not appends then it will still have
-    // its progenitor as its owner and be considered "synchronized".
-    while (_lineBlocks.count > 0) {
-        LineBlock *lastBlock = _lineBlocks.lastBlock;
-
-        if ([lastBlock isSynchronizedWithProgenitor]) {
-            break;  // Already in sync
+    // Try zero-copy merge for the last block before falling back to drop-and-replace.
+    if (_lineBlocks.count > 0 &&
+        _lineBlocks.count == source->_lineBlocks.count &&
+        [_lineBlocks.lastBlock canZeroCopyMergeFromProgenitor]) {
+        DLog(@"zero-copy merge last block");
+        [_lineBlocks.lastBlock zeroCopyMergeFromProgenitor];
+        if (_lineBlocks.count > 0) {
+            [_lineBlocks.firstBlock dropMirroringProgenitor:source->_lineBlocks.firstBlock];
         }
+    } else {
+        // Drop blocks from the end until we get to one that is in sync.
+        // Note that if the first block has experienced drops but not appends then it will still have
+        // its progenitor as its owner and be considered "synchronized".
+        while (_lineBlocks.count > 0) {
+            LineBlock *lastBlock = _lineBlocks.lastBlock;
 
-        if ([lastBlock canIncrementalMergeFromProgenitor]) {
-            DLog(@"incremental merge");
-            [lastBlock incrementalMergeFromProgenitor];
-            break;  // Now caught up
-        }
+            if ([lastBlock isSynchronizedWithProgenitor]) {
+                break;  // Already in sync
+            }
 
-        DLog(@"remove last");
-        [_lineBlocks removeLastBlock];
-    }
-    if (gDebugLogging) {
-        stage2 = [_lineBlocks dumpWidths:commonWidths];
-    }
-
-    if (_lineBlocks.count > 0) {
-        DLog(@"mirror first");
-        [_lineBlocks.firstBlock dropMirroringProgenitor:source->_lineBlocks.firstBlock];
-    }
-    if (gDebugLogging) {
-        stage3 = [_lineBlocks dumpWidths:commonWidths];
-    }
-
-    // Add copies of terminal blocks.
-    while (_lineBlocks.count < source->_lineBlocks.count) {
-        DLog(@"append");
-        LineBlock *sourceBlock = source->_lineBlocks[_lineBlocks.count];
-        LineBlock *theCopy = [sourceBlock cowCopy];
-        [_lineBlocks addBlock:theCopy];
-        if (_lineBlocks.count < source->_lineBlocks.count) {
-            [self commitLastBlock];
+            DLog(@"remove last");
+            [_lineBlocks removeLastBlock];
         }
         if (gDebugLogging) {
-            [_lineBlocks sanityCheck:droppedChars];
+            stage2 = [_lineBlocks dumpWidths:commonWidths];
+        }
+
+        if (_lineBlocks.count > 0) {
+            DLog(@"mirror first");
+            [_lineBlocks.firstBlock dropMirroringProgenitor:source->_lineBlocks.firstBlock];
+        }
+        if (gDebugLogging) {
+            stage3 = [_lineBlocks dumpWidths:commonWidths];
+        }
+
+        // Add copies of terminal blocks.
+        while (_lineBlocks.count < source->_lineBlocks.count) {
+            DLog(@"append");
+            LineBlock *sourceBlock = source->_lineBlocks[_lineBlocks.count];
+            LineBlock *theCopy = [sourceBlock cowCopy];
+            [_lineBlocks addBlock:theCopy];
+            if (_lineBlocks.count < source->_lineBlocks.count) {
+                [self commitLastBlock];
+            }
+            if (gDebugLogging) {
+                [_lineBlocks sanityCheck:droppedChars];
+            }
         }
     }
 

--- a/sources/LineBuffer.m
+++ b/sources/LineBuffer.m
@@ -671,7 +671,12 @@ static int RawNumLines(LineBuffer* buffer, int width) {
             num_wrapped_lines_width = -1;
             int space_used = [block rawSpaceUsed];
             if (partial) {
-                [block changeBufferSize:space_used + length + block_size];
+                // Geometric growth: double the buffer capacity so resizes are
+                // O(log N) and total clone cost is O(N) (geometric series).
+                // Linear growth (adding block_size each time) would be O(N²).
+                int needed = space_used + length;
+                int doubled = [block rawBufferSize] * 2;
+                [block changeBufferSize:MAX(needed, doubled)];
             } else {
                 [block changeBufferSize:space_used + length];
             }

--- a/sources/iTermCharacterBuffer.h
+++ b/sources/iTermCharacterBuffer.h
@@ -12,13 +12,25 @@ NS_ASSUME_NONNULL_BEGIN
 
 // Stores a chunk of `screen_char_t`s for LineBlock. Many line blocks may reference the same
 // character buffer. When one is modified, it gets a private copy to avoid disturbing the others.
+//
+// Sharing is tracked via an internal shareCount (starts at 1). Call -incrementShareCount when
+// a second LineBlock begins sharing this buffer (e.g., during cowCopy). Call
+// -cloneAndDecrementShareCount to atomically get a private copy and release the shared reference.
+// All shareCount operations must be called under the same external lock (gLineBlockMutex).
 @interface iTermCharacterBuffer: NSObject
 @property(nonatomic, readonly) int size;
 @property(nonatomic, readonly) screen_char_t *mutablePointer;
 @property(nonatomic, readonly) const screen_char_t *pointer;
 @property(nonatomic, readonly) NSData *data;
 @property(nonatomic, readonly) NSString *shortDescription;
-@property(nonatomic, readonly) BOOL wasRelocated;
+
+// YES when shareCount > 1 (another LineBlock shares this buffer).
+// Caller must hold gLineBlockMutex.
+@property(nonatomic, readonly) BOOL isShared;
+
+// Exposed for testing. Returns the raw shareCount value.
+// Caller must hold gLineBlockMutex.
+@property(nonatomic, readonly) int testShareCount;
 
 - (instancetype)initWithSize:(int)size;
 - (instancetype)initWithData:(NSData *)data;
@@ -26,7 +38,19 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)resize:(int)newSize;
 - (iTermCharacterBuffer *)clone;
 - (BOOL)deepIsEqual:(id)object;
-- (void)clearRelocationFlag;
+
+// Increment the sharing count. Call when a LineBlock begins sharing this buffer.
+// Caller must hold gLineBlockMutex.
+- (void)incrementShareCount;
+
+// Decrement the sharing count and return a private clone. The caller takes
+// ownership of the clone (which has shareCount 1). Caller must hold gLineBlockMutex.
+- (iTermCharacterBuffer *)cloneAndDecrementShareCount;
+
+// Decrement the sharing count without cloning. Call when a LineBlock releases
+// its reference to a shared buffer (e.g., during dealloc). Caller must hold
+// gLineBlockMutex.
+- (void)decrementShareCount;
 
 @end
 

--- a/sources/iTermCharacterBuffer.h
+++ b/sources/iTermCharacterBuffer.h
@@ -18,6 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) const screen_char_t *pointer;
 @property(nonatomic, readonly) NSData *data;
 @property(nonatomic, readonly) NSString *shortDescription;
+@property(nonatomic, readonly) BOOL wasRelocated;
 
 - (instancetype)initWithSize:(int)size;
 - (instancetype)initWithData:(NSData *)data;
@@ -25,6 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)resize:(int)newSize;
 - (iTermCharacterBuffer *)clone;
 - (BOOL)deepIsEqual:(id)object;
+- (void)clearRelocationFlag;
 
 @end
 

--- a/sources/iTermCharacterBuffer.m
+++ b/sources/iTermCharacterBuffer.m
@@ -11,7 +11,7 @@
 @implementation iTermCharacterBuffer {
     screen_char_t *_buffer;
     int _size;
-    BOOL _wasRelocated;
+    int _shareCount;
 }
 
 - (void)dealloc {
@@ -51,6 +51,7 @@
     if (self) {
         _buffer = iTermUninitializedCalloc(size, sizeof(screen_char_t));
         _size = size;
+        _shareCount = 1;
     }
     return self;
 }
@@ -66,25 +67,18 @@
     if (self) {
         _buffer = iTermMemdup(source, size, sizeof(screen_char_t));
         _size = size;
+        _shareCount = 1;
     }
     return self;
 }
 
 - (void)resize:(int)newSize {
-    screen_char_t *oldBuffer = _buffer;
     _buffer = iTermRealloc(_buffer, newSize, sizeof(screen_char_t));
-    if (_buffer != oldBuffer) {
-        _wasRelocated = YES;
-    }
     _size = newSize;
 }
 
 - (iTermCharacterBuffer *)clone {
     return [[iTermCharacterBuffer alloc] initWithChars:_buffer size:_size];
-}
-
-- (void)clearRelocationFlag {
-    _wasRelocated = NO;
 }
 
 - (BOOL)deepIsEqual:(id)object {
@@ -96,6 +90,29 @@
         return NO;
     }
     return _size == other->_size && !memcmp(_buffer, other->_buffer, _size * sizeof(screen_char_t));
+}
+
+- (BOOL)isShared {
+    return _shareCount > 1;
+}
+
+- (int)testShareCount {
+    return _shareCount;
+}
+
+- (void)incrementShareCount {
+    _shareCount++;
+}
+
+- (iTermCharacterBuffer *)cloneAndDecrementShareCount {
+    assert(_shareCount > 1);
+    _shareCount--;
+    return [self clone];
+}
+
+- (void)decrementShareCount {
+    assert(_shareCount > 1);
+    _shareCount--;
 }
 
 @end

--- a/sources/iTermCharacterBuffer.m
+++ b/sources/iTermCharacterBuffer.m
@@ -11,6 +11,7 @@
 @implementation iTermCharacterBuffer {
     screen_char_t *_buffer;
     int _size;
+    BOOL _wasRelocated;
 }
 
 - (void)dealloc {
@@ -70,12 +71,20 @@
 }
 
 - (void)resize:(int)newSize {
+    screen_char_t *oldBuffer = _buffer;
     _buffer = iTermRealloc(_buffer, newSize, sizeof(screen_char_t));
+    if (_buffer != oldBuffer) {
+        _wasRelocated = YES;
+    }
     _size = newSize;
 }
 
 - (iTermCharacterBuffer *)clone {
     return [[iTermCharacterBuffer alloc] initWithChars:_buffer size:_size];
+}
+
+- (void)clearRelocationFlag {
+    _wasRelocated = NO;
 }
 
 - (BOOL)deepIsEqual:(id)object {


### PR DESCRIPTION
Evolves the incremental merge from 0ee322c into zero-copy sync for the eligible single-partial-line case. Instead of memcpy'ing deltas on each sync, progenitor and copy share the character buffer across sync cycles; sync updates only CLL and metadata.

The buffer is append-only: progenitor writes past the copy's CLL boundary, and the copy reads only within its current boundary. Merge advances the copy's CLL to include newly appended data, making sync O(1) instead of O(delta).

Non-append mutations (line completion, removal, drop, setPartial) break sharing via existing mutation guards and fall back to COW behavior. Buffer relocation on resize also disables zero-copy and uses the existing fallback path.
