### PR TITLE
Clear text selection when search string is emptied

### DIFF
--- a/sources/PTYSession.m
+++ b/sources/PTYSession.m
@@ -7512,6 +7512,7 @@ scrollToFirstResult:(BOOL)scrollToFirstResult
         return;
     }
     [_textview clearHighlights:YES];
+    [_textview.selection clearSelection];
 }
 
 - (void)findViewControllerVisibilityDidChange:(id<iTermFindViewController>)sender {


### PR DESCRIPTION
When you type a search string and delete it character by character, the first matching character stays selected after the search box is empty. It looks like `findViewControllerClearSearch` clears the highlight map but not the text selection that was placed on the current match. Adding a `clearSelection` call clears it.

Note: This change also clears selection when closing the Find Bar.