### PR TITLE
Add preference to show/hide browser toolbar

### DIFF
--- a/sources/Browser/Core/iTermBrowserViewController.swift
+++ b/sources/Browser/Core/iTermBrowserViewController.swift
@@ -844,19 +844,23 @@ extension iTermBrowserViewController {
 
     private func layoutSubviews() {
         let bounds = view.bounds
-        
+
         // Background view - full coverage
         backgroundView.frame = bounds
-        
-        // Toolbar - top, full width, 44pt height
-        toolbar.frame = NSRect(x: 0, y: bounds.height - 44,
-                              width: bounds.width, height: 44)
-        
-        // WebView - below toolbar
+
+        let showToolbar = profileObserver.value(KEY_BROWSER_SHOW_TOOLBAR) == true
+        let toolbarHeight: CGFloat = showToolbar ? 44 : 0
+        toolbar.isHidden = !showToolbar
+
+        // Toolbar - top, full width
+        toolbar.frame = NSRect(x: 0, y: bounds.height - toolbarHeight,
+                              width: bounds.width, height: toolbarHeight)
+
+        // WebView - below toolbar (full height when toolbar is hidden)
         browserManager.webView.frame = NSRect(x: 0, y: 0,
                                             width: bounds.width,
-                                            height: bounds.height - 44)
-        
+                                            height: bounds.height - toolbarHeight)
+
         // Shade view - full coverage
         shadeView.frame = bounds
     }

--- a/sources/Settings/Profiles/ITAddressBookMgr.h
+++ b/sources/Settings/Profiles/ITAddressBookMgr.h
@@ -195,6 +195,7 @@
 // Web
 #define KEY_BROWSER_ZOOM           @"Browser Zoom"  // 100 = 100%
 #define KEY_BROWSER_DEV_NULL       @"Dev Null Mode"
+#define KEY_BROWSER_SHOW_TOOLBAR   @"Browser Show Toolbar"  // bool
 #define KEY_BROWSER_EXTENSIONS_ROOT @"Browser Extensions Root"
 #define KEY_BROWSER_EXTENSION_ACTIVE_IDS @"Browser Extension Active IDs"
 #define KEY_INSTANT_REPLAY         @"Instant Replay"

--- a/sources/Settings/iTermProfilePreferences.m
+++ b/sources/Settings/iTermProfilePreferences.m
@@ -358,6 +358,7 @@ typedef struct {
             KEY_DYNAMIC_PROFILE_REWRITABLE,
             KEY_DYNAMIC_PROFILE,
             KEY_BROWSER_DEV_NULL,
+            KEY_BROWSER_SHOW_TOOLBAR,
             KEY_INSTANT_REPLAY,
         ];
         NSArray *number = @[
@@ -1169,6 +1170,7 @@ typedef struct {
 
                   KEY_BROWSER_ZOOM: @100,
                   KEY_BROWSER_DEV_NULL: @NO,
+                  KEY_BROWSER_SHOW_TOOLBAR: @YES,
                   KEY_BROWSER_EXTENSIONS_ROOT: [NSNull null],
                   KEY_BROWSER_EXTENSION_ACTIVE_IDS: @[],
                   KEY_WIDTH: @1000,


### PR DESCRIPTION
## Summary
Adds a profile preference to control the visibility of the browser's navigation toolbar.

## Motivation
Browser profiles in iTerm2 embed a full web view with a navigation toolbar. Some use cases—such as plugins or extensions that host their own chrome-less web content—benefit from having the toolbar hidden to maximize screen real estate and avoid redundant UI.

## Changes
- Add `KEY_BROWSER_SHOW_TOOLBAR` profile key (default: `YES`)
- Register the key in preference validation and default value maps
- Update `iTermBrowserViewController.layoutSubviews()` to conditionally hide the toolbar and adjust the web view frame

## Backward Compatibility
Defaults to `YES`, preserving the existing behavior for all current users.