### PR TITLE
Require confirmation before closing a pinned tab

### DIFF
--- a/docs/notes-3.7.txt
+++ b/docs/notes-3.7.txt
@@ -107,6 +107,11 @@ New Features in Terminal Sessions:
   Settings > Profiles > Text.
 
 Tabs, Windows, and UI:
+- Closing a pinned tab now requires
+  confirmation, whether via the close
+  button, middle-click, ⌘W, or quitting
+  the app. The dialog identifies the tab
+  as pinned so the prompt is clear.
 - The control-sequence-controlled progress
   indicator is now shown in the tab bar.
 - An active pane border can be displayed to

--- a/sources/AppShutdown/iTermPromptOnCloseReason.h
+++ b/sources/AppShutdown/iTermPromptOnCloseReason.h
@@ -22,6 +22,7 @@
 + (instancetype)closingMultipleSessionsPreferenceEnabled;
 + (instancetype)tmuxClientsAlwaysPromptBecauseJobsAreNotExposed;
 + (instancetype)sessionIsLocked;
++ (instancetype)tabIsPinned;
 
 - (void)addReason:(iTermPromptOnCloseReason *)reason;
 

--- a/sources/AppShutdown/iTermPromptOnCloseReason.m
+++ b/sources/AppShutdown/iTermPromptOnCloseReason.m
@@ -238,6 +238,10 @@
     return [[[iTermPromptOnCloseMessageReason alloc] initWithMessage:@"This pane is locked." priority:75] autorelease];
 }
 
++ (instancetype)tabIsPinned {
+    return [[[iTermPromptOnCloseMessageReason alloc] initWithMessage:@"A pinned tab is open." priority:70] autorelease];
+}
+
 - (BOOL)hasReason {
     return YES;
 }

--- a/sources/TerminalView/PseudoTerminal.m
+++ b/sources/TerminalView/PseudoTerminal.m
@@ -6675,10 +6675,6 @@ hidingToolbeltShouldResizeWindow:(BOOL)hidingToolbeltShouldResizeWindow
 // NSTabView
 - (void)tabView:(NSTabView *)tabView closeTab:(id)identifier button:(int)button {
     if (button != 2 || [iTermAdvancedSettingsModel middleClickClosesTab]) {
-        PTYTab *const tab = identifier;
-        if (tab.isPinned && ![self confirmCloseTab:tab suppressConfirmation:NO]) {
-            return;
-        }
         [self closeTab:identifier];
     }
 }

--- a/sources/TerminalView/PseudoTerminal.m
+++ b/sources/TerminalView/PseudoTerminal.m
@@ -1941,14 +1941,21 @@ ITERM_WEAKLY_REFERENCEABLE
         const BOOL anyIsLocked = [[aTab sessions] anyWithBlock:^BOOL(PTYSession *anObject) {
             return anObject.locked;
         }];
+        NSString *const pinnedPrefix = aTab.isPinned ? @"pinned " : @"";
         if (numClosing == 1) {
+            NSString *const identifier = anyIsLocked
+                ? [NSString stringWithFormat:@"This %@tab (with a locked session)", pinnedPrefix]
+                : [NSString stringWithFormat:@"This %@tab", pinnedPrefix];
             okToClose = [self confirmCloseForSessions:[aTab sessions]
-                                           identifier:anyIsLocked ? @"This tab (with a locked session)" : @"This tab"
+                                           identifier:identifier
                                           genericName:[NSString stringWithFormat:@"tab #%d",
                                                        [aTab tabNumber]]];
         } else {
+            NSString *const identifier = anyIsLocked
+                ? [NSString stringWithFormat:@"This %@multi-pane tab (with locked sessions)", pinnedPrefix]
+                : [NSString stringWithFormat:@"This %@multi-pane tab", pinnedPrefix];
             okToClose = [self confirmCloseForSessions:[aTab sessions]
-                                           identifier:anyIsLocked ? @"This multi-pane tab (with locked sessions)" : @"This multi-pane tab"
+                                           identifier:identifier
                                           genericName:[NSString stringWithFormat:@"tab #%d",
                                                        [aTab tabNumber]]];
         }
@@ -4174,6 +4181,12 @@ hidingToolbeltShouldResizeWindow:(BOOL)hidingToolbeltShouldResizeWindow
     iTermPromptOnCloseReason *reason = [iTermPromptOnCloseReason noReason];
     for (PTYSession *aSession in [self allSessions]) {
         [reason addReason:[aSession promptOnCloseReason]];
+    }
+    for (PTYTab *tab in self.tabs) {
+        if (tab.isPinned) {
+            [reason addReason:[iTermPromptOnCloseReason tabIsPinned]];
+            break;
+        }
     }
     return reason;
 }
@@ -6662,6 +6675,10 @@ hidingToolbeltShouldResizeWindow:(BOOL)hidingToolbeltShouldResizeWindow
 // NSTabView
 - (void)tabView:(NSTabView *)tabView closeTab:(id)identifier button:(int)button {
     if (button != 2 || [iTermAdvancedSettingsModel middleClickClosesTab]) {
+        PTYTab *const tab = identifier;
+        if (tab.isPinned && ![self confirmCloseTab:tab suppressConfirmation:NO]) {
+            return;
+        }
         [self closeTab:identifier];
     }
 }


### PR DESCRIPTION
Hi @gnachman , 

I saw that the pinned tab feature has recently been implemented (thanks! I've wanted it for a while). However, I've noticed that there's no protection to prevent a pinned tab from being closed by mistake. 

Here is my contribution – I hope you like it!

## Description
This pull request introduces a confirmation dialog whenever a user attempts to close a pinned tab, regardless of the method used (close button, middle-click, ⌘W, or quitting the app). 

The confirmation dialog clearly identifies the tab as pinned to avoid accidental closure. 

>Builds on ed3f5b06f ("Add pinned tabs support") — pinned tabs had no close protection, allowing them to be closed the same as any other tab.

## Changes

**Pinned Tab Close Confirmation:**

* Added a new close reason, `tabIsPinned`, to `iTermPromptOnCloseReason` for use in close confirmation dialogs. [[1]](diffhunk://#diff-9ed8ec7bc4995e5de5a54f733f2ef8166ccb257f72ae821f31cefd04e7d1cad6R25) [[2]](diffhunk://#diff-b42e07d26e037663f37e4e36cca57fdd398b68ffcc53629d89af9f980ba3dd9cR241-R244)
* Updated the tab close confirmation logic in `PseudoTerminal.m` to prepend "pinned" to the tab identifier in confirmation dialogs, making it clear when a pinned tab is being closed.
* Modified the prompt-on-close reason logic to include a reason if any open tab is pinned, ensuring the prompt is shown when quitting with pinned tabs open.
* Enforced confirmation for closing pinned tabs via the tab close button or middle-click, preventing accidental closure without explicit confirmation.
* Updated documentation to reflect that closing a pinned tab now always requires confirmation, with the dialog clearly indicating the tab is pinned.
* Added a release note to `notes-3.7.txt`.