### PR TITLE
Add common Unicode range presets to Special Exceptions

### DIFF
--- a/ModernTests/SpecialExceptionsPresetTests.swift
+++ b/ModernTests/SpecialExceptionsPresetTests.swift
@@ -1,0 +1,111 @@
+import XCTest
+@testable import iTerm2SharedARC
+
+final class SpecialExceptionsPresetTests: XCTestCase {
+    private func makeDistinctFonts() -> [NSFont] {
+        let candidates = [
+            "Menlo",
+            "Monaco",
+            "Courier",
+            "Courier New",
+            "Helvetica",
+            "Times New Roman"
+        ]
+        var fonts: [NSFont] = []
+        for candidate in candidates {
+            guard let font = NSFont(name: candidate, size: 12),
+                  let familyName = font.familyName else {
+                continue
+            }
+            if fonts.allSatisfy({ $0.familyName != familyName }) {
+                fonts.append(font)
+            }
+            if fonts.count == 3 {
+                return fonts
+            }
+        }
+        XCTFail("Expected at least three distinct fonts for the font table tests")
+        let fallback = NSFont.userFixedPitchFont(ofSize: 12)!
+        return [fallback, fallback, fallback]
+    }
+
+    private func makeFontTable(entries: [FontTable.Entry] = []) -> (FontTable, [NSFont]) {
+        let fonts = makeDistinctFonts()
+        let ascii = PTYFontInfo(font: fonts[0])
+        let nonAscii = PTYFontInfo(font: fonts[1])
+        let configString = entries.isEmpty ? nil : FontTable.Config(entries: entries).stringValue
+        let table = FontTable(defaultFont: ascii,
+                              nonAsciiFont: nonAscii,
+                              configString: configString,
+                              browserZoom: 1.0)
+        return (table, fonts)
+    }
+
+    private func familyName(for codePoint: UTF32Char, in table: FontTable) -> String? {
+        var remapped = codePoint
+        return table.font(for: codePoint, remapped: &remapped).font.familyName
+    }
+
+    func testPresetCatalogMatchesExpectedRanges() {
+        XCTAssertEqual(SpecialExceptionRangePreset.han.range, 0x4E00...0x9FFF)
+        XCTAssertEqual(SpecialExceptionRangePreset.hiraganaKatakana.range, 0x3040...0x30FF)
+        XCTAssertEqual(SpecialExceptionRangePreset.hangulSyllables.range, 0xAC00...0xD7AF)
+        XCTAssertEqual(SpecialExceptionRangePreset.arabic.range, 0x0600...0x06FF)
+        XCTAssertEqual(SpecialExceptionRangePreset.cyrillic.range, 0x0400...0x04FF)
+        XCTAssertEqual(SpecialExceptionRangePreset.greek.range, 0x0370...0x03FF)
+        XCTAssertEqual(SpecialExceptionRangePreset.privateUseArea.range, 0xE000...0xF8FF)
+    }
+
+    func testPresetMenuOrderIsAlphabetical() {
+        XCTAssertEqual(SpecialExceptionRangePreset.menuOrder.map(\.title), [
+            "Arabic",
+            "Cyrillic",
+            "Greek (Greek and Coptic)",
+            "Han (CJK Unified Ideographs)",
+            "Hangul Syllables",
+            "Hiragana/Katakana",
+            "Private Use Area",
+        ])
+    }
+
+    func testNoConfigPreservesLegacyNonAsciiFallbackBehavior() {
+        let (table, fonts) = makeFontTable()
+
+        XCTAssertEqual(familyName(for: 0x41, in: table), fonts[0].familyName)
+        XCTAssertEqual(familyName(for: 0x4E2D, in: table), fonts[1].familyName)
+    }
+
+    func testExplicitPresetOverridesLegacyNonAsciiFallback() {
+        let ruleFont = makeDistinctFonts()[2]
+        var entry = SpecialExceptionRangePreset.han.entry
+        entry.fontName = ruleFont.fontName
+
+        let (table, fonts) = makeFontTable(entries: [entry])
+
+        XCTAssertEqual(familyName(for: 0x4E2D, in: table), ruleFont.familyName)
+        XCTAssertEqual(familyName(for: 0x3042, in: table), fonts[1].familyName)
+    }
+
+    func testGreekPresetOverridesLegacyNonAsciiFallback() {
+        let ruleFont = makeDistinctFonts()[2]
+        var entry = SpecialExceptionRangePreset.greek.entry
+        entry.fontName = ruleFont.fontName
+
+        let (table, fonts) = makeFontTable(entries: [entry])
+
+        XCTAssertEqual(familyName(for: 0x03A9, in: table), ruleFont.familyName)
+        XCTAssertEqual(familyName(for: 0x0416, in: table), fonts[1].familyName)
+    }
+
+    func testPresetEntriesDoNotRemapCodePoints() {
+        var entry = SpecialExceptionRangePreset.privateUseArea.entry
+        entry.fontName = makeDistinctFonts()[2].fontName
+        let (table, _) = makeFontTable(entries: [entry])
+
+        let codePoint: UTF32Char = 0xE0B0
+        var remapped = codePoint
+        _ = table.font(for: codePoint, remapped: &remapped)
+
+        XCTAssertEqual(remapped, codePoint)
+    }
+}

--- a/sources/SpecialExceptionsWindowController.swift
+++ b/sources/SpecialExceptionsWindowController.swift
@@ -13,6 +13,67 @@ protocol SpecialExceptionEntryEditorWindowControllerDelegate: AnyObject {
     func editorRangeIsValid(range: ClosedRange<Int>) -> Bool
 }
 
+enum SpecialExceptionRangePreset: CaseIterable {
+    case han
+    case hiraganaKatakana
+    case hangulSyllables
+    case arabic
+    case cyrillic
+    case greek
+    case privateUseArea
+
+    var title: String {
+        switch self {
+        case .han:
+            return "Han (CJK Unified Ideographs)"
+        case .hiraganaKatakana:
+            return "Hiragana/Katakana"
+        case .hangulSyllables:
+            return "Hangul Syllables"
+        case .arabic:
+            return "Arabic"
+        case .cyrillic:
+            return "Cyrillic"
+        case .greek:
+            return "Greek (Greek and Coptic)"
+        case .privateUseArea:
+            return "Private Use Area"
+        }
+    }
+
+    var range: ClosedRange<Int> {
+        switch self {
+        case .han:
+            return 0x4E00...0x9FFF
+        case .hiraganaKatakana:
+            return 0x3040...0x30FF
+        case .hangulSyllables:
+            return 0xAC00...0xD7AF
+        case .arabic:
+            return 0x0600...0x06FF
+        case .cyrillic:
+            return 0x0400...0x04FF
+        case .greek:
+            return 0x0370...0x03FF
+        case .privateUseArea:
+            return 0xE000...0xF8FF
+        }
+    }
+
+    var entry: FontTable.Entry {
+        FontTable.Entry(start: range.lowerBound,
+                        count: range.upperBound - range.lowerBound + 1,
+                        destination: nil,
+                        fontName: "")
+    }
+
+    static var menuOrder: [SpecialExceptionRangePreset] {
+        allCases.sorted {
+            $0.title.localizedStandardCompare($1.title) == .orderedAscending
+        }
+    }
+}
+
 @objc
 class SpecialExceptionEntryEditorWindowController: NSWindowController, NSTextFieldDelegate, AffordanceDelegate {
     @IBOutlet weak var start: NSTextField!
@@ -42,10 +103,7 @@ class SpecialExceptionEntryEditorWindowController: NSWindowController, NSTextFie
         compositeView.removeOptionsButton()
         compositeView.affordance.delegate = self
         preview.textColor = .textColor
-        if let entry {
-            copyEntryToControls()
-            affordance.familyName = entry.fontName
-        }
+        copyEntryToControls()
         updateEnabled()
     }
 
@@ -131,11 +189,16 @@ class SpecialExceptionEntryEditorWindowController: NSWindowController, NSTextFie
 
     func copyEntryToControls() {
         guard let entry else {
+            start.stringValue = ""
+            end.stringValue = ""
+            compositeView.affordance.familyName = nil
+            hasDestination.state = .off
+            destination.stringValue = ""
             return
         }
         start.stringValue = Self.formatUnicode(entry.start)
         end.stringValue = Self.formatUnicode(entry.start + entry.count - 1)
-        compositeView.affordance.familyName = entry.fontName
+        compositeView.affordance.familyName = entry.fontName.isEmpty ? nil : entry.fontName
         if let d = entry.destination {
             hasDestination.state = .on
             destination.stringValue = Self.formatUnicode(d)
@@ -433,6 +496,29 @@ final class SpecialExceptionsWindowController: NSWindowController {
         crud.reload()
     }
 
+    @IBAction func addPreset(_ sender: NSButton) {
+        let menu = NSMenu()
+        for (index, preset) in SpecialExceptionRangePreset.menuOrder.enumerated() {
+            let item = NSMenuItem(title: preset.title,
+                                  action: #selector(addPresetMenuItem(_:)),
+                                  keyEquivalent: "")
+            item.tag = index
+            item.target = self
+            menu.addItem(item)
+        }
+        menu.popUp(positioning: nil,
+                   at: NSPoint(x: 0, y: sender.bounds.maxY + 4),
+                   in: sender)
+    }
+
+    @objc
+    private func addPresetMenuItem(_ sender: NSMenuItem) {
+        let preset = SpecialExceptionRangePreset.menuOrder[sender.tag]
+        beginAdd(with: preset.entry) { [weak self] in
+            self?.acceptAddPreset()
+        }
+    }
+
     private func showError(_ message: String) {
         iTermWarning.show(withTitle: message,
                           actions: ["OK"],
@@ -622,25 +708,48 @@ extension SpecialExceptionsWindowController: CRUDDataProvider {
     }
 
     func makeNew(completion: @escaping (Int) -> ()) {
-        editorWindowController.entry = nil
-        editorWindowController.delegate = self
-        editorWindowController.disallowedIndexes = assignedIndexes
-        editorWindowController.copyEntryToControls()
-        window?.beginSheet(editorWindowController.window!) { [weak self] status in
-            if status == .OK {
-                self?.acceptAdd(completion: completion)
-            }
+        beginAdd(with: nil) { [weak self] in
+            self?.acceptAdd(completion: completion)
         }
     }
 
     private func acceptAdd(completion: (Int) -> ()) {
+        let row = insertEditorEntry()
+        completion(row)
+        updateEnabled()
+    }
+
+    private func acceptAddPreset() {
+        let row = insertEditorEntry()
+        crud.reload()
+        tableView.selectRowIndexes(IndexSet(integer: row), byExtendingSelection: false)
+        tableView.scrollRowToVisible(row)
+        updateEnabled()
+    }
+
+    private func beginAdd(with entry: FontTable.Entry?, completion: @escaping () -> ()) {
+        rowBeingEdited = -1
+        editorWindowController.entry = entry
+        editorWindowController.delegate = self
+        editorWindowController.disallowedIndexes = assignedIndexes
+        editorWindowController.copyEntryToControls()
+        window?.beginSheet(editorWindowController.window!) { status in
+            if status == .OK {
+                completion()
+            }
+        }
+    }
+
+    @discardableResult
+    private func insertEditorEntry() -> Int {
         let entry = editorWindowController!.entry!
-        let row = config.entries.insertionIndex { $0.start < entry.start }
+        let row = config.entries.insertionIndex {
+            $0.closedRange.lowerBound < entry.closedRange.lowerBound
+        }
         crud.undoable {
             config.entries.insert(entry, at: row)
         }
-        completion(row)
-        updateEnabled()
+        return row
     }
 }
 
@@ -660,4 +769,3 @@ extension RandomAccessCollection {
         return currentSlice.startIndex
     }
 }
-

--- a/sources/SpecialExceptionsWindowController.xib
+++ b/sources/SpecialExceptionsWindowController.xib
@@ -227,14 +227,25 @@ Gw
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     </progressIndicator>
                     <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uvk-ki-cpM">
-                        <rect key="frame" x="18" y="351" width="444" height="11"/>
+                        <rect key="frame" x="18" y="351" width="368" height="11"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <textFieldCell key="cell" controlSize="mini" lineBreakMode="clipping" alignment="center" title="Special Exceptions specify fonts to use for particular characters." id="50c-TU-qXa">
+                        <textFieldCell key="cell" controlSize="mini" lineBreakMode="clipping" alignment="center" title="Special Exceptions override fonts for specific Unicode ranges or scripts." id="50c-TU-qXa">
                             <font key="font" metaFont="miniSystem"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
+                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="drZ-2V-Q5Y">
+                        <rect key="frame" x="394" y="346" width="140" height="32"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="push" title="Add Preset…" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="K4n-LF-VUt">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                        <connections>
+                            <action selector="addPreset:" target="-2" id="vpo-Lh-9hA"/>
+                        </connections>
+                    </button>
                 </subviews>
             </view>
             <point key="canvasLocation" x="138" y="200"/>


### PR DESCRIPTION
Summary

This adds an “Add Preset…” button to the Special Exceptions window for a few common Unicode ranges/scripts:

- Arabic
- Cyrillic
- Greek (Greek and Coptic)
- Han (CJK Unified Ideographs)
- Hangul Syllables
- Hiragana/Katakana
- Private Use Area

Special Exceptions already supports per-range font overrides, but configuring it currently requires manually entering Unicode code point ranges. This change does not introduce a new font fallback mechanism; it improves discoverability and usability on top of the existing per-range override system.

The existing Non-ASCII Font behavior remains unchanged:
- explicit Special Exceptions entries still take precedence
- unmatched characters still fall back to the legacy Non-ASCII Font

Details

- adds preset entries for common ranges/scripts in the Special Exceptions UI
- sorts preset menu entries alphabetically by title
- keeps the existing manual range-based workflow intact
- treats an empty font selection as unset so invalid entries are not persisted

Tests

Added focused tests covering:
- preset range definitions
- alphabetical preset menu order
- explicit range overrides taking precedence over the legacy Non-ASCII font
- unchanged fallback behavior when no preset matches
- no code point remapping for preset-only entries

Validation

- built the app locally
- ran `SpecialExceptionsPresetTests` successfully

Related

- GitLab feature request: https://gitlab.com/gnachman/iterm2/-/work_items/12823
