### PR TITLE
fix: VT100ScreenMark dealloc crash with unresolved return-code

### DIFF
--- a/ModernTests/VT100ScreenTests.swift
+++ b/ModernTests/VT100ScreenTests.swift
@@ -414,6 +414,21 @@ class VT100ScreenTests: XCTestCase {
         XCTAssertTrue(VT100GridCoordRangeEqualsCoordRange(rangeAfterResize, expected))
     }
 
+    // MARK: - VT100ScreenMark dealloc tests
+
+    // Regression test: a mark with an unfulfilled return-code promise (i.e. returnCodePromise
+    // was called but setCode: was never called) must not crash on dealloc.
+    // This reproduces the crash seen when marks are freed during copySlowStuffFrom: while a
+    // command is still running (session closed before the command finished).
+    func testMarkDeallocWithUnfulfilledReturnCodePromise() {
+        autoreleasepool {
+            let mark = VT100ScreenMark()
+            _ = mark.returnCodePromise
+            // mark deallocates here without setCode: ever being called
+        }
+        // reaching this line without a crash is the pass condition
+    }
+
     // MARK: - VT100ScreenMark property resize tests
 
     // Test that VT100ScreenMark's commandRange, promptRange, and outputStart are updated

--- a/sources/Marks/VT100ScreenMark.m
+++ b/sources/Marks/VT100ScreenMark.m
@@ -192,6 +192,10 @@ static NSString *const kMarkOutputStart = @"Output Start";
 }
 
 - (void)dealloc {
+    // If the promise was created but setCode: was never called (e.g., session terminated while a
+    // command was running), reject it now so iTermPromiseSeal's dealloc assertion doesn't fire.
+    [_codeSeal rejectWithDefaultError];
+    _codeSeal = nil;
     @synchronized([VT100ScreenMark class]) {
         // I think this is not needed because we use weak pointers but I also don't trust
         // NSMapTable to ever remove dead objects. Do this to avoid a possible waste of memory.


### PR DESCRIPTION
This change fixes a crash caused by `VT100ScreenMark` deallocation when `returnCodePromise` was requested but `setCode:` was never called. In that state, `_codeSeal` was left unresolved and iTermPromiseSeal asserted in dealloc with `_promise` still set, terminating the app.

The fix resolves the promise lifecycle in `VT100ScreenMark` dealloc. If `_codeSeal` still exists at teardown time, it is rejected with the default error and cleared before normal cleanup. This preserves the existing semantics for successful command completion while safely handling session teardown or similar early-exit paths where a running command never reports a final code.

A regression test was added in `VT100ScreenTests`. The test creates a mark, accesses returnCodePromise, intentionally does not call `setCode:`, and verifies deallocation does not crash. This reproduces the previously failing lifecycle pattern and locks in the behavior.