### PR TITLE
feat: add right-side tab position

### DIFF
--- a/ModernTests/iTermLayoutCalculatorTest.swift
+++ b/ModernTests/iTermLayoutCalculatorTest.swift
@@ -148,6 +148,22 @@ final class iTermLayoutCalculatorTest: XCTestCase {
         XCTAssertEqual(result, frame)
     }
 
+    /// Test: Right tab bar position -> no shrinking
+    func testRightTabBar_NoShrinking() {
+        var inputs = makeDefaultInputs()
+        inputs.tabBarVisible = true
+        inputs.tabBarOnLoan = true
+        inputs.tabBarAccessoryOverlapsContent = true
+        inputs.inFullscreen = true
+        inputs.tabPosition = kLayoutTabPositionRight
+
+        let frame = CGRect(x: 0, y: 0, width: 800, height: 600)
+        let result = iTermLayoutCalculator.tabViewFrame(byShrinkingForFullScreenTabBar: frame, with: inputs)
+
+        // Right tab bar never shrinks via this method
+        XCTAssertEqual(result, frame)
+    }
+
     /// Test: Flashing tab bar overlaps content -> no shrinking
     func testFlashingTabBar_NoShrinking() {
         var inputs = makeDefaultInputs()
@@ -429,6 +445,64 @@ final class iTermLayoutCalculatorTest: XCTestCase {
         hiddenInputs.tabBarVisible = false
         let hiddenOutputs = iTermLayoutCalculator.calculateLayout(with: hiddenInputs)
         XCTAssertEqual(hiddenOutputs.tabBarFrame, CGRect.zero)
+
+        // Right tab bar
+        var rightInputs = makeDefaultInputs()
+        rightInputs.tabBarVisible = true
+        rightInputs.tabPosition = kLayoutTabPositionRight
+        let rightOutputs = iTermLayoutCalculator.calculateLayout(with: rightInputs)
+        XCTAssertGreaterThan(rightOutputs.tabBarFrame.origin.x, rightOutputs.tabViewFrame.origin.x)
+    }
+
+    // MARK: - Visible Right Tab Bar Layout Tests
+
+    /// Test: Right tab bar occupies the right edge when toolbelt is hidden
+    func testVisibleRightTabBarWithoutToolbelt() {
+        var inputs = makeDefaultInputs()
+        inputs.tabBarVisible = true
+        inputs.tabPosition = kLayoutTabPositionRight
+        inputs.leftTabBarWidth = 200
+        inputs.contentViewWidth = 800
+
+        let outputs = iTermLayoutCalculator.calculateLayout(withVisibleRightTabBarInputs: inputs)
+
+        XCTAssertEqual(outputs.tabBarFrame.origin.x, 600)
+        XCTAssertEqual(outputs.tabBarFrame.size.width, 200)
+        XCTAssertEqual(outputs.tabViewFrame.origin.x, 0)
+        XCTAssertEqual(outputs.tabViewFrame.size.width, 600)
+    }
+
+    /// Test: Right tab bar sits left of the toolbelt when toolbelt is visible
+    func testVisibleRightTabBarWithToolbelt() {
+        var inputs = makeDefaultInputs()
+        inputs.tabBarVisible = true
+        inputs.tabPosition = kLayoutTabPositionRight
+        inputs.leftTabBarWidth = 200
+        inputs.shouldShowToolbelt = true
+        inputs.toolbeltWidth = 150
+        inputs.contentViewWidth = 800
+
+        let outputs = iTermLayoutCalculator.calculateLayout(withVisibleRightTabBarInputs: inputs)
+
+        XCTAssertEqual(outputs.tabBarFrame.origin.x, 450)
+        XCTAssertEqual(outputs.tabBarFrame.size.width, 200)
+        XCTAssertEqual(outputs.tabViewFrame.size.width, 450)
+        XCTAssertEqual(outputs.toolbeltFrame.origin.x, 650)
+    }
+
+    /// Test: Flashing right tab bar overlaps content instead of shrinking it
+    func testVisibleRightTabBarFlashing() {
+        var inputs = makeDefaultInputs()
+        inputs.tabBarVisible = true
+        inputs.tabPosition = kLayoutTabPositionRight
+        inputs.leftTabBarWidth = 200
+        inputs.tabBarFlashing = true
+        inputs.contentViewWidth = 800
+
+        let outputs = iTermLayoutCalculator.calculateLayout(withVisibleRightTabBarInputs: inputs)
+
+        XCTAssertEqual(outputs.tabViewFrame.origin.x, 0)
+        XCTAssertEqual(outputs.tabViewFrame.size.width, 800)
     }
 
     // MARK: - Unified Mechanism Tests (Phase 4)

--- a/ThirdParty/PSMTabBarControl/source/PSMMinimalTabStyle.m
+++ b/ThirdParty/PSMTabBarControl/source/PSMMinimalTabStyle.m
@@ -606,6 +606,7 @@ static CGFloat PSMWeightedAverage(CGFloat l, CGFloat u, CGFloat w) {
             return NO;
 
         case PSMTab_LeftTab:
+        case PSMTab_RightTab:
         case PSMTab_TopTab:
             return [super shouldDrawTopLineSelected:selected attached:attached position:position];
     }

--- a/ThirdParty/PSMTabBarControl/source/PSMTabBarControl.h
+++ b/ThirdParty/PSMTabBarControl/source/PSMTabBarControl.h
@@ -174,6 +174,7 @@ typedef NS_ENUM(int, PSMTabPosition) {
     PSMTab_TopTab = 0,
     PSMTab_BottomTab = 1,
     PSMTab_LeftTab = 2,
+    PSMTab_RightTab = 3,
 };
 
 extern const CGFloat PSMTabBarProgressBarHeight;
@@ -291,4 +292,3 @@ extern const CGFloat PSMTabBarProgressBarHeight;
 NS_ASSUME_NONNULL_END
 
 BOOL PSMShouldExtendTransparencyIntoMinimalTabBar(void);
-

--- a/ThirdParty/PSMTabBarControl/source/PSMTabBarControl.m
+++ b/ThirdParty/PSMTabBarControl/source/PSMTabBarControl.m
@@ -584,6 +584,7 @@ PSMTabBarControlOptionKey PSMTabBarControlOptionPUAFontProvider = @"PSMTabBarCon
             break;
 
         case PSMTab_LeftTab:
+        case PSMTab_RightTab:
             [self setOrientation:PSMTabBarVerticalOrientation];
             break;
     }
@@ -607,6 +608,7 @@ PSMTabBarControlOptionKey PSMTabBarControlOptionPUAFontProvider = @"PSMTabBarCon
             return (point.y > self.bounds.size.height - edgeDragHeight);
 
         case PSMTab_LeftTab:
+        case PSMTab_RightTab:
             break;
     }
     return NO;
@@ -1821,7 +1823,8 @@ PSMTabBarControlOptionKey PSMTabBarControlOptionPUAFontProvider = @"PSMTabBarCon
     NSPoint mousePt = [self convertPoint:[theEvent locationInWindow] fromView:nil];
     NSRect frame = [self frame];
 
-    if ([self orientation] == PSMTabBarVerticalOrientation && [self allowsResizing] && partnerView && (mousePt.x > frame.size.width - 3)) {
+    const BOOL mouseIsOverVerticalResizeHandle = (_tabLocation == PSMTab_RightTab) ? (mousePt.x < 3) : (mousePt.x > frame.size.width - 3);
+    if ([self orientation] == PSMTabBarVerticalOrientation && [self allowsResizing] && partnerView && mouseIsOverVerticalResizeHandle) {
         _resizing = YES;
     }
 
@@ -1873,16 +1876,28 @@ PSMTabBarControlOptionKey PSMTabBarControlOptionPUAFontProvider = @"PSMTabBarCon
     if (_resizing) {
         NSRect frame = [self frame];
         float resizeAmount = [theEvent deltaX];
-        if ((currentPoint.x > frame.size.width && resizeAmount > 0) || (currentPoint.x < frame.size.width && resizeAmount < 0)) {
+        if (_tabLocation == PSMTab_RightTab) {
+            resizeAmount = -resizeAmount;
+        }
+        const BOOL shouldResize = (_tabLocation == PSMTab_RightTab) ?
+            ((currentPoint.x < 0 && resizeAmount > 0) || (currentPoint.x > 0 && resizeAmount < 0)) :
+            ((currentPoint.x > frame.size.width && resizeAmount > 0) || (currentPoint.x < frame.size.width && resizeAmount < 0));
+        if (shouldResize) {
             [[NSCursor resizeLeftRightCursor] push];
 
             NSRect partnerFrame = [partnerView frame];
 
             //do some bounds checking
             if ((frame.size.width + resizeAmount > [self cellMinWidth]) && (frame.size.width + resizeAmount < [self cellMaxWidth])) {
-                frame.size.width += resizeAmount;
-                partnerFrame.size.width -= resizeAmount;
-                partnerFrame.origin.x += resizeAmount;
+                if (_tabLocation == PSMTab_RightTab) {
+                    frame.origin.x -= resizeAmount;
+                    frame.size.width += resizeAmount;
+                    partnerFrame.size.width -= resizeAmount;
+                } else {
+                    frame.size.width += resizeAmount;
+                    partnerFrame.size.width -= resizeAmount;
+                    partnerFrame.origin.x += resizeAmount;
+                }
 
                 [self setFrame:frame];
                 [partnerView setFrame:partnerFrame];
@@ -2033,7 +2048,8 @@ PSMTabBarControlOptionKey PSMTabBarControlOptionPUAFontProvider = @"PSMTabBarCon
     [super resetCursorRects];
     if ([self orientation] == PSMTabBarVerticalOrientation) {
         NSRect frame = [self frame];
-        [self addCursorRect:NSMakeRect(frame.size.width - 2, 0, 2, frame.size.height) cursor:[NSCursor resizeLeftRightCursor]];
+        const CGFloat cursorX = (_tabLocation == PSMTab_RightTab) ? 0 : frame.size.width - 2;
+        [self addCursorRect:NSMakeRect(cursorX, 0, 2, frame.size.height) cursor:[NSCursor resizeLeftRightCursor]];
     } else {
         const CGFloat edgeDragHeight = self.style.edgeDragHeight;
         if (edgeDragHeight == 0) {
@@ -2053,6 +2069,7 @@ PSMTabBarControlOptionKey PSMTabBarControlOptionPUAFontProvider = @"PSMTabBarCon
                 break;
 
             case PSMTab_LeftTab:
+            case PSMTab_RightTab:
                 break;
         }
     }
@@ -2940,4 +2957,3 @@ static CFAbsoluteTime gDragMoveFirstTime = 0;
 }
 
 @end
-

--- a/ThirdParty/PSMTabBarControl/source/PSMTabDragAssistant.m
+++ b/ThirdParty/PSMTabBarControl/source/PSMTabDragAssistant.m
@@ -395,6 +395,7 @@ static CVReturn DisplayLinkCallback(CVDisplayLinkRef displayLink,
                     switch (control.tabLocation) {
                         case PSMTab_TopTab:
                         case PSMTab_LeftTab:
+                        case PSMTab_RightTab:
                             drawPoint.y = viewImage.size.height - self.draggedCell.frame.size.height;
                             break;
                         case PSMTab_BottomTab:
@@ -421,7 +422,7 @@ static CVReturn DisplayLinkCallback(CVDisplayLinkRef displayLink,
                 [viewImage unlockFocus];
             }
 
-            if (self.sourceTabBar.tabLocation == PSMTab_LeftTab) {
+            if (self.sourceTabBar.tabLocation == PSMTab_LeftTab || self.sourceTabBar.tabLocation == PSMTab_RightTab) {
                 _dragWindowOffset.height += self.height;
             } else if (styleMask & NSWindowStyleMaskFullSizeContentView) {
                _dragWindowOffset.height += self.draggedCell.frame.size.height;
@@ -711,6 +712,7 @@ static CVReturn DisplayLinkCallback(CVDisplayLinkRef displayLink,
             break;
         }
         case PSMTab_LeftTab:
+        case PSMTab_RightTab:
         case PSMTab_TopTab: {
             NSPoint topLeft = control.window.frame.origin;
             topLeft.y += control.window.frame.size.height;
@@ -791,6 +793,7 @@ static CVReturn DisplayLinkCallback(CVDisplayLinkRef displayLink,
             break;
         }
         case PSMTab_LeftTab:
+        case PSMTab_RightTab:
         case PSMTab_TopTab: {
             NSPoint topLeft = origin;
             [window setFrameTopLeftPoint:topLeft];

--- a/ThirdParty/PSMTabBarControl/source/PSMYosemiteTabStyle.m
+++ b/ThirdParty/PSMTabBarControl/source/PSMYosemiteTabStyle.m
@@ -1356,10 +1356,12 @@ const void *PSMTabStyleDarkColorKey = "dark";
         [[self bottomLineColorSelected:NO] set];
         NSRect rightLineRect = rect;
         rightLineRect.origin.y -= 1;
-        [self drawVerticalLineInFrame:rightLineRect x:NSMaxX(rect) - 1];
+        const CGFloat x = (bar.tabLocation == PSMTab_RightTab) ? NSMinX(rect) : NSMaxX(rect) - 1;
+        [self drawVerticalLineInFrame:rightLineRect x:x];
     } else {
         switch (bar.tabLocation) {
             case PSMTab_LeftTab:
+            case PSMTab_RightTab:
                 break;
             case PSMTab_TopTab:
                 // Bottom line
@@ -1381,6 +1383,7 @@ const void *PSMTabStyleDarkColorKey = "dark";
     switch (position) {
         case PSMTab_BottomTab:
         case PSMTab_LeftTab:
+        case PSMTab_RightTab:
             return YES;
 
         case PSMTab_TopTab:

--- a/docs/notes-3.7.txt
+++ b/docs/notes-3.7.txt
@@ -9,6 +9,9 @@ to version 3.6.7 and duplicates some items in
 betas since then.
 
 Major New Features:
+- Tabs can now be placed on the right side
+  of the window.
+
 - A new Tab Status system was added. Sessions
   can now report status that appears on their
   tab with a custom subtitle, color, and dot

--- a/sources/Settings/PreferencePanel.xib
+++ b/sources/Settings/PreferencePanel.xib
@@ -8655,6 +8655,7 @@ You can choose to define the characters considered part of a word with a regular
                                                             <menuItem title="Top" id="4497"/>
                                                             <menuItem title="Bottom" tag="1" id="4498"/>
                                                             <menuItem title="Left" tag="2" id="KWx-TT-5ME"/>
+                                                            <menuItem title="Right" tag="3" id="26R-Nm-GZq"/>
                                                         </items>
                                                     </menu>
                                                 </popUpButtonCell>

--- a/sources/Settings/iTermPreferences.h
+++ b/sources/Settings/iTermPreferences.h
@@ -45,6 +45,7 @@ typedef NS_ENUM(NSUInteger, iTermStatusBarPosition) {
 #define TAB_POSITION_TOP PSMTab_TopTab
 #define TAB_POSITION_BOTTOM PSMTab_BottomTab
 #define TAB_POSITION_LEFT PSMTab_LeftTab
+#define TAB_POSITION_RIGHT PSMTab_RightTab
 
 // Values for kPreferenceKeyXxxRemapping (corresponds to tags in controls).
 // Note that this serves two purposes. It describes what keys are remapped to and also the shortcuts

--- a/sources/TerminalView/PTYTab.m
+++ b/sources/TerminalView/PTYTab.m
@@ -2654,6 +2654,10 @@ static void SetAgainstGrainDim(BOOL isVertical, NSSize *dest, CGFloat value) {
                 xOrigin = tabFrame.size.width;
                 viewSize.width += tabFrame.size.width;
                 break;
+
+            case PSMTab_RightTab:
+                viewSize.width += tabFrame.size.width;
+                break;
         }
     }
 

--- a/sources/TerminalView/PseudoTerminal.m
+++ b/sources/TerminalView/PseudoTerminal.m
@@ -1818,6 +1818,7 @@ ITERM_WEAKLY_REFERENCEABLE
         case PSMTab_TopTab:
             return NO;
         case PSMTab_LeftTab:
+        case PSMTab_RightTab:
         case PSMTab_BottomTab:
             return YES;
     }
@@ -3078,7 +3079,11 @@ ITERM_WEAKLY_REFERENCEABLE
             tabSize = NSMakeSize(step.width - 2, 8);
             break;
         case PSMTab_LeftTab:
+        case PSMTab_RightTab:
             tabsRect.size.width = kLeftTabPreviewWidth;
+            if ([iTermPreferences intForKey:kPreferenceKeyTabPosition] == PSMTab_RightTab) {
+                tabsRect.origin.x = NSMaxX(rect) - kLeftTabPreviewWidth - 1;
+            }
             tabsRect.size.height = rect.size.height;
             step.width = 0;
             tabSize = NSMakeSize(kLeftTabPreviewWidth - 2, 4);
@@ -3114,6 +3119,10 @@ ITERM_WEAKLY_REFERENCEABLE
               break;
           case PSMTab_LeftTab:
               contentRect.origin.x += kLeftTabPreviewWidth;
+              contentRect.size.width -= kLeftTabPreviewWidth;
+              contentRect.size.height += 10;
+              break;
+          case PSMTab_RightTab:
               contentRect.size.width -= kLeftTabPreviewWidth;
               contentRect.size.height += 10;
               break;
@@ -5127,6 +5136,7 @@ hidingToolbeltShouldResizeWindow:(BOOL)hidingToolbeltShouldResizeWindow
         case PSMTab_TopTab:
             return NO;
         case PSMTab_LeftTab:
+        case PSMTab_RightTab:
             return !self.tabBarShouldBeVisible;
     }
 
@@ -5165,6 +5175,7 @@ hidingToolbeltShouldResizeWindow:(BOOL)hidingToolbeltShouldResizeWindow
                                 bottomInset = 4.5;
                                 break;
                             case PSMTab_LeftTab:
+                            case PSMTab_RightTab:
                                 break;
                         }
                     }
@@ -5234,6 +5245,7 @@ hidingToolbeltShouldResizeWindow:(BOOL)hidingToolbeltShouldResizeWindow
             }
         }
         case PSMTab_LeftTab:
+        case PSMTab_RightTab:
             return NSEdgeInsetsMake(24, 0, 0, 0);
 
         case PSMTab_BottomTab:
@@ -6281,8 +6293,9 @@ hidingToolbeltShouldResizeWindow:(BOOL)hidingToolbeltShouldResizeWindow
 - (BOOL)shouldMoveTabBarToTitlebarAccessoryInLionFullScreen {
     switch ([iTermPreferences intForKey:kPreferenceKeyTabPosition]) {
         case PSMTab_LeftTab:
+        case PSMTab_RightTab:
         case PSMTab_BottomTab:
-            DLog(@"left or bottom tabbar - return NO");
+            DLog(@"side or bottom tabbar - return NO");
             return NO;
 
         case PSMTab_TopTab:
@@ -6362,6 +6375,7 @@ hidingToolbeltShouldResizeWindow:(BOOL)hidingToolbeltShouldResizeWindow
     }
     switch ((PSMTabPosition)[iTermPreferences intForKey:kPreferenceKeyTabPosition]) {
         case PSMTab_LeftTab:
+        case PSMTab_RightTab:
         case PSMTab_BottomTab:
             DLog(@"NO - tabs not on top");
             return NO;
@@ -7125,6 +7139,7 @@ hidingToolbeltShouldResizeWindow:(BOOL)hidingToolbeltShouldResizeWindow
 
     switch ((PSMTabPosition)[iTermPreferences intForKey:kPreferenceKeyTabPosition]) {
         case PSMTab_LeftTab:
+        case PSMTab_RightTab:
             return NO;
 
         case PSMTab_BottomTab:
@@ -7232,6 +7247,7 @@ hidingToolbeltShouldResizeWindow:(BOOL)hidingToolbeltShouldResizeWindow
     contentFrame = viewRect = [tabRootView frame];
     switch ([iTermPreferences intForKey:kPreferenceKeyTabPosition]) {
         case PSMTab_LeftTab:
+        case PSMTab_RightTab:
             contentFrame.size.width += _contentView.leftTabBarWidth;
             break;
 
@@ -7253,6 +7269,10 @@ hidingToolbeltShouldResizeWindow:(BOOL)hidingToolbeltShouldResizeWindow
     switch ([iTermPreferences intForKey:kPreferenceKeyTabPosition]) {
         case PSMTab_LeftTab:
             viewRect.origin.x += _contentView.leftTabBarWidth;
+            viewRect.size.width -= _contentView.leftTabBarWidth;
+            break;
+
+        case PSMTab_RightTab:
             viewRect.size.width -= _contentView.leftTabBarWidth;
             break;
 
@@ -7356,7 +7376,8 @@ hidingToolbeltShouldResizeWindow:(BOOL)hidingToolbeltShouldResizeWindow
         // In case the tab bar will go away
         [_contentView invalidateAutomaticTabBarBackingHiding];
 
-        if (willShowTabBar && [iTermPreferences intForKey:kPreferenceKeyTabPosition] == PSMTab_LeftTab) {
+        const PSMTabPosition tabPosition = [iTermPreferences intForKey:kPreferenceKeyTabPosition];
+        if (willShowTabBar && (tabPosition == PSMTab_LeftTab || tabPosition == PSMTab_RightTab)) {
             [_contentView willShowTabBar];
         }
         const BOOL generallyPreserveWindowSize = [iTermPreferences boolForKey:kPreferenceKeyPreserveWindowSizeWhenTabBarVisibilityChanges];
@@ -7597,7 +7618,8 @@ hidingToolbeltShouldResizeWindow:(BOOL)hidingToolbeltShouldResizeWindow
 
         if (hasUnpinnedToRight) {
             NSString *title;
-            if ([iTermPreferences intForKey:kPreferenceKeyTabPosition] == PSMTab_LeftTab) {
+            const PSMTabPosition tabPosition = [iTermPreferences intForKey:kPreferenceKeyTabPosition];
+            if (tabPosition == PSMTab_LeftTab || tabPosition == PSMTab_RightTab) {
                 title = @"Close Tabs Below";
             } else {
                 title = @"Close Tabs to the Right";
@@ -7725,6 +7747,7 @@ hidingToolbeltShouldResizeWindow:(BOOL)hidingToolbeltShouldResizeWindow
             break;
 
         case PSMTab_LeftTab:
+        case PSMTab_RightTab:
             switch ([term windowType]) {
                 case WINDOW_TYPE_COMPACT:
                 case WINDOW_TYPE_NO_TITLE_BAR: {
@@ -8158,6 +8181,9 @@ static CGFloat iTermDimmingAmount(PSMTabBarControl *tabView) {
         case PSMTab_LeftTab:
             sessions = self.currentTab.sessionsAtLeft;
             break;
+        case PSMTab_RightTab:
+            sessions = self.currentTab.sessionsAtRight;
+            break;
         case PSMTab_TopTab:
             sessions = self.currentTab.sessionsAtTop;
             break;
@@ -8236,6 +8262,7 @@ static CGFloat iTermDimmingAmount(PSMTabBarControl *tabView) {
                         case PSMTab_TopTab:
                             return @NO;
                         case PSMTab_LeftTab:
+                        case PSMTab_RightTab:
                         case PSMTab_BottomTab:
                             return @YES;
                     }
@@ -8317,6 +8344,7 @@ static CGFloat iTermDimmingAmount(PSMTabBarControl *tabView) {
         }
         switch ([iTermPreferences intForKey:kPreferenceKeyTabPosition]) {
             case PSMTab_LeftTab:
+            case PSMTab_RightTab:
                 return NO;
             case PSMTab_TopTab:
                 return (point.y < height);
@@ -10579,6 +10607,7 @@ static BOOL iTermApproximatelyEqualRects(NSRect lhs, NSRect rhs, double epsilon)
     }
     switch ([iTermPreferences intForKey:kPreferenceKeyTabPosition]) {
         case PSMTab_LeftTab:
+        case PSMTab_RightTab:
         case PSMTab_TopTab:
             break;
         case PSMTab_BottomTab:
@@ -10638,7 +10667,8 @@ static BOOL iTermApproximatelyEqualRects(NSRect lhs, NSRect rhs, double epsilon)
 }
 
 - (BOOL)shouldHaveTallTabBar {
-    if ([iTermPreferences intForKey:kPreferenceKeyTabPosition] == PSMTab_LeftTab) {
+    const PSMTabPosition tabPosition = [iTermPreferences intForKey:kPreferenceKeyTabPosition];
+    if (tabPosition == PSMTab_LeftTab || tabPosition == PSMTab_RightTab) {
         return NO;
     }
     if (!iTermWindowTypeIsCompact(self.windowType) &&
@@ -10778,6 +10808,7 @@ static BOOL iTermApproximatelyEqualRects(NSRect lhs, NSRect rhs, double epsilon)
         switch ([iTermPreferences intForKey:kPreferenceKeyTabPosition]) {
             case PSMTab_TopTab:
             case PSMTab_LeftTab:
+            case PSMTab_RightTab:
                 switch (_savedWindowType) {
                     case WINDOW_TYPE_TOP_PERCENTAGE:
                     case WINDOW_TYPE_LEFT_PERCENTAGE:
@@ -11080,10 +11111,12 @@ static BOOL iTermApproximatelyEqualRects(NSRect lhs, NSRect rhs, double epsilon)
 }
 
 - (BOOL)haveRightBorderRegardlessOfScrollBar {
+    BOOL rightTabBar = ([iTermPreferences intForKey:kPreferenceKeyTabPosition] == PSMTab_RightTab);
     if (!self.shouldShowBorder) {
         return NO;
     } else if ([self anyFullScreen] ||
-               self.windowType == WINDOW_TYPE_RIGHT_PERCENTAGE ) {
+               self.windowType == WINDOW_TYPE_RIGHT_PERCENTAGE ||
+               (rightTabBar && [self tabBarShouldBeVisible])) {
         return NO;
     }
     return YES;
@@ -11147,6 +11180,7 @@ static BOOL iTermApproximatelyEqualRects(NSRect lhs, NSRect rhs, double epsilon)
                 }
                 break;
             case PSMTab_LeftTab:
+            case PSMTab_RightTab:
                 if (self.tabs.count == 1 && self.tabs.firstObject.reportIdeal) {
                     // Initial setup. Do this so we can get the initial session's desired number of columns. Issue 8365.
                     decorationSize.width += _contentView.leftTabBarPreferredWidth;

--- a/sources/TerminalView/iTermLayoutCalculator.h
+++ b/sources/TerminalView/iTermLayoutCalculator.h
@@ -45,7 +45,7 @@ typedef struct {
     BOOL enteringFullscreen;
     BOOL inFullscreen;
 
-    /// Tab position (PSMTab_TopTab, PSMTab_BottomTab, PSMTab_LeftTab)
+    /// Tab position (PSMTab_TopTab, PSMTab_BottomTab, PSMTab_LeftTab, PSMTab_RightTab)
     int tabPosition;
 
     /// Division view
@@ -110,11 +110,15 @@ typedef struct {
 /// Calculate layout for visible left tab bar.
 + (iTermLayoutOutputs)calculateLayoutWithVisibleLeftTabBarInputs:(iTermLayoutInputs)inputs;
 
+/// Calculate layout for visible right tab bar.
++ (iTermLayoutOutputs)calculateLayoutWithVisibleRightTabBarInputs:(iTermLayoutInputs)inputs;
+
 @end
 
 // Tab position constants (matching PSMTabBarControl)
 extern const int kLayoutTabPositionTop;
 extern const int kLayoutTabPositionBottom;
 extern const int kLayoutTabPositionLeft;
+extern const int kLayoutTabPositionRight;
 
 NS_ASSUME_NONNULL_END

--- a/sources/TerminalView/iTermLayoutCalculator.m
+++ b/sources/TerminalView/iTermLayoutCalculator.m
@@ -26,6 +26,7 @@
 const int kLayoutTabPositionTop = 0;
 const int kLayoutTabPositionBottom = 1;
 const int kLayoutTabPositionLeft = 2;
+const int kLayoutTabPositionRight = 3;
 
 @implementation iTermLayoutCalculator
 
@@ -43,6 +44,8 @@ const int kLayoutTabPositionLeft = 2;
             return [self calculateLayoutWithVisibleBottomTabBarInputs:inputs];
         case kLayoutTabPositionLeft:
             return [self calculateLayoutWithVisibleLeftTabBarInputs:inputs];
+        case kLayoutTabPositionRight:
+            return [self calculateLayoutWithVisibleRightTabBarInputs:inputs];
         default:
             return [self calculateLayoutWithVisibleTopTabBarInputs:inputs];
     }
@@ -286,6 +289,65 @@ const int kLayoutTabPositionLeft = 2;
         CGRectGetMaxX(outputs.tabBarFrame) + xOffset,
         outputs.decorationHeightBottom,
         inputs.contentViewWidth - CGRectGetWidth(outputs.tabBarFrame) - widthAdjustment,
+        inputs.contentViewHeight - outputs.decorationHeightBottom - outputs.decorationHeightTop
+    );
+
+    outputs.tabViewFrame = [self tabViewFrameByShrinkingForFullScreenTabBar:outputs.tabViewFrame
+                                                                 withInputs:inputs];
+
+    outputs.toolbeltFrame = [self toolbeltFrameWithInputs:inputs];
+
+    return outputs;
+}
+
+#pragma mark - Visible Right Tab Bar Layout
+
++ (iTermLayoutOutputs)calculateLayoutWithVisibleRightTabBarInputs:(iTermLayoutInputs)inputs {
+    iTermLayoutOutputs outputs = {0};
+
+    outputs.decorationHeightTop = inputs.notchInset;
+    outputs.decorationHeightBottom = 0;
+
+    if (inputs.divisionViewVisible) {
+        outputs.decorationHeightTop += inputs.divisionViewHeight;
+    }
+
+    const CGFloat toolbeltWidth = inputs.shouldShowToolbelt ? inputs.toolbeltWidth : 0;
+    const CGFloat tabBarMaxX = inputs.contentViewWidth - toolbeltWidth;
+
+    outputs.tabBarFrame = CGRectMake(
+        tabBarMaxX - inputs.leftTabBarWidth,
+        outputs.decorationHeightBottom,
+        inputs.leftTabBarWidth,
+        inputs.contentViewHeight - outputs.decorationHeightBottom - outputs.decorationHeightTop
+    );
+
+    CGFloat widthAdjustment = 0;
+    const CGFloat tabViewWidthAdjustment = CGRectGetWidth(outputs.tabBarFrame);
+    if (inputs.tabBarFlashing) {
+        widthAdjustment -= CGRectGetWidth(outputs.tabBarFrame);
+    }
+    if (inputs.shouldShowToolbelt) {
+        widthAdjustment += inputs.toolbeltWidth;
+    }
+
+    CGRect frame = CGRectMake(
+        0,
+        outputs.decorationHeightBottom,
+        inputs.contentViewWidth - tabViewWidthAdjustment - widthAdjustment,
+        inputs.contentViewHeight - outputs.decorationHeightBottom - outputs.decorationHeightTop
+    );
+
+    [self layoutStatusBarWithInputs:inputs
+                   decorationTop:&outputs.decorationHeightTop
+                decorationBottom:&outputs.decorationHeightBottom
+                  statusBarFrame:&outputs.statusBarFrame
+                   tabViewFrame:frame];
+
+    outputs.tabViewFrame = CGRectMake(
+        0,
+        outputs.decorationHeightBottom,
+        inputs.contentViewWidth - tabViewWidthAdjustment - widthAdjustment,
         inputs.contentViewHeight - outputs.decorationHeightBottom - outputs.decorationHeightTop
     );
 

--- a/sources/TerminalView/iTermRootTerminalView.m
+++ b/sources/TerminalView/iTermRootTerminalView.m
@@ -241,6 +241,11 @@ NS_CLASS_AVAILABLE_MAC(10_14)
                 _tabBarControl.orientation = PSMTabBarVerticalOrientation;
                 [self setTabBarControlAutoresizingMask:(NSViewHeightSizable | NSViewMaxXMargin)];
                 break;
+
+            case PSMTab_RightTab:
+                _tabBarControl.orientation = PSMTabBarVerticalOrientation;
+                [self setTabBarControlAutoresizingMask:(NSViewHeightSizable | NSViewMinXMargin)];
+                break;
         }
         [self addSubview:_tabBarBacking];
         [_tabBarBacking addSubview:_tabBarControl];
@@ -597,7 +602,8 @@ NS_CLASS_AVAILABLE_MAC(10_14)
     }
     [_windowNumberLabel sizeToFit];
     const NSRect standardButtonsFrame = [self frameForStandardWindowButtons];
-    const CGFloat tabBarHeight = [iTermPreferences intForKey:kPreferenceKeyTabPosition] == PSMTab_LeftTab ? 26.0 : _tabBarControl.height;
+    const PSMTabPosition tabPosition = [iTermPreferences intForKey:kPreferenceKeyTabPosition];
+    const CGFloat tabBarHeight = (tabPosition == PSMTab_LeftTab || tabPosition == PSMTab_RightTab) ? 26.0 : _tabBarControl.height;
     const CGFloat windowNumberHeight = _windowNumberLabel.frame.size.height;
     const CGFloat baselineOffset = -_windowNumberLabel.font.descender;
     const CGFloat capHeight = _windowNumberLabel.font.capHeight;
@@ -1310,6 +1316,11 @@ NS_CLASS_AVAILABLE_MAC(10_14)
             [self layoutSubviewsWithVisibleLeftTabBarAndInlineToolbelt:showToolbeltInline forWindow:thisWindow];
             break;
         }
+
+        case PSMTab_RightTab: {
+            [self layoutSubviewsWithVisibleRightTabBarAndInlineToolbelt:showToolbeltInline forWindow:thisWindow];
+            break;
+        }
     }
 }
 
@@ -1541,6 +1552,29 @@ NS_CLASS_AVAILABLE_MAC(10_14)
     [self updateLeftTabBarDragHandleForTabBarFrame:outputs.tabBarFrame];
 }
 
+- (void)layoutSubviewsWithVisibleRightTabBarAndInlineToolbelt:(BOOL)showToolbeltInline forWindow:(NSWindow *)thisWindow {
+    assert(!_tabBarControlOnLoan);
+    [self setLeftTabBarWidthFromPreferredWidth];
+
+    iTermLayoutInputs inputs = [self layoutInputsForWindow:thisWindow];
+    inputs.tabBarVisible = YES;
+    inputs.tabPosition = kLayoutTabPositionRight;
+    iTermLayoutOutputs outputs = [iTermLayoutCalculator calculateLayoutWithInputs:inputs];
+
+    self.tabBarControl.insets = [self.delegate tabBarInsets];
+    [self setTabBarFrame:outputs.tabBarFrame];
+    [self setTabBarControlAutoresizingMask:(NSViewHeightSizable | NSViewMinXMargin)];
+
+    DLog(@"repositionWidgets - Set tab view frame to %@", NSStringFromRect(outputs.tabViewFrame));
+    self.tabView.frame = outputs.tabViewFrame;
+
+    [self layoutStatusBarWithOutputs:outputs window:thisWindow];
+
+    [self updateDivisionViewAndWindowNumberLabel];
+
+    [self updateRightTabBarDragHandleForTabBarFrame:outputs.tabBarFrame];
+}
+
 - (void)updateLeftTabBarDragHandleForTabBarFrame:(CGRect)tabBarFrame {
     if (CGRectIsEmpty(tabBarFrame)) {
         [self removeLeftTabBarDragHandle];
@@ -1558,6 +1592,26 @@ NS_CLASS_AVAILABLE_MAC(10_14)
         [self addSubview:self.leftTabBarDragHandle];
     } else {
         self.leftTabBarDragHandle.frame = leftTabBarDragHandleFrame;
+    }
+}
+
+- (void)updateRightTabBarDragHandleForTabBarFrame:(CGRect)tabBarFrame {
+    if (CGRectIsEmpty(tabBarFrame)) {
+        [self removeLeftTabBarDragHandle];
+        return;
+    }
+
+    const CGFloat dragHandleWidth = 3;
+    NSRect rightTabBarDragHandleFrame = NSMakeRect(NSMinX(tabBarFrame),
+                                                   0,
+                                                   dragHandleWidth,
+                                                   NSHeight(tabBarFrame));
+    if (!self.leftTabBarDragHandle) {
+        self.leftTabBarDragHandle = [[iTermDragHandleView alloc] initWithFrame:rightTabBarDragHandleFrame];
+        self.leftTabBarDragHandle.delegate = self;
+        [self addSubview:self.leftTabBarDragHandle];
+    } else {
+        self.leftTabBarDragHandle.frame = rightTabBarDragHandleFrame;
     }
 }
 
@@ -1867,6 +1921,7 @@ NS_CLASS_AVAILABLE_MAC(10_14)
     switch ([iTermPreferences intForKey:kPreferenceKeyTabPosition]) {
         case PSMTab_BottomTab:
         case PSMTab_LeftTab:
+        case PSMTab_RightTab:
             return YES;
 
         case PSMTab_TopTab:
@@ -1895,7 +1950,8 @@ NS_CLASS_AVAILABLE_MAC(10_14)
 // For the left-side tab bar.
 - (CGFloat)dragHandleView:(iTermDragHandleView *)dragHandle didMoveBy:(CGFloat)delta {
     CGFloat originalValue = _leftTabBarPreferredWidth;
-    _leftTabBarPreferredWidth = round([self leftTabBarWidthForPreferredWidth:_leftTabBarPreferredWidth + delta]);
+    const CGFloat signedDelta = [iTermPreferences intForKey:kPreferenceKeyTabPosition] == PSMTab_RightTab ? -delta : delta;
+    _leftTabBarPreferredWidth = round([self leftTabBarWidthForPreferredWidth:_leftTabBarPreferredWidth + signedDelta]);
     [self layoutSubviews];  // This may modify _leftTabBarWidth if it's too big or too small.
     [[iTermUserDefaults userDefaults] setDouble:_leftTabBarPreferredWidth
                                               forKey:kPreferenceKeyLeftTabBarWidth];


### PR DESCRIPTION
## Summary
- Add a right-side option to the tab position preference.
- Mirror left-side tab bar layout, rendering, drag, and window sizing behavior for right-side tabs.
- Cover right-side tab geometry in layout calculator tests and document the feature in 3.7 notes.