### PR TITLE
feat(tab-progress-bars): add tab and single-tab progress bars

### DIFF
--- a/ThirdParty/PSMTabBarControl/source/PSMTabBarControl.h
+++ b/ThirdParty/PSMTabBarControl/source/PSMTabBarControl.h
@@ -174,6 +174,8 @@ typedef NS_ENUM(int, PSMTabPosition) {
     PSMTab_LeftTab = 2,
 };
 
+extern const CGFloat PSMTabBarProgressBarHeight;
+
 // This view provides a control interface to manage a regular NSTabView.  It looks and works like
 // the tabbed browsing interface of many popular browsers.
 @interface PSMTabBarControl : NSControl<
@@ -256,6 +258,9 @@ typedef NS_ENUM(int, PSMTabPosition) {
 
 - (void)setIsProcessing:(BOOL)isProcessing forTabWithIdentifier:(id)identifier;
 - (void)setProgress:(PSMProgress)progress forTabWithIdentifier:(id)identifier;
+- (BOOL)shouldShowCustomProgressBarForTabCell:(PSMTabBarCell *)cell;
+- (nullable NSView *)customProgressBarViewForTabCell:(PSMTabBarCell *)cell;
+- (void)configureCustomProgressBarView:(NSView *)view forTabCell:(PSMTabBarCell *)cell;
 - (void)setIcon:(NSImage *)icon forTabWithIdentifier:(id)identifier;
 - (void)setObjectCount:(NSInteger)objectCount forTabWithIdentifier:(id)identifier;
 - (void)graphicDidChangeForTabWithIdentifier:(id)identifier;

--- a/ThirdParty/PSMTabBarControl/source/PSMTabBarControl.m
+++ b/ThirdParty/PSMTabBarControl/source/PSMTabBarControl.m
@@ -37,6 +37,7 @@ NSString *const kPSMTabModifierKey = @"TabModifier";
 NSString *const PSMTabDragDidEndNotification = @"PSMTabDragDidEndNotification";
 NSString *const PSMTabDragDidBeginNotification = @"PSMTabDragDidBeginNotification";
 const CGFloat kSPMTabBarCellInternalXMargin = 6;
+const CGFloat PSMTabBarProgressBarHeight = 2;
 
 const CGFloat kPSMTabBarCellPadding = 4;
 const CGFloat kPSMTabBarCellIconPadding = 4;
@@ -140,6 +141,8 @@ PSMTabBarControlOptionKey PSMTabBarControlOptionPUAFontProvider = @"PSMTabBarCon
 @end
 
 @interface PSMTabBarControl ()<PSMTabBarControlProtocol, NSMenuItemValidation, NSViewToolTipOwner>
+- (void)removeTabProgressBarForCell:(PSMTabBarCell *)cell;
+- (void)syncTabProgressBars;
 @end
 
 @implementation PSMTabBarControl {
@@ -177,6 +180,7 @@ PSMTabBarControlOptionKey PSMTabBarControlOptionPUAFontProvider = @"PSMTabBarCon
     BOOL _needsUpdateAnimate;
     BOOL _needsUpdate;
     NSInteger _preDragSelectedTabIndex;  // or NSNotFound
+    NSMutableDictionary<NSValue *, NSView *> *_tabProgressBars;
     NSMutableArray<PSMToolTip *> *_tooltips;
     NSInteger _toolTipCoalescing;
 }
@@ -251,6 +255,7 @@ PSMTabBarControlOptionKey PSMTabBarControlOptionPUAFontProvider = @"PSMTabBarCon
             _style = [[PSMYosemiteTabStyle alloc] init];
         }
         _preDragSelectedTabIndex = NSNotFound;
+        _tabProgressBars = [[NSMutableDictionary alloc] init];
 
         // the overflow button/menu
         [self setupButtons];
@@ -376,6 +381,10 @@ PSMTabBarControlOptionKey PSMTabBarControlOptionPUAFontProvider = @"PSMTabBarCon
         [cell release];
     }
 
+    for (NSView *progressBar in _tabProgressBars.allValues) {
+        [progressBar removeFromSuperview];
+    }
+    [_tabProgressBars release];
     [_overflowPopUpButton release];
     [_cells release];
     [_tabView release];
@@ -715,9 +724,72 @@ PSMTabBarControlOptionKey PSMTabBarControlOptionPUAFontProvider = @"PSMTabBarCon
     [cell removeCloseButtonTrackingRectFrom:self];
     [cell removeCellTrackingRectFrom:self];
     [self removeAllToolTips];
+    [self removeTabProgressBarForCell:cell];
 
     // pull from collection
     [_cells removeObject:cell];
+}
+
+- (BOOL)shouldShowCustomProgressBarForTabCell:(PSMTabBarCell *)cell {
+    return NO;
+}
+
+- (NSView *)customProgressBarViewForTabCell:(PSMTabBarCell *)cell {
+    return nil;
+}
+
+- (void)configureCustomProgressBarView:(NSView *)view forTabCell:(PSMTabBarCell *)cell {
+}
+
+- (NSValue *)tabProgressBarKeyForCell:(PSMTabBarCell *)cell {
+    return [NSValue valueWithNonretainedObject:cell];
+}
+
+- (void)removeTabProgressBarForCell:(PSMTabBarCell *)cell {
+    NSValue *key = [self tabProgressBarKeyForCell:cell];
+    NSView *progressBar = _tabProgressBars[key];
+    if (!progressBar) {
+        return;
+    }
+    [progressBar removeFromSuperview];
+    [_tabProgressBars removeObjectForKey:key];
+}
+
+- (void)syncTabProgressBars {
+    NSMutableSet<NSValue *> *visibleKeys = [NSMutableSet set];
+    for (PSMTabBarCell *cell in _cells) {
+        if (![self shouldShowCustomProgressBarForTabCell:cell]) {
+            [self removeTabProgressBarForCell:cell];
+            continue;
+        }
+        NSValue *key = [self tabProgressBarKeyForCell:cell];
+        [visibleKeys addObject:key];
+        NSView *progressBar = _tabProgressBars[key];
+        if (!progressBar) {
+            progressBar = [self customProgressBarViewForTabCell:cell];
+            if (!progressBar) {
+                continue;
+            }
+            _tabProgressBars[key] = progressBar;
+        }
+        [self configureCustomProgressBarView:progressBar forTabCell:cell];
+        progressBar.frame = [self.style progressBarRectForTabCell:cell];
+        progressBar.hidden = NO;
+        if (progressBar.superview != self) {
+            [self addSubview:progressBar];
+        }
+        cell.indicator.hidden = YES;
+        cell.indicator.animate = NO;
+        [cell.indicator removeFromSuperview];
+    }
+
+    for (NSValue *key in [_tabProgressBars allKeys]) {
+        if (![visibleKeys containsObject:key]) {
+            NSView *progressBar = _tabProgressBars[key];
+            [progressBar removeFromSuperview];
+            [_tabProgressBars removeObjectForKey:key];
+        }
+    }
 }
 
 - (void)dragDidFinish {
@@ -1014,6 +1086,7 @@ PSMTabBarControlOptionKey PSMTabBarControlOptionPUAFontProvider = @"PSMTabBarCon
               clipRect:rect
             horizontal:(_orientation == PSMTabBarHorizontalOrientation)
           withOverflow:_lainOutWithOverflow];
+    [self syncTabProgressBars];
 
 #if PSM_DEBUG_DRAG_PERFORMANCE
     CFAbsoluteTime end = CFAbsoluteTimeGetCurrent();
@@ -1064,6 +1137,11 @@ PSMTabBarControlOptionKey PSMTabBarControlOptionPUAFontProvider = @"PSMTabBarCon
 
 - (void)update {
     [self update:NO];
+}
+
+- (void)setFrame:(NSRect)frame {
+    [super setFrame:frame];
+    [self syncTabProgressBars];
 }
 
 - (void)update:(BOOL)animate {
@@ -1198,6 +1276,7 @@ PSMTabBarControlOptionKey PSMTabBarControlOptionPUAFontProvider = @"PSMTabBarCon
         [self finishUpdateWithRegularWidths:newOrigins widthsWithOverflow:newOrigins];
     }
 
+    [self syncTabProgressBars];
     [self setNeedsDisplay:YES];
 }
 
@@ -1401,6 +1480,7 @@ PSMTabBarControlOptionKey PSMTabBarControlOptionPUAFontProvider = @"PSMTabBarCon
 - (void)removeCell:(PSMTabBarCell *)cell {
     [cell removeCloseButtonTrackingRectFrom:self];
     [cell removeCellTrackingRectFrom:self];
+    [self removeTabProgressBarForCell:cell];
     [[self cells] removeObject:cell];
 }
 
@@ -2521,6 +2601,7 @@ static CFAbsoluteTime gDragMoveFirstTime = 0;
 - (void)setProgress:(PSMProgress)progress forTabWithIdentifier:(id)identifier {
     PSMTabBarCell *cell = [self cellWithIdentifier:identifier];
     cell.progress = progress;
+    [self syncTabProgressBars];
 }
 
 - (void)graphicDidChangeForTabWithIdentifier:(id)identifier {

--- a/ThirdParty/PSMTabBarControl/source/PSMTabStyle.h
+++ b/ThirdParty/PSMTabBarControl/source/PSMTabStyle.h
@@ -39,6 +39,7 @@ Protocol to be observed by all style delegate objects.  These objects handle the
 - (NSRect)dragRectForTabCell:(PSMTabBarCell *)cell orientation:(PSMTabBarOrientation)orientation;
 - (NSRect)closeButtonRectForTabCell:(PSMTabBarCell *)cell;
 - (NSRect)indicatorRectForTabCell:(PSMTabBarCell *)cell;
+- (NSRect)progressBarRectForTabCell:(PSMTabBarCell *)cell;
 - (NSRect)objectCounterRectForTabCell:(PSMTabBarCell *)cell;
 - (float)minimumWidthOfTabCell:(PSMTabBarCell *)cell;
 - (float)desiredWidthOfTabCell:(PSMTabBarCell *)cell;

--- a/ThirdParty/PSMTabBarControl/source/PSMTahoeTabStyle.swift
+++ b/ThirdParty/PSMTabBarControl/source/PSMTahoeTabStyle.swift
@@ -423,7 +423,13 @@ class PSMTahoeTabStyle: NSObject, PSMTabStyle {
 
     @objc func progressBarRect(forTabCell cell: PSMTabBarCell) -> NSRect {
         let cellFrame = cell.frame
-        guard _orientation == .horizontalOrientation, cell.state == .on else {
+        if _orientation == .verticalOrientation {
+            return NSRect(x: cellFrame.origin.x,
+                          y: cellFrame.origin.y,
+                          width: PSMTabBarProgressBarHeight,
+                          height: cellFrame.size.height)
+        }
+        guard cell.state == .on else {
             return NSRect(x: cellFrame.origin.x,
                           y: cellFrame.origin.y,
                           width: cellFrame.size.width,

--- a/ThirdParty/PSMTabBarControl/source/PSMTahoeTabStyle.swift
+++ b/ThirdParty/PSMTabBarControl/source/PSMTahoeTabStyle.swift
@@ -423,7 +423,9 @@ class PSMTahoeTabStyle: NSObject, PSMTabStyle {
 
     @objc func progressBarRect(forTabCell cell: PSMTabBarCell) -> NSRect {
         let cellFrame = cell.frame
-        if _orientation == .verticalOrientation {
+        let showVerticalProgressBar = (_orientation == .verticalOrientation &&
+                                       !iTermAdvancedSettingsModel.leftTabBarProgressBarsAreHorizontal())
+        if showVerticalProgressBar {
             return NSRect(x: cellFrame.origin.x,
                           y: cellFrame.origin.y,
                           width: PSMTabBarProgressBarHeight,

--- a/ThirdParty/PSMTabBarControl/source/PSMTahoeTabStyle.swift
+++ b/ThirdParty/PSMTabBarControl/source/PSMTahoeTabStyle.swift
@@ -413,6 +413,31 @@ class PSMTahoeTabStyle: NSObject, PSMTabStyle {
         frame.size.height = generic.height - 1
         return frame
     }
+
+    private func backgroundRect(for cellFrame: NSRect) -> NSRect {
+        var rect = cellFrame
+        rect.origin.y += 2
+        rect.size.height -= 3
+        return rect
+    }
+
+    @objc func progressBarRect(forTabCell cell: PSMTabBarCell) -> NSRect {
+        let cellFrame = cell.frame
+        guard _orientation == .horizontalOrientation, cell.state == .on else {
+            return NSRect(x: cellFrame.origin.x,
+                          y: cellFrame.origin.y,
+                          width: cellFrame.size.width,
+                          height: PSMTabBarProgressBarHeight)
+        }
+
+        let pillRect = backgroundRect(for: cellFrame)
+        let horizontalInset = CGFloat(4)
+        let verticalInset = CGFloat(1)
+        return NSRect(x: pillRect.origin.x + horizontalInset,
+                      y: pillRect.maxY - PSMTabBarProgressBarHeight - verticalInset,
+                      width: max(CGFloat(0), pillRect.size.width - horizontalInset * 2),
+                      height: PSMTabBarProgressBarHeight)
+    }
     
     // MARK: - Drawing
     
@@ -789,9 +814,7 @@ class PSMTahoeTabStyle: NSObject, PSMTabStyle {
         backgroundColorSelected(selected, highlightAmount: isHighlighted ? 1.0 : 0.0).set()
         
         let radius = barRadius - 2.5
-        var rect = cellFrame
-        rect.origin.y += 2
-        rect.size.height -= 3
+        let rect = backgroundRect(for: cellFrame)
         let path = NSBezierPath(roundedRect: rect, xRadius: radius, yRadius: radius)
         path.fill()
         if selected {

--- a/ThirdParty/PSMTabBarControl/source/PSMYosemiteTabStyle.m
+++ b/ThirdParty/PSMTabBarControl/source/PSMYosemiteTabStyle.m
@@ -262,6 +262,14 @@
     return result;
 }
 
+- (NSRect)progressBarRectForTabCell:(PSMTabBarCell *)cell {
+    NSRect cellFrame = [cell frame];
+    return NSMakeRect(cellFrame.origin.x,
+                      cellFrame.origin.y,
+                      cellFrame.size.width,
+                      PSMTabBarProgressBarHeight);
+}
+
 - (NSRect)adjustedCellRect:(NSRect)rect generic:(NSRect)generic {
     return rect;
 }

--- a/ThirdParty/PSMTabBarControl/source/PSMYosemiteTabStyle.m
+++ b/ThirdParty/PSMTabBarControl/source/PSMYosemiteTabStyle.m
@@ -264,7 +264,9 @@
 
 - (NSRect)progressBarRectForTabCell:(PSMTabBarCell *)cell {
     NSRect cellFrame = [cell frame];
-    if (_orientation == PSMTabBarVerticalOrientation) {
+    const BOOL showVerticalProgressBar = (_orientation == PSMTabBarVerticalOrientation &&
+                                          ![iTermAdvancedSettingsModel leftTabBarProgressBarsAreHorizontal]);
+    if (showVerticalProgressBar) {
         return NSMakeRect(cellFrame.origin.x,
                           cellFrame.origin.y,
                           PSMTabBarProgressBarHeight,

--- a/ThirdParty/PSMTabBarControl/source/PSMYosemiteTabStyle.m
+++ b/ThirdParty/PSMTabBarControl/source/PSMYosemiteTabStyle.m
@@ -264,6 +264,12 @@
 
 - (NSRect)progressBarRectForTabCell:(PSMTabBarCell *)cell {
     NSRect cellFrame = [cell frame];
+    if (_orientation == PSMTabBarVerticalOrientation) {
+        return NSMakeRect(cellFrame.origin.x,
+                          cellFrame.origin.y,
+                          PSMTabBarProgressBarHeight,
+                          cellFrame.size.height);
+    }
     return NSMakeRect(cellFrame.origin.x,
                       cellFrame.origin.y,
                       cellFrame.size.width,

--- a/sources/PTYSession.m
+++ b/sources/PTYSession.m
@@ -5316,6 +5316,8 @@ webViewConfiguration:(WKWebViewConfiguration *)webViewConfiguration
                                                                 inProfile:aDict]];
     self.view.enableProgressBars = [iTermProfilePreferences boolForKey:KEY_ENABLE_PROGRESS_BARS
                                                              inProfile:aDict];
+    id<WindowControllerInterface> parentWindow = [_delegate parentWindow];
+    self.view.showInlineProgressBar = (!parentWindow || [parentWindow numberOfTabs] == 1);
     self.view.progressBarHeight = [iTermProfilePreferences floatForKey:KEY_PROGRESS_BAR_HEIGHT
                                                              inProfile:aDict];
     self.view.progressBarColorScheme = [iTermProfilePreferences stringForKey:KEY_PROGRESS_BAR_COLOR_SCHEME

--- a/sources/PTYSession.m
+++ b/sources/PTYSession.m
@@ -5316,8 +5316,6 @@ webViewConfiguration:(WKWebViewConfiguration *)webViewConfiguration
                                                                 inProfile:aDict]];
     self.view.enableProgressBars = [iTermProfilePreferences boolForKey:KEY_ENABLE_PROGRESS_BARS
                                                              inProfile:aDict];
-    id<WindowControllerInterface> parentWindow = [_delegate parentWindow];
-    self.view.showInlineProgressBar = (!parentWindow || [parentWindow numberOfTabs] == 1);
     self.view.progressBarHeight = [iTermProfilePreferences floatForKey:KEY_PROGRESS_BAR_HEIGHT
                                                              inProfile:aDict];
     self.view.progressBarColorScheme = [iTermProfilePreferences stringForKey:KEY_PROGRESS_BAR_COLOR_SCHEME

--- a/sources/PTYTab.h
+++ b/sources/PTYTab.h
@@ -66,6 +66,7 @@ extern NSString *const PTYTabArrangementOptionsPendingJumps;
 @property(nonatomic, retain) NSImage *icon;
 // Aggregated tab status from all sessions (highest-priority wins)
 @property(nonatomic, readonly) iTermSessionTabStatus *aggregatedTabStatus;
+@property(nonatomic, readonly) VT100ScreenProgress progress;
 
 // Size we should report to fit the current layout
 @property(nonatomic, readonly) NSSize tmuxSize;

--- a/sources/PTYTab.m
+++ b/sources/PTYTab.m
@@ -7283,10 +7283,34 @@ backgroundColor:(NSColor *)backgroundColor {
     [self.delegate tabProcessInfoProviderDidChange:self];
 }
 
-- (void)session:(PTYSession *)session progressDidChange:(VT100ScreenProgress)progress {
-    if (session == self.activeSession) {
-        [self.delegate tab:self progressDidChange:progress];
+static BOOL iTermTabProgressIsVisible(VT100ScreenProgress progress) {
+    if (progress == VT100ScreenProgressError || progress == VT100ScreenProgressIndeterminate) {
+        return YES;
     }
+    return ((progress >= VT100ScreenProgressSuccessBase && progress <= VT100ScreenProgressSuccessBase + 100) ||
+            (progress >= VT100ScreenProgressErrorBase && progress <= VT100ScreenProgressErrorBase + 100) ||
+            (progress >= VT100ScreenProgressWarningBase && progress <= VT100ScreenProgressWarningBase + 100));
+}
+
+- (VT100ScreenProgress)progress {
+    const VT100ScreenProgress activeProgress = self.activeSession.screen.progress;
+    if (iTermTabProgressIsVisible(activeProgress)) {
+        return activeProgress;
+    }
+    for (PTYSession *session in self.sessions) {
+        if (session == self.activeSession) {
+            continue;
+        }
+        const VT100ScreenProgress progress = session.screen.progress;
+        if (iTermTabProgressIsVisible(progress)) {
+            return progress;
+        }
+    }
+    return VT100ScreenProgressStopped;
+}
+
+- (void)session:(PTYSession *)session progressDidChange:(VT100ScreenProgress)progress {
+    [self.delegate tab:self progressDidChange:self.progress];
 }
 
 - (NSScriptObjectSpecifier *)objectSpecifier { 

--- a/sources/PseudoTerminal.m
+++ b/sources/PseudoTerminal.m
@@ -7284,6 +7284,7 @@ hidingToolbeltShouldResizeWindow:(BOOL)hidingToolbeltShouldResizeWindow
     }
 
     [self updateTabColors];
+    [self updateSessionProgressBarVisibility];
     [self updateTabProgress];
     [self updateToolbeltAppearance];
     [self setNeedsUpdateTabObjectCounts:YES];
@@ -7758,6 +7759,8 @@ hidingToolbeltShouldResizeWindow:(BOOL)hidingToolbeltShouldResizeWindow
 - (void)tabView:(NSTabView *)tabView updateStateForTabViewItem:(NSTabViewItem *)tabViewItem {
     PTYTab *tab = tabViewItem.identifier;
     [_contentView.tabBarControl setIsProcessing:tab.isProcessing forTabWithIdentifier:tab];
+    [_contentView.tabBarControl setProgress:(PSMProgress)tab.activeSession.screen.progress
+                       forTabWithIdentifier:tab];
     [_contentView.tabBarControl setIcon:tab.icon forTabWithIdentifier:tab];
     [_contentView.tabBarControl setObjectCount:tab.objectCount forTabWithIdentifier:tab];
     [_contentView.tabBarControl setIsPinned:tab.isPinned forTabViewItem:tabViewItem];
@@ -7788,6 +7791,13 @@ hidingToolbeltShouldResizeWindow:(BOOL)hidingToolbeltShouldResizeWindow
         }
     }
     [_contentView updateTitleAndBorderViews];
+}
+
+- (void)updateSessionProgressBarVisibility {
+    const BOOL showInlineProgressBar = (self.numberOfTabs == 1);
+    for (PTYSession *session in self.allSessions) {
+        session.view.showInlineProgressBar = showInlineProgressBar;
+    }
 }
 
 - (void)updateTabProgress {

--- a/sources/PseudoTerminal.m
+++ b/sources/PseudoTerminal.m
@@ -6309,6 +6309,7 @@ hidingToolbeltShouldResizeWindow:(BOOL)hidingToolbeltShouldResizeWindow
         DLog(@"tab bar should NOT be accessory, but is on loan.");
         [self returnTabBarToContentView];
     }
+    [self updateSessionProgressBarVisibility];
     DLog(@"Tab bar state after updateTabBarControlIsTitlebarAccessory: hidden=%@ alpha=%@ frame=%@",
          @(_contentView.tabBarControl.isHidden),
          @(_contentView.tabBarControl.alphaValue),
@@ -7759,7 +7760,7 @@ hidingToolbeltShouldResizeWindow:(BOOL)hidingToolbeltShouldResizeWindow
 - (void)tabView:(NSTabView *)tabView updateStateForTabViewItem:(NSTabViewItem *)tabViewItem {
     PTYTab *tab = tabViewItem.identifier;
     [_contentView.tabBarControl setIsProcessing:tab.isProcessing forTabWithIdentifier:tab];
-    [_contentView.tabBarControl setProgress:(PSMProgress)tab.activeSession.screen.progress
+    [_contentView.tabBarControl setProgress:(PSMProgress)tab.progress
                        forTabWithIdentifier:tab];
     [_contentView.tabBarControl setIcon:tab.icon forTabWithIdentifier:tab];
     [_contentView.tabBarControl setObjectCount:tab.objectCount forTabWithIdentifier:tab];
@@ -7793,16 +7794,34 @@ hidingToolbeltShouldResizeWindow:(BOOL)hidingToolbeltShouldResizeWindow
     [_contentView updateTitleAndBorderViews];
 }
 
+- (BOOL)tabBarProvidesProgressVisibility {
+    if (togglingLionFullScreen_ || self.lionFullScreen) {
+        return self.shouldShowPermanentFullScreenTabBar;
+    }
+    return self.tabBarShouldBeVisible;
+}
+
+- (BOOL)shouldShowInlineProgressBarForSession:(PTYSession *)session tabBarVisible:(BOOL)tabBarVisible {
+    PTYTab *tab = [self tabForSession:session];
+    if (!tab) {
+        return YES;
+    }
+    const BOOL hasSingleTab = (self.numberOfTabs == 1);
+    const BOOL hasSplitPanes = (tab.sessions.count > 1);
+    return (hasSingleTab || hasSplitPanes || !tabBarVisible);
+}
+
 - (void)updateSessionProgressBarVisibility {
-    const BOOL showInlineProgressBar = (self.numberOfTabs == 1);
+    const BOOL tabBarVisible = [self tabBarProvidesProgressVisibility];
     for (PTYSession *session in self.allSessions) {
-        session.view.showInlineProgressBar = showInlineProgressBar;
+        session.view.showInlineProgressBar = [self shouldShowInlineProgressBarForSession:session
+                                                                           tabBarVisible:tabBarVisible];
     }
 }
 
 - (void)updateTabProgress {
     for (PTYTab *tab in [self tabs]) {
-        [_contentView.tabBarControl setProgress:(PSMProgress)tab.activeSession.screen.progress
+        [_contentView.tabBarControl setProgress:(PSMProgress)tab.progress
                            forTabWithIdentifier:tab];
     }
 }
@@ -13015,6 +13034,7 @@ typedef NS_ENUM(NSUInteger, iTermBroadcastCommand) {
 }
 
 - (void)numberOfSessionsDidChangeInTab:(PTYTab *)tab {
+    [self updateSessionProgressBarVisibility];
     if (tab == self.currentTab) {
         [self updateUseTransparency];
     }

--- a/sources/SessionView.h
+++ b/sources/SessionView.h
@@ -223,6 +223,7 @@ typedef NS_ENUM(NSUInteger, iTermSessionViewFindDriver) {
 @property (nonatomic, readonly) BOOL isBrowser;
 @property (nonatomic) VT100ScreenProgress progress;
 @property (nonatomic) BOOL enableProgressBars;
+@property (nonatomic) BOOL showInlineProgressBar;
 @property (nonatomic) CGFloat progressBarHeight;
 @property (nonatomic, copy) NSString *progressBarColorScheme;
 @property (nonatomic, readonly) SessionTitleView *title;

--- a/sources/SessionView.m
+++ b/sources/SessionView.m
@@ -186,6 +186,7 @@ NSString *const SessionViewWasSelectedForInspectionNotification = @"SessionViewW
     if (self) {
         [self registerForDraggedTypes:@[ iTermMovePaneDragType, @"com.iterm2.psm.controlitem" ]];
         lastResizeDate_ = [NSDate date];
+        _showInlineProgressBar = YES;
         _announcements = [[NSMutableArray alloc] init];
 
         _imageView = [[iTermImageView alloc] init];
@@ -1967,13 +1968,18 @@ typedef NS_ENUM(NSInteger, SessionViewTrackingMode) {
             _progressBar.hidden = YES;
         }
     }
-    if (!self.enableProgressBars) {
+    if (!self.enableProgressBars || !self.showInlineProgressBar) {
         _progressBar.hidden = YES;
     }
 }
 
 - (void)setEnableProgressBars:(BOOL)enableProgressBars {
     _enableProgressBars = enableProgressBars;
+    [self updateProgressBar];
+}
+
+- (void)setShowInlineProgressBar:(BOOL)showInlineProgressBar {
+    _showInlineProgressBar = showInlineProgressBar;
     [self updateProgressBar];
 }
 

--- a/sources/iTermAdvancedSettingsModel.h
+++ b/sources/iTermAdvancedSettingsModel.h
@@ -151,6 +151,7 @@ extern NSString *const iTermAdvancedSettingsDidChange;
 + (BOOL)disableSmartSelectionActionsOnClick;
 + (BOOL)disableTabBarTooltips;
 + (BOOL)disableTopRightIndicators;
++ (BOOL)leftTabBarProgressBarsAreHorizontal;
 + (BOOL)disableTmuxWindowPositionRestoration;
 + (BOOL)disableTmuxWindowResizing;
 + (BOOL)disableWindowShadowWhenTransparencyOnMojave;

--- a/sources/iTermAdvancedSettingsModel.m
+++ b/sources/iTermAdvancedSettingsModel.m
@@ -305,6 +305,7 @@ DEFINE_BOOL(disregardDockSettingToOpenTabsInsteadOfWindows, YES, SECTION_TABS @"
 DEFINE_BOOL(convertTabDragToWindowDragForSolitaryTabInCompactOrMinimalTheme, YES, SECTION_TABS @"In the Minimal and Compact themes when there is a single tab and the tab bar is visible, should dragging the tab bar move the window?\nThis also affects windows without titlebars in any theme.");
 DEFINE_BOOL(highVisibility, YES, SECTION_TABS @"High Contrast modes maximize visibility.\nWhen enabled, the dark high-contrast theme emphasizes visibility over beauty.");
 DEFINE_BOOL(drawBottomLineForHorizontalTabBar, YES, SECTION_TABS @"Draw bottom line for horizontal tabbar in Regular, Dark and Light theme?");
+DEFINE_BOOL(leftTabBarProgressBarsAreHorizontal, NO, SECTION_TABS @"Draw horizontal progress bars in left-side tab bars?\nWhen disabled, left-side tab bars show vertical progress bars along the leading edge of each tab.");
 DEFINE_BOOL(disableTabBarTooltips, NO, SECTION_TABS @"Disable tab bar tooltips?");
 DEFINE_BOOL(useCustomTabBarFontSize, NO, SECTION_TABS @"Use custom font size for tab labels?\nSee also advanced setting “Custom tab label font size”.");
 DEFINE_FLOAT(customTabBarFontSize, 11.0, SECTION_TABS @"Custom tab label font size\nFor this to take effect, turn on “Use custom font size for tab labels?”.");

--- a/sources/iTermProgressBarView.swift
+++ b/sources/iTermProgressBarView.swift
@@ -508,6 +508,10 @@ private extension iTermProgressBarView {
 // MARK: - NSView overrides
 
 extension iTermProgressBarView {
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        nil
+    }
+
     // Layer frame updates are handled in layoutSublayers(of:), which updates frames based on mode,
     // ensuring the error layer fills its superlayer, the indeterminate layer animates properly,
     // and the determinate layer reflects the current progress percentage.

--- a/sources/iTermProgressBarView.swift
+++ b/sources/iTermProgressBarView.swift
@@ -45,6 +45,14 @@ extension VT100ScreenProgress {
 @objc
 class iTermProgressBarView: NSView {
     @objc var heightValue: CGFloat = 2.0
+    @objc var vertical = false {
+        didSet {
+            if vertical != oldValue {
+                updateGradientDirections()
+                layer?.setNeedsLayout()
+            }
+        }
+    }
     @objc var colorScheme: String = iTermProgressBarColorSchemeDefault {
         didSet {
             updateLayerColors()
@@ -274,7 +282,28 @@ private extension iTermProgressBarView {
         updateLayerColors()
     }
 
+    private func updateGradientDirections() {
+        let startPoint: CGPoint
+        let endPoint: CGPoint
+        if vertical {
+            startPoint = CGPoint(x: 0.5, y: 1)
+            endPoint = CGPoint(x: 0.5, y: 0)
+        } else {
+            startPoint = CGPoint(x: 0, y: 0.5)
+            endPoint = CGPoint(x: 1, y: 0.5)
+        }
+        for layer in [errorLayer, indeterminateLayer1, indeterminateLayer2, determinateLayer] {
+            guard let gradientLayer = layer as? CAGradientLayer else {
+                continue
+            }
+            gradientLayer.startPoint = startPoint
+            gradientLayer.endPoint = endPoint
+        }
+    }
+
     private func updateLayerColors() {
+        updateGradientDirections()
+
         // Update error layer colors
         if let errorGradient = errorLayer as? CAGradientLayer {
             let colors = errorColors(dark: darkMode)
@@ -401,17 +430,15 @@ private extension iTermProgressBarView {
 
     private func setupIndeterminateLayers() {
         let width = layer?.bounds.width ?? bounds.width
-        let height = desiredHeight
-
-        let gradientWidth = width
+        let height = vertical ? (layer?.bounds.height ?? bounds.height) : desiredHeight
 
         // Set up container to clip content
         indeterminateContainer.frame = CGRect(x: 0, y: 0, width: width, height: height)
         indeterminateContainer.masksToBounds = true
 
         // Set up both gradient layers
-        indeterminateLayer1.frame = CGRect(x: 0, y: 0, width: gradientWidth, height: height)
-        indeterminateLayer2.frame = CGRect(x: 0, y: 0, width: gradientWidth, height: height)
+        indeterminateLayer1.frame = CGRect(x: 0, y: 0, width: width, height: height)
+        indeterminateLayer2.frame = CGRect(x: 0, y: 0, width: width, height: height)
 
         indeterminateContainer.addSublayer(indeterminateLayer1)
         indeterminateContainer.addSublayer(indeterminateLayer2)
@@ -430,44 +457,71 @@ private extension iTermProgressBarView {
         indeterminateLayer2.removeAnimation(forKey: animationKey)
 
         let width = layer?.bounds.width ?? bounds.width
-        let gradientWidth = width
-
-        // Calculate the distance to travel (one full cycle)
-        let distance = width + gradientWidth
+        let height = layer?.bounds.height ?? bounds.height
         let duration = darkMode ? 3.0 : 6.0
-
-        // Get current time to synchronize both animations precisely
         let now = CACurrentMediaTime()
 
-        // Layer 1 starts from off-screen left
-        let animation1 = CABasicAnimation(keyPath: "position.x")
-        animation1.fromValue = -gradientWidth / 2
-        animation1.toValue = width + gradientWidth / 2
-        animation1.duration = duration
-        animation1.repeatCount = .infinity
-        animation1.timingFunction = CAMediaTimingFunction(name: .linear)
-        animation1.beginTime = now
-        animation1.isRemovedOnCompletion = false
-        animation1.fillMode = .forwards
+        if vertical {
+            let gradientHeight = height
+            let distance = height + gradientHeight
 
-        indeterminateLayer1.position.x = -gradientWidth / 2
-        indeterminateLayer1.add(animation1, forKey: animationKey)
+            let animation1 = CABasicAnimation(keyPath: "position.y")
+            animation1.fromValue = height + gradientHeight / 2
+            animation1.toValue = -gradientHeight / 2
+            animation1.duration = duration
+            animation1.repeatCount = .infinity
+            animation1.timingFunction = CAMediaTimingFunction(name: .linear)
+            animation1.beginTime = now
+            animation1.isRemovedOnCompletion = false
+            animation1.fillMode = .forwards
 
-        // Layer 2 follows layer 1, offset by half the duration to create wrap-around effect
-        let animation2 = CABasicAnimation(keyPath: "position.x")
-        animation2.fromValue = -gradientWidth / 2
-        animation2.toValue = width + gradientWidth / 2
-        animation2.duration = duration
-        animation2.repeatCount = .infinity
-        animation2.timingFunction = CAMediaTimingFunction(name: .linear)
-        animation2.isRemovedOnCompletion = false
-        animation2.fillMode = .forwards
-        // Start layer 2's animation offset by the time it takes to travel one gradient width
-        let timeOffset = (duration * Double(gradientWidth)) / Double(distance)
-        animation2.beginTime = now - timeOffset
+            indeterminateLayer1.position = CGPoint(x: width / 2, y: height + gradientHeight / 2)
+            indeterminateLayer1.add(animation1, forKey: animationKey)
 
-        indeterminateLayer2.position.x = -gradientWidth / 2
-        indeterminateLayer2.add(animation2, forKey: animationKey)
+            let animation2 = CABasicAnimation(keyPath: "position.y")
+            animation2.fromValue = height + gradientHeight / 2
+            animation2.toValue = -gradientHeight / 2
+            animation2.duration = duration
+            animation2.repeatCount = .infinity
+            animation2.timingFunction = CAMediaTimingFunction(name: .linear)
+            animation2.isRemovedOnCompletion = false
+            animation2.fillMode = .forwards
+            let timeOffset = (duration * Double(gradientHeight)) / Double(distance)
+            animation2.beginTime = now - timeOffset
+
+            indeterminateLayer2.position = CGPoint(x: width / 2, y: height + gradientHeight / 2)
+            indeterminateLayer2.add(animation2, forKey: animationKey)
+        } else {
+            let gradientWidth = width
+            let distance = width + gradientWidth
+
+            let animation1 = CABasicAnimation(keyPath: "position.x")
+            animation1.fromValue = -gradientWidth / 2
+            animation1.toValue = width + gradientWidth / 2
+            animation1.duration = duration
+            animation1.repeatCount = .infinity
+            animation1.timingFunction = CAMediaTimingFunction(name: .linear)
+            animation1.beginTime = now
+            animation1.isRemovedOnCompletion = false
+            animation1.fillMode = .forwards
+
+            indeterminateLayer1.position.x = -gradientWidth / 2
+            indeterminateLayer1.add(animation1, forKey: animationKey)
+
+            let animation2 = CABasicAnimation(keyPath: "position.x")
+            animation2.fromValue = -gradientWidth / 2
+            animation2.toValue = width + gradientWidth / 2
+            animation2.duration = duration
+            animation2.repeatCount = .infinity
+            animation2.timingFunction = CAMediaTimingFunction(name: .linear)
+            animation2.isRemovedOnCompletion = false
+            animation2.fillMode = .forwards
+            let timeOffset = (duration * Double(gradientWidth)) / Double(distance)
+            animation2.beginTime = now - timeOffset
+
+            indeterminateLayer2.position.x = -gradientWidth / 2
+            indeterminateLayer2.add(animation2, forKey: animationKey)
+        }
 
         CATransaction.commit()
     }
@@ -475,8 +529,18 @@ private extension iTermProgressBarView {
     private func setDeterminate(success: Success, percentage: Int32, animated: Bool) {
         let clamped = max(0, min(100, percentage))
         let width = layer?.bounds.width ?? bounds.width
-        let progressWidth = width * CGFloat(clamped) / 100.0
-        let newFrame = CGRect(x: 0, y: 0, width: progressWidth, height: desiredHeight)
+        let height = vertical ? (layer?.bounds.height ?? bounds.height) : desiredHeight
+        let newFrame: CGRect
+        if vertical {
+            let progressHeight = height * CGFloat(clamped) / 100.0
+            newFrame = CGRect(x: 0,
+                              y: height - progressHeight,
+                              width: width,
+                              height: progressHeight)
+        } else {
+            let progressWidth = width * CGFloat(clamped) / 100.0
+            newFrame = CGRect(x: 0, y: 0, width: progressWidth, height: height)
+        }
         if animated {
             let animation = CABasicAnimation(keyPath: "frame")
             animation.fromValue = determinateLayer.presentation()?.frame ?? determinateLayer.frame
@@ -560,7 +624,7 @@ extension iTermProgressBarView: CALayerDelegate {
     // CALayerDelegate method to update sublayer frames appropriately.
     func layoutSublayers(of layer: CALayer) {
         let width = layer.bounds.width
-        let height = desiredHeight
+        let height = vertical ? layer.bounds.height : desiredHeight
         switch mode {
         case .error:
             // Make the error layer fill the entire width and desired height.
@@ -572,9 +636,8 @@ extension iTermProgressBarView: CALayerDelegate {
         case .indeterminate:
             // Update container frame and restart animation if needed.
             indeterminateContainer.frame = CGRect(x: 0, y: 0, width: width, height: height)
-            let gradientWidth = width
-            indeterminateLayer1.frame = CGRect(x: 0, y: 0, width: gradientWidth, height: height)
-            indeterminateLayer2.frame = CGRect(x: 0, y: 0, width: gradientWidth, height: height)
+            indeterminateLayer1.frame = CGRect(x: 0, y: 0, width: width, height: height)
+            indeterminateLayer2.frame = CGRect(x: 0, y: 0, width: width, height: height)
             // Only restart animation if it's not already running
             if indeterminateLayer1.animation(forKey: "indeterminateScroll") == nil {
                 startIndeterminateAnimation()
@@ -582,8 +645,16 @@ extension iTermProgressBarView: CALayerDelegate {
         case let .determinate(success: success, percentage: percentage):
             // Set determinate layer width according to current percentage.
             let clamped = max(0, min(100, percentage))
-            let progressWidth = width * CGFloat(clamped) / 100.0
-            determinateLayer.frame = CGRect(x: 0, y: 0, width: progressWidth, height: height)
+            if vertical {
+                let progressHeight = height * CGFloat(clamped) / 100.0
+                determinateLayer.frame = CGRect(x: 0,
+                                                y: height - progressHeight,
+                                                width: width,
+                                                height: progressHeight)
+            } else {
+                let progressWidth = width * CGFloat(clamped) / 100.0
+                determinateLayer.frame = CGRect(x: 0, y: 0, width: progressWidth, height: height)
+            }
             updateDeterminateColors(success: success)
         case .ground:
             // No visible layer to layout.

--- a/sources/iTermTabBarControlView.m
+++ b/sources/iTermTabBarControlView.m
@@ -22,6 +22,10 @@
 - (NSRect)_opaqueRectForWindowMoveWhenInTitlebar;
 @end
 
+@interface PSMTabBarControl (Private)
+- (void)syncTabProgressBars;
+@end
+
 typedef NS_ENUM(NSInteger, iTermTabBarFlashState) {
     kFlashOff,
     kFlashHolding,  // Regular delay
@@ -56,8 +60,17 @@ typedef NS_ENUM(NSInteger, iTermTabBarFlashState) {
         }
         self.showAddTabButton = ![iTermAdvancedSettingsModel removeAddTabButton];
         self.selectsTabsOnMouseDown = [iTermAdvancedSettingsModel selectsTabsOnMouseDown];
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(advancedSettingsDidChange:)
+                                                     name:iTermAdvancedSettingsDidChange
+                                                   object:nil];
     }
     return self;
+}
+
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+    [super dealloc];
 }
 
 - (void)setCmdPressed:(BOOL)cmdPressed {
@@ -322,6 +335,11 @@ typedef NS_ENUM(NSInteger, iTermTabBarFlashState) {
     return [self cellShouldShowTabProgressBar:cell];
 }
 
+- (BOOL)tabProgressBarsShouldBeVertical {
+    return (self.orientation == PSMTabBarVerticalOrientation &&
+            ![iTermAdvancedSettingsModel leftTabBarProgressBarsAreHorizontal]);
+}
+
 - (NSView *)customProgressBarViewForTabCell:(PSMTabBarCell *)cell {
     iTermProgressBarView *progressBar = [[[iTermProgressBarView alloc] init] autorelease];
     progressBar.heightValue = PSMTabBarProgressBarHeight;
@@ -331,10 +349,14 @@ typedef NS_ENUM(NSInteger, iTermTabBarFlashState) {
 - (void)configureCustomProgressBarView:(NSView *)view forTabCell:(PSMTabBarCell *)cell {
     iTermProgressBarView *progressBar = (iTermProgressBarView *)view;
     progressBar.heightValue = PSMTabBarProgressBarHeight;
-    progressBar.vertical = (self.orientation == PSMTabBarVerticalOrientation);
+    progressBar.vertical = [self tabProgressBarsShouldBeVertical];
     progressBar.darkMode = self.style.useLightControls;
     progressBar.colorScheme = [self tabProgressBarColorSchemeForCell:cell];
     progressBar.state = (VT100ScreenProgress)cell.progress;
+}
+
+- (void)advancedSettingsDidChange:(NSNotification *)notification {
+    [self syncTabProgressBars];
 }
 
 - (void)setFlashState:(iTermTabBarFlashState)flashState {

--- a/sources/iTermTabBarControlView.m
+++ b/sources/iTermTabBarControlView.m
@@ -331,6 +331,7 @@ typedef NS_ENUM(NSInteger, iTermTabBarFlashState) {
 - (void)configureCustomProgressBarView:(NSView *)view forTabCell:(PSMTabBarCell *)cell {
     iTermProgressBarView *progressBar = (iTermProgressBarView *)view;
     progressBar.heightValue = PSMTabBarProgressBarHeight;
+    progressBar.vertical = (self.orientation == PSMTabBarVerticalOrientation);
     progressBar.darkMode = self.style.useLightControls;
     progressBar.colorScheme = [self tabProgressBarColorSchemeForCell:cell];
     progressBar.state = (VT100ScreenProgress)cell.progress;

--- a/sources/iTermTabBarControlView.m
+++ b/sources/iTermTabBarControlView.m
@@ -29,26 +29,17 @@ typedef NS_ENUM(NSInteger, iTermTabBarFlashState) {
     kFlashFadingOut,
 };
 
-@interface PSMTabBarControl (iTermTabBarControlViewPrivate)
-- (NSMutableArray<PSMTabBarCell *> *)cells;
-- (void)update:(BOOL)animate;
-@end
-
 @interface iTermTabBarControlView ()
 @property(nonatomic, assign) iTermTabBarFlashState flashState;
 @end
 
 @implementation iTermTabBarControlView {
     iTermDelayedPerform *_flashDelayedPerform;  // weak
-    NSMutableDictionary<NSValue *, iTermProgressBarView *> *_tabProgressBars;
 }
-
-static const CGFloat iTermTabProgressBarHeight = 2;
 
 - (instancetype)initWithFrame:(NSRect)frameRect {
     self = [super initWithFrame:frameRect];
     if (self) {
-        _tabProgressBars = [[NSMutableDictionary alloc] init];
         [self setTabsHaveCloseButtons:[iTermPreferences boolForKey:kPreferenceKeyTabsHaveCloseButton]];
         self.minimumTabDragDistance = [iTermAdvancedSettingsModel minimumTabDragDistance];
         // This used to depend on job but it's too difficult to do now that different sessions might
@@ -67,19 +58,6 @@ static const CGFloat iTermTabProgressBarHeight = 2;
         self.selectsTabsOnMouseDown = [iTermAdvancedSettingsModel selectsTabsOnMouseDown];
     }
     return self;
-}
-
-- (void)dealloc {
-    for (iTermProgressBarView *progressBar in _tabProgressBars.allValues) {
-        [progressBar removeFromSuperview];
-    }
-    [_tabProgressBars release];
-    [super dealloc];
-}
-
-- (void)drawRect:(NSRect)dirtyRect {
-    [super drawRect:dirtyRect];
-    [self syncTabProgressBars];
 }
 
 - (void)setCmdPressed:(BOOL)cmdPressed {
@@ -295,34 +273,9 @@ static const CGFloat iTermTabProgressBarHeight = 2;
         self.height = tabBarHeight;
     }
     self.showAddTabButton = ![iTermAdvancedSettingsModel removeAddTabButton] && (orientation == PSMTabBarHorizontalOrientation);
-    [self syncTabProgressBars];
-}
-
-- (void)update:(BOOL)animate {
-    [super update:animate];
-    [self syncTabProgressBars];
-}
-
-- (void)setProgress:(PSMProgress)progress forTabWithIdentifier:(id)identifier {
-    [super setProgress:progress forTabWithIdentifier:identifier];
-    [self syncTabProgressBars];
-}
-
-- (void)removeTabForCell:(PSMTabBarCell *)cell {
-    [self removeProgressBarForCell:cell];
-    [super removeTabForCell:cell];
-}
-
-- (void)removeCell:(PSMTabBarCell *)cell {
-    [self removeProgressBarForCell:cell];
-    [super removeCell:cell];
 }
 
 #pragma mark - Private
-
-- (NSValue *)progressBarKeyForCell:(PSMTabBarCell *)cell {
-    return [NSValue valueWithNonretainedObject:cell];
-}
 
 - (BOOL)cellAllowsTabProgressBar:(PSMTabBarCell *)cell {
     NSTabViewItem *item = (NSTabViewItem *)cell.representedObject;
@@ -365,58 +318,22 @@ static const CGFloat iTermTabProgressBarHeight = 2;
     return tab.activeSession.view.progressBarColorScheme ?: iTermProgressBarColorSchemeDefault;
 }
 
-- (NSRect)frameForProgressBarInCell:(PSMTabBarCell *)cell {
-    return NSMakeRect(cell.frame.origin.x,
-                      cell.frame.origin.y,
-                      cell.frame.size.width,
-                      iTermTabProgressBarHeight);
+- (BOOL)shouldShowCustomProgressBarForTabCell:(PSMTabBarCell *)cell {
+    return [self cellShouldShowTabProgressBar:cell];
 }
 
-- (void)removeProgressBarForCell:(PSMTabBarCell *)cell {
-    NSValue *key = [self progressBarKeyForCell:cell];
-    iTermProgressBarView *progressBar = _tabProgressBars[key];
-    if (!progressBar) {
-        return;
-    }
-    [progressBar removeFromSuperview];
-    [_tabProgressBars removeObjectForKey:key];
+- (NSView *)customProgressBarViewForTabCell:(PSMTabBarCell *)cell {
+    iTermProgressBarView *progressBar = [[[iTermProgressBarView alloc] init] autorelease];
+    progressBar.heightValue = PSMTabBarProgressBarHeight;
+    return progressBar;
 }
 
-- (void)syncTabProgressBars {
-    NSMutableSet<NSValue *> *visibleKeys = [NSMutableSet set];
-    for (PSMTabBarCell *cell in self.cells) {
-        if (![self cellShouldShowTabProgressBar:cell]) {
-            [self removeProgressBarForCell:cell];
-            continue;
-        }
-        NSValue *key = [self progressBarKeyForCell:cell];
-        [visibleKeys addObject:key];
-        iTermProgressBarView *progressBar = _tabProgressBars[key];
-        if (!progressBar) {
-            progressBar = [[[iTermProgressBarView alloc] init] autorelease];
-            progressBar.heightValue = iTermTabProgressBarHeight;
-            _tabProgressBars[key] = progressBar;
-        }
-        progressBar.darkMode = self.style.useLightControls;
-        progressBar.colorScheme = [self tabProgressBarColorSchemeForCell:cell];
-        progressBar.state = (VT100ScreenProgress)cell.progress;
-        progressBar.frame = [self frameForProgressBarInCell:cell];
-        progressBar.hidden = NO;
-        if (progressBar.superview != self) {
-            [self addSubview:progressBar];
-        }
-        cell.indicator.hidden = YES;
-        cell.indicator.animate = NO;
-        [cell.indicator removeFromSuperview];
-    }
-
-    for (NSValue *key in [_tabProgressBars allKeys]) {
-        if (![visibleKeys containsObject:key]) {
-            iTermProgressBarView *progressBar = _tabProgressBars[key];
-            [progressBar removeFromSuperview];
-            [_tabProgressBars removeObjectForKey:key];
-        }
-    }
+- (void)configureCustomProgressBarView:(NSView *)view forTabCell:(PSMTabBarCell *)cell {
+    iTermProgressBarView *progressBar = (iTermProgressBarView *)view;
+    progressBar.heightValue = PSMTabBarProgressBarHeight;
+    progressBar.darkMode = self.style.useLightControls;
+    progressBar.colorScheme = [self tabProgressBarColorSchemeForCell:cell];
+    progressBar.state = (VT100ScreenProgress)cell.progress;
 }
 
 - (void)setFlashState:(iTermTabBarFlashState)flashState {

--- a/sources/iTermTabBarControlView.m
+++ b/sources/iTermTabBarControlView.m
@@ -15,6 +15,8 @@
 #import "NSObject+iTerm.h"
 #import "NSView+iTerm.h"
 #import "NSWindow+iTerm.h"
+#import "PTYTab.h"
+#import "SessionView.h"
 
 @interface NSView (Private2)
 - (NSRect)_opaqueRectForWindowMoveWhenInTitlebar;
@@ -27,17 +29,26 @@ typedef NS_ENUM(NSInteger, iTermTabBarFlashState) {
     kFlashFadingOut,
 };
 
+@interface PSMTabBarControl (iTermTabBarControlViewPrivate)
+- (NSMutableArray<PSMTabBarCell *> *)cells;
+- (void)update:(BOOL)animate;
+@end
+
 @interface iTermTabBarControlView ()
 @property(nonatomic, assign) iTermTabBarFlashState flashState;
 @end
 
 @implementation iTermTabBarControlView {
     iTermDelayedPerform *_flashDelayedPerform;  // weak
+    NSMutableDictionary<NSValue *, iTermProgressBarView *> *_tabProgressBars;
 }
+
+static const CGFloat iTermTabProgressBarHeight = 2;
 
 - (instancetype)initWithFrame:(NSRect)frameRect {
     self = [super initWithFrame:frameRect];
     if (self) {
+        _tabProgressBars = [[NSMutableDictionary alloc] init];
         [self setTabsHaveCloseButtons:[iTermPreferences boolForKey:kPreferenceKeyTabsHaveCloseButton]];
         self.minimumTabDragDistance = [iTermAdvancedSettingsModel minimumTabDragDistance];
         // This used to depend on job but it's too difficult to do now that different sessions might
@@ -58,8 +69,17 @@ typedef NS_ENUM(NSInteger, iTermTabBarFlashState) {
     return self;
 }
 
+- (void)dealloc {
+    for (iTermProgressBarView *progressBar in _tabProgressBars.allValues) {
+        [progressBar removeFromSuperview];
+    }
+    [_tabProgressBars release];
+    [super dealloc];
+}
+
 - (void)drawRect:(NSRect)dirtyRect {
     [super drawRect:dirtyRect];
+    [self syncTabProgressBars];
 }
 
 - (void)setCmdPressed:(BOOL)cmdPressed {
@@ -144,6 +164,7 @@ typedef NS_ENUM(NSInteger, iTermTabBarFlashState) {
          self,
          [NSThread callStackSymbols]);
     [super setFrame:frame];
+    [self syncTabProgressBars];
 }
 
 - (void)fadeIn {
@@ -274,9 +295,129 @@ typedef NS_ENUM(NSInteger, iTermTabBarFlashState) {
         self.height = tabBarHeight;
     }
     self.showAddTabButton = ![iTermAdvancedSettingsModel removeAddTabButton] && (orientation == PSMTabBarHorizontalOrientation);
+    [self syncTabProgressBars];
+}
+
+- (void)update:(BOOL)animate {
+    [super update:animate];
+    [self syncTabProgressBars];
+}
+
+- (void)setProgress:(PSMProgress)progress forTabWithIdentifier:(id)identifier {
+    [super setProgress:progress forTabWithIdentifier:identifier];
+    [self syncTabProgressBars];
+}
+
+- (void)removeTabForCell:(PSMTabBarCell *)cell {
+    [self removeProgressBarForCell:cell];
+    [super removeTabForCell:cell];
+}
+
+- (void)removeCell:(PSMTabBarCell *)cell {
+    [self removeProgressBarForCell:cell];
+    [super removeCell:cell];
 }
 
 #pragma mark - Private
+
+- (NSValue *)progressBarKeyForCell:(PSMTabBarCell *)cell {
+    return [NSValue valueWithNonretainedObject:cell];
+}
+
+- (BOOL)cellAllowsTabProgressBar:(PSMTabBarCell *)cell {
+    NSTabViewItem *item = (NSTabViewItem *)cell.representedObject;
+    PTYTab *tab = item.identifier;
+    if (![tab isKindOfClass:[PTYTab class]]) {
+        return YES;
+    }
+    return tab.activeSession.view.enableProgressBars;
+}
+
+- (BOOL)cellShouldShowTabProgressBar:(PSMTabBarCell *)cell {
+    if (self.tabView.numberOfTabViewItems <= 1 ||
+        cell.isPlaceholder ||
+        cell.isInOverflowMenu ||
+        ![self cellAllowsTabProgressBar:cell]) {
+        return NO;
+    }
+    switch (cell.progress) {
+        case PSMProgressStopped:
+            return NO;
+        case PSMProgressError:
+        case PSMProgressIndeterminate:
+            return YES;
+        case PSMProgressSuccessBase:
+        case PSMProgressWarningBase:
+        case PSMProgressErrorBase:
+            break;
+    }
+    return ((cell.progress >= PSMProgressSuccessBase && cell.progress <= PSMProgressSuccessBase + 100) ||
+            (cell.progress >= PSMProgressErrorBase && cell.progress <= PSMProgressErrorBase + 100) ||
+            (cell.progress >= PSMProgressWarningBase && cell.progress <= PSMProgressWarningBase + 100));
+}
+
+- (NSString *)tabProgressBarColorSchemeForCell:(PSMTabBarCell *)cell {
+    NSTabViewItem *item = (NSTabViewItem *)cell.representedObject;
+    PTYTab *tab = item.identifier;
+    if (![tab isKindOfClass:[PTYTab class]]) {
+        return iTermProgressBarColorSchemeDefault;
+    }
+    return tab.activeSession.view.progressBarColorScheme ?: iTermProgressBarColorSchemeDefault;
+}
+
+- (NSRect)frameForProgressBarInCell:(PSMTabBarCell *)cell {
+    return NSMakeRect(cell.frame.origin.x,
+                      cell.frame.origin.y,
+                      cell.frame.size.width,
+                      iTermTabProgressBarHeight);
+}
+
+- (void)removeProgressBarForCell:(PSMTabBarCell *)cell {
+    NSValue *key = [self progressBarKeyForCell:cell];
+    iTermProgressBarView *progressBar = _tabProgressBars[key];
+    if (!progressBar) {
+        return;
+    }
+    [progressBar removeFromSuperview];
+    [_tabProgressBars removeObjectForKey:key];
+}
+
+- (void)syncTabProgressBars {
+    NSMutableSet<NSValue *> *visibleKeys = [NSMutableSet set];
+    for (PSMTabBarCell *cell in self.cells) {
+        if (![self cellShouldShowTabProgressBar:cell]) {
+            [self removeProgressBarForCell:cell];
+            continue;
+        }
+        NSValue *key = [self progressBarKeyForCell:cell];
+        [visibleKeys addObject:key];
+        iTermProgressBarView *progressBar = _tabProgressBars[key];
+        if (!progressBar) {
+            progressBar = [[[iTermProgressBarView alloc] init] autorelease];
+            progressBar.heightValue = iTermTabProgressBarHeight;
+            _tabProgressBars[key] = progressBar;
+        }
+        progressBar.darkMode = self.style.useLightControls;
+        progressBar.colorScheme = [self tabProgressBarColorSchemeForCell:cell];
+        progressBar.state = (VT100ScreenProgress)cell.progress;
+        progressBar.frame = [self frameForProgressBarInCell:cell];
+        progressBar.hidden = NO;
+        if (progressBar.superview != self) {
+            [self addSubview:progressBar];
+        }
+        cell.indicator.hidden = YES;
+        cell.indicator.animate = NO;
+        [cell.indicator removeFromSuperview];
+    }
+
+    for (NSValue *key in [_tabProgressBars allKeys]) {
+        if (![visibleKeys containsObject:key]) {
+            iTermProgressBarView *progressBar = _tabProgressBars[key];
+            [progressBar removeFromSuperview];
+            [_tabProgressBars removeObjectForKey:key];
+        }
+    }
+}
 
 - (void)setFlashState:(iTermTabBarFlashState)flashState {
     NSArray *names = @[ @"Off", @"FadeIn", @"Holding", @"Extending", @"FadeOut" ];


### PR DESCRIPTION
PoC for feature request https://gitlab.com/gnachman/iterm2/-/work_items/12808

The version in here respects the session settings for progress bars (hide/show and color scheme). If only a single tab is opened the progress bar is shown at the top of the session view, as soon as multiple tabs are opened the progress bar moves to the tab itself.

