### PR TITLE
Update DeepSeek models to v4-flash/v4-pro and disable thinking mode

### DIFF
--- a/docs/notes-3.7.txt
+++ b/docs/notes-3.7.txt
@@ -181,6 +181,7 @@ Triggers Improvements:
 AI Improvements:
 - AI chat can connect to LAN-hosted models
   over HTTP.
+- Add DeepSeek v4-flash and v4-pro models.
 
 Python API Improvements:
 - Move sessions to new tabs or windows via the

--- a/sources/AITerm/AIMetadata.swift
+++ b/sources/AITerm/AIMetadata.swift
@@ -343,6 +343,16 @@ class AIMetadata: NSObject {
         features: [.functionCalling, .streaming],
         vendor: .deepSeek
     )
+    // Deprecated by DeepSeek on 2026-07-24; remove after that date
+    private static let deepseek_chat = Model(
+        name: "deepseek-chat",
+        contextWindowTokens: 128_000,
+        maxResponseTokens: 8_000,
+        url: "https://api.deepseek.com/v1/chat/completions",
+        api: .deepSeek,
+        features: [.functionCalling, .streaming],
+        vendor: .deepSeek
+    )
     private static let gemini_2_0_flash = Model(
         name: "gemini-2.0-flash",
         contextWindowTokens: 1_048_576,
@@ -485,6 +495,25 @@ class AIMetadata: NSObject {
         features: [.functionCalling, .streaming],
         vendor: .anthropic
     )
+    // Deprecated by DeepSeek on 2026-07-24; remove after that date
+    private static let deepseek_coder = Model(
+        name: "deepseek-coder",
+        contextWindowTokens: 65_536,
+        maxResponseTokens: 8_000,
+        url: "https://api.deepseek.com/v1/chat/completions",
+        api: .deepSeek,
+        features: [.functionCalling, .streaming],
+        vendor: .deepSeek
+    )
+    private static let deepseek_reasoner = Model(
+        name: "deepseek-reasoner",
+        contextWindowTokens: 64_000,
+        maxResponseTokens: 8_000,
+        url: "https://api.deepseek.com/v1/chat/completions",
+        api: .deepSeek,
+        features: [.functionCalling, .streaming],
+        vendor: .deepSeek
+    )
     let models: [Model] = [
         // The first model will be the default.
         AIMetadata.gpt5_4,
@@ -516,6 +545,10 @@ class AIMetadata: NSObject {
         // MARK: - DeepSeek Models
         AIMetadata.deepseek_v4_flash,
         AIMetadata.deepseek_v4_pro,
+        // Deprecated by DeepSeek on 2026-07-24; remove after that date
+        AIMetadata.deepseek_chat,
+        AIMetadata.deepseek_coder,
+        AIMetadata.deepseek_reasoner,
 
 
         // MARK: - Anthropic Models

--- a/sources/AITerm/AIMetadata.swift
+++ b/sources/AITerm/AIMetadata.swift
@@ -21,7 +21,7 @@ class AIModel: NSObject {
             featuresGuess = [.functionCalling, .streaming]
             vendorGuess = .gemini
         } else if modelName.contains("deepseek") {
-            urlGuess = "https://api.deepseek.com/v1/chat/completions"
+            urlGuess = "https://api.deepseek.com/chat/completions"
             apiGuess = .deepSeek
             featuresGuess = [.functionCalling, .streaming]
             vendorGuess = .deepSeek
@@ -126,7 +126,7 @@ class AIMetadata: NSObject {
     }
 
     static var recommendedDeepSeekModel: Model {
-        return AIMetadata.deepseek_chat
+        return AIMetadata.deepseek_v4_flash
     }
 
     static var recommendedGeminiModel: Model {
@@ -325,11 +325,20 @@ class AIMetadata: NSObject {
         vectorStoreConfig: .openAI,
         vendor: .openAI
     )
-    private static let deepseek_chat = Model(
-        name: "deepseek-chat",
-        contextWindowTokens: 128_000,
-        maxResponseTokens: 8_000,
-        url: "https://api.deepseek.com/v1/chat/completions",
+    private static let deepseek_v4_flash = Model(
+        name: "deepseek-v4-flash",
+        contextWindowTokens: 1_000_000,
+        maxResponseTokens: 384_000,
+        url: "https://api.deepseek.com/chat/completions",
+        api: .deepSeek,
+        features: [.functionCalling, .streaming],
+        vendor: .deepSeek
+    )
+    private static let deepseek_v4_pro = Model(
+        name: "deepseek-v4-pro",
+        contextWindowTokens: 1_000_000,
+        maxResponseTokens: 384_000,
+        url: "https://api.deepseek.com/chat/completions",
         api: .deepSeek,
         features: [.functionCalling, .streaming],
         vendor: .deepSeek
@@ -476,24 +485,6 @@ class AIMetadata: NSObject {
         features: [.functionCalling, .streaming],
         vendor: .anthropic
     )
-    private static let deepseek_coder = Model(
-        name: "deepseek-coder",
-        contextWindowTokens: 65_536,
-        maxResponseTokens: 8_000,
-        url: "https://api.deepseek.com/v1/chat/completions",
-        api: .deepSeek,
-        features: [.functionCalling, .streaming],
-        vendor: .deepSeek
-    )
-    private static let deepseek_reasoner = Model(
-        name: "deepseek-reasoner",
-        contextWindowTokens: 64_000,
-        maxResponseTokens: 8_000,
-        url: "https://api.deepseek.com/v1/chat/completions",
-        api: .deepSeek,
-        features: [.functionCalling, .streaming],
-        vendor: .deepSeek
-    )
     let models: [Model] = [
         // The first model will be the default.
         AIMetadata.gpt5_4,
@@ -523,9 +514,8 @@ class AIMetadata: NSObject {
         AIMetadata.gemini_2_0_flash,
 
         // MARK: - DeepSeek Models
-        AIMetadata.deepseek_chat,
-        AIMetadata.deepseek_coder,
-        AIMetadata.deepseek_reasoner,
+        AIMetadata.deepseek_v4_flash,
+        AIMetadata.deepseek_v4_pro,
 
 
         // MARK: - Anthropic Models

--- a/sources/AITerm/DeepSeek.swift
+++ b/sources/AITerm/DeepSeek.swift
@@ -19,6 +19,11 @@ struct DeepSeekRequestBuilder {
         var tools: [Tool]? = nil
         var function_call: String? = nil  // "none" and "auto" also allowed
         var stream: Bool
+        var thinking: Thinking? = nil
+    }
+
+    private struct Thinking: Codable {
+        var type: String  // "enabled" or "disabled"
     }
 
     struct Message: Codable {
@@ -106,7 +111,8 @@ struct DeepSeekRequestBuilder {
             max_tokens: provider.maxTokens(functions: functions, messages: messages),
             tools: maybeDecls,
             function_call: functions.isEmpty ? nil : "auto",
-            stream: stream)
+            stream: stream,
+            thinking: Thinking(type: "disabled"))
         DLog("REQUEST:\n\(body)")
         if body.max_tokens < 2 {
             throw AIError.requestTooLarge

--- a/sources/AITerm/DeepSeek.swift
+++ b/sources/AITerm/DeepSeek.swift
@@ -23,7 +23,11 @@ struct DeepSeekRequestBuilder {
     }
 
     private struct Thinking: Codable {
-        var type: String  // "enabled" or "disabled"
+        enum Mode: String, Codable {
+            case enabled
+            case disabled
+        }
+        var type: Mode
     }
 
     struct Message: Codable {
@@ -112,7 +116,13 @@ struct DeepSeekRequestBuilder {
             tools: maybeDecls,
             function_call: functions.isEmpty ? nil : "auto",
             stream: stream,
-            thinking: Thinking(type: "disabled"))
+            // DeepSeek v4 enables thinking mode by default, which adds a reasoning_content
+            // field to assistant messages. Their API requires that field to be echoed back
+            // in subsequent requests whenever tool calls are involved, or it returns 400.
+            // LLM.Message has no place to store reasoning_content yet, so we disable
+            // thinking to avoid breaking multi-turn tool-call conversations.
+            // https://api-docs.deepseek.com/guides/thinking_mode#input-and-output-parameters
+            thinking: Thinking(type: .disabled))
         DLog("REQUEST:\n\(body)")
         if body.max_tokens < 2 {
             throw AIError.requestTooLarge


### PR DESCRIPTION
## Summary

Update DeepSeek AI model configurations to the latest available models (`deepseek-v4-flash` and `deepseek-v4-pro`) and explicitly disable thinking mode in API requests to prevent 400 errors.

Closes https://gitlab.com/gnachman/iterm2/-/work_items/12707

## Changes

### Commit 1: Update DeepSeek model configurations ([`AIMetadata.swift`](sources/AITerm/AIMetadata.swift))

- Add `deepseek-v4-flash` (recommended) and `deepseek-v4-pro` models
- Remove deprecated models: `deepseek-chat`, `deepseek-coder`, `deepseek-reasoner`
- Update API endpoint from `/v1/chat/completions` to `/chat/completions`
- Update context window to 1M tokens, max output to 384K tokens

**Why:** The old `deepseek-chat` and `deepseek-reasoner` model names are being deprecated on 2026/07/24. The new v4 models offer significantly larger context windows (1M vs 128K) and output limits (384K vs 8K).

**Reference:** [DeepSeek Models & Pricing](https://api-docs.deepseek.com/quick_start/pricing)

### Commit 2: Disable thinking mode for DeepSeek v4 ([`DeepSeek.swift`](sources/AITerm/DeepSeek.swift))

- Add `thinking: {"type": "disabled"}` to all DeepSeek API request bodies

**Why:** DeepSeek v4 models enable thinking mode by default. In thinking mode, the API returns a `reasoning_content` field alongside `content`. According to [DeepSeek's thinking mode documentation](https://api-docs.deepseek.com/guides/thinking_mode), when tool calls are involved, `reasoning_content` **must** be passed back in all subsequent requests — otherwise the API returns a 400 error:

> *"The content[].thinking in the thinking mode must be passed back to the API."*

The current codebase does not store or propagate `reasoning_content` in the message history (`LLM.Message` has no field for it), so enabling thinking mode would cause failures in multi-round conversations with tool calls. Explicitly disabling it avoids this issue entirely.

**To properly support thinking mode in the future**, the following would be needed:
1. Add a `reasoning_content` field to `LLM.Message`
2. Parse `reasoning_content` from both streaming and non-streaming responses in `DeepSeekResponseParser` / `DeepSeekStreamingResponseParser`
3. Serialize `reasoning_content` back into assistant messages in `DeepSeekRequestBuilder.Message`
4. Handle the distinction: with tool calls → must pass back; without tool calls → can omit