### PR TITLE
Add a preference to hide session status text from tab subtitles

### DIFF
--- a/docs/notes-3.7.txt
+++ b/docs/notes-3.7.txt
@@ -282,6 +282,11 @@ Expressions and Variables:
   interpolated strings.
 
 UI Improvements:
+- A new preference hides the session status
+  text from tab subtitles while keeping the
+  colored dot. Toggle it from the Session
+  Status toolbelt tool or during Claude Code
+  integration setup.
 - Contextual alternates (calt) are enabled by
   default for ligature-capable fonts.
 - Prettier, animated toasts.

--- a/sources/ClaudeCode/ClaudeCodeOnboarding.swift
+++ b/sources/ClaudeCode/ClaudeCodeOnboarding.swift
@@ -93,6 +93,7 @@ class ClaudeCodeOnboarding: NSObject {
     // UI elements
     private var stepLabels = [NSTextField]()
     private var contentLabel: NSTextField!
+    private var subtitleToggleCheckbox: NSButton!
     private var backButton: NSButton!
     private var doItButton: NSButton!
     private var nextButton: NSButton!
@@ -682,6 +683,20 @@ class ClaudeCodeOnboarding: NSObject {
         contentLabel.isSelectable = false
         contentView.addSubview(contentLabel)
 
+        // Optional toggle shown only on the explainStatus step. The dot
+        // on the tab already conveys session state; the text under the
+        // title is redundant for users who recognize the dot color, and
+        // can clash with custom tab colors. Default on.
+        subtitleToggleCheckbox = NSButton(checkboxWithTitle: "Show status as subtitle on the tab",
+                                          target: self,
+                                          action: #selector(toggleSubtitlePref(_:)))
+        subtitleToggleCheckbox.state = iTermUserDefaults.showSessionStatusInTabSubtitle ? .on : .off
+        subtitleToggleCheckbox.sizeToFit()
+        subtitleToggleCheckbox.frame.origin = NSPoint(x: margin, y: 55)
+        subtitleToggleCheckbox.autoresizingMask = [.maxXMargin, .maxYMargin]
+        subtitleToggleCheckbox.isHidden = true
+        contentView.addSubview(subtitleToggleCheckbox)
+
         // Button bar at the bottom
         let buttonY: CGFloat = 15
 
@@ -963,6 +978,11 @@ class ClaudeCodeOnboarding: NSObject {
 
         // Update content
         contentLabel.stringValue = currentStep.description
+        // Reflect the live pref each time we land on the step in case
+        // it was flipped from the Session Status settings popover
+        // since the wizard opened.
+        subtitleToggleCheckbox.isHidden = (currentStep != .explainStatus)
+        subtitleToggleCheckbox.state = iTermUserDefaults.showSessionStatusInTabSubtitle ? .on : .off
 
         // Update buttons
         backButton.isEnabled = !isFirstStep
@@ -1015,6 +1035,10 @@ class ClaudeCodeOnboarding: NSObject {
         }
         currentStep = activeSteps[i + 1]
         updateUI()
+    }
+
+    @objc private func toggleSubtitlePref(_ sender: NSButton) {
+        iTermUserDefaults.showSessionStatusInTabSubtitle = (sender.state == .on)
     }
 
     @objc private func doItPressed(_ sender: Any?) {

--- a/sources/Settings/iTermUserDefaults.h
+++ b/sources/Settings/iTermUserDefaults.h
@@ -10,6 +10,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 extern NSString *const kSelectionRespectsSoftBoundariesKey;
+extern NSString *const iTermShowSessionStatusInTabSubtitleDidChange;
 
 @interface iTermUserDefaults : NSObject
 
@@ -48,6 +49,15 @@ typedef NS_ENUM(NSUInteger, iTermAppleWindowTabbingMode) {
 // signal so we can detect when something else (e.g. Claude Code
 // rewriting ~/.claude/settings.json) silently strips our hook.
 @property (class, nonatomic) BOOL claudeCodeIntegrationCompleted;
+
+// Whether session-status text (from cc-status, OSC 21337, the SetTabStatus
+// trigger, or iterm2.set_status) is woven into the tab’s subtitle and
+// allowed to tint that subtitle text. The colored dot on the tab is
+// independent and always visible regardless of this setting. Default YES
+// preserves the existing behavior. Posted as
+// iTermShowSessionStatusInTabSubtitleDidChange when toggled so tabs can
+// refresh their labels live.
+@property (class, nonatomic) BOOL showSessionStatusInTabSubtitle;
 @property (class, nonatomic) BOOL haveExplainedHowToAddTouchbarControls;
 @property (class, nonatomic) BOOL ignoreSystemWindowRestoration;
 @property (class, nonatomic) NSUInteger globalSearchMode;

--- a/sources/Settings/iTermUserDefaults.m
+++ b/sources/Settings/iTermUserDefaults.m
@@ -30,6 +30,8 @@ static NSString *const iTermUserDefaultsKeyClaudeCodeWorkgroupUpsellSuppressed =
 static NSString *const iTermUserDefaultsKeyClaudeCodeHooksInstalled = @"NoSyncClaudeCodeHooksInstalled";
 static NSString *const iTermUserDefaultsKeyClaudeCodeTriggersInstalled = @"ClaudeCodeTriggersInstalled";
 static NSString *const iTermUserDefaultsKeyClaudeCodeIntegrationCompleted = @"NoSyncClaudeCodeIntegrationCompleted";
+static NSString *const iTermUserDefaultsKeyShowSessionStatusInTabSubtitle = @"ShowSessionStatusInTabSubtitle";
+NSString *const iTermShowSessionStatusInTabSubtitleDidChange = @"iTermShowSessionStatusInTabSubtitleDidChange";
 static NSString *const iTermUserDefaultsKeyHaveExplainedHowToAddTouchbarControls = @"NoSyncHaveExplainedHowToAddTouchbarControls";
 static NSString *const iTermUserDefaultsKeyIgnoreSystemWindowRestoration = @"NoSyncIgnoreSystemWindowRestoration";
 static NSString *const iTermUserDefaultsKeyGlobalSearchMode = @"NoSyncGlobalSearchMode";
@@ -94,7 +96,8 @@ static NSUserDefaults *iTermPrivateUserDefaults(void) {
             userDefaults = [NSUserDefaults standardUserDefaults];
         }
         [userDefaults registerDefaults:@{ iTermUserDefaultsKeyOpenTmuxDashboardIfHiddenWindows: @YES,
-                                          iTermUserDefaultsKeyShouldSendReturnAfterPassword: @YES }];
+                                          iTermUserDefaultsKeyShouldSendReturnAfterPassword: @YES,
+                                          iTermUserDefaultsKeyShowSessionStatusInTabSubtitle: @YES }];
     });
     return userDefaults;
 }
@@ -229,6 +232,20 @@ static NSUserDefaults *iTermPrivateUserDefaults(void) {
 + (void)setClaudeCodeIntegrationCompleted:(BOOL)completed {
     [self.userDefaults setBool:completed
                         forKey:iTermUserDefaultsKeyClaudeCodeIntegrationCompleted];
+}
+
++ (BOOL)showSessionStatusInTabSubtitle {
+    return [self.userDefaults boolForKey:iTermUserDefaultsKeyShowSessionStatusInTabSubtitle];
+}
+
++ (void)setShowSessionStatusInTabSubtitle:(BOOL)show {
+    if (show == [self showSessionStatusInTabSubtitle]) {
+        return;
+    }
+    [self.userDefaults setBool:show
+                        forKey:iTermUserDefaultsKeyShowSessionStatusInTabSubtitle];
+    [[NSNotificationCenter defaultCenter] postNotificationName:iTermShowSessionStatusInTabSubtitleDidChange
+                                                        object:nil];
 }
 
 + (BOOL)haveExplainedHowToAddTouchbarControls {

--- a/sources/TerminalView/PTYTab.m
+++ b/sources/TerminalView/PTYTab.m
@@ -22,6 +22,7 @@
 #import "iTermSwiftyString.h"
 #import "iTermSwiftyStringGraph.h"
 #import "iTermTmuxLayoutBuilder.h"
+#import "iTermUserDefaults.h"
 #import "iTermVariableReference.h"
 #import "iTermVariableScope.h"
 #import "iTermVariableScope+Session.h"
@@ -484,6 +485,10 @@ static void SetAgainstGrainDim(BOOL isVertical, NSSize *dest, CGFloat value) {
                                              selector:@selector(annotationVisibilityDidChange:)
                                                  name:iTermAnnotationVisibilityDidChange
                                                object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(_refreshLabels:)
+                                                 name:iTermShowSessionStatusInTabSubtitleDidChange
+                                               object:nil];
     [iTermPreferenceDidChangeNotification subscribe:self selector:@selector(preferenceDidChange:)];
     _tabTitleOverrideSwiftyString = [[iTermSwiftyString alloc] initWithScope:self.variablesScope
                                                                   sourcePath:iTermVariableKeyTabTitleOverrideFormat
@@ -692,7 +697,7 @@ static void SetAgainstGrainDim(BOOL isVertical, NSSize *dest, CGFloat value) {
 - (NSString *)stringByAppendingSubtitleForActiveSession:(NSString *)title {
     NSString *subtitle = self.activeSession.subtitle;
     NSString *statusText = _aggregatedTabStatus.statusText;
-    if (statusText.length > 0) {
+    if (statusText.length > 0 && iTermUserDefaults.showSessionStatusInTabSubtitle) {
         if (subtitle.length > 0) {
             subtitle = [NSString stringWithFormat:@"%@ \u2013 %@", statusText, subtitle];
         } else {
@@ -1213,7 +1218,8 @@ static void SetAgainstGrainDim(BOOL isVertical, NSSize *dest, CGFloat value) {
 - (NSColor *)psmTabStatusSubtitleColor {
     if (!_aggregatedTabStatus.hasActiveStatus ||
         !_aggregatedTabStatus.hasStatusTextColor ||
-        _aggregatedTabStatus.statusText.length == 0) {
+        _aggregatedTabStatus.statusText.length == 0 ||
+        !iTermUserDefaults.showSessionStatusInTabSubtitle) {
         return nil;
     }
     iTermSRGBColor c = _aggregatedTabStatus.statusTextColor;

--- a/sources/Toolbelt/StatusPrioritySettings.swift
+++ b/sources/Toolbelt/StatusPrioritySettings.swift
@@ -218,7 +218,7 @@ private final class StatusPriorityPopover: NSObject {
         let popover = NSPopover()
         popover.contentViewController = vc
         popover.behavior = .semitransient
-        popover.contentSize = NSSize(width: 280, height: 260)
+        popover.contentSize = NSSize(width: 280, height: 296)
         popover.show(relativeTo: positioningRect, of: positioningView, preferredEdge: edge)
         self.popover = popover
     }
@@ -241,10 +241,12 @@ private final class StatusPriorityViewController: NSViewController, CRUDTableVie
 
     override func loadView() {
         let width: CGFloat = 280
-        let height: CGFloat = 260
+        let height: CGFloat = 296
         let margin: CGFloat = 10
         let segmentHeight: CGFloat = 24
         let labelHeight: CGFloat = 48
+        let toggleHeight: CGFloat = 18
+        let toggleGap: CGFloat = 8
 
         let container = NSView(frame: NSRect(x: 0, y: 0, width: width, height: height))
 
@@ -268,8 +270,24 @@ private final class StatusPriorityViewController: NSViewController, CRUDTableVie
         addRemove.autoresizingMask = [.maxXMargin, .maxYMargin]
         container.addSubview(addRemove)
 
-        // Table view between label and segmented control
-        let scrollY = margin + segmentHeight + 4
+        // Global toggle: gate the status-text subtitle on tabs without
+        // affecting the colored dot or this priority list’s meaning.
+        // Sits between the +/- and the table so it’s visually grouped
+        // with the per-popover controls.
+        let toggleY = margin + segmentHeight + toggleGap
+        let toggle = NSButton(checkboxWithTitle: "Show status in tab subtitle",
+                              target: self,
+                              action: #selector(showSubtitleToggleChanged(_:)))
+        toggle.state = iTermUserDefaults.showSessionStatusInTabSubtitle ? .on : .off
+        toggle.frame = NSRect(x: margin,
+                              y: toggleY,
+                              width: width - 2 * margin,
+                              height: toggleHeight)
+        toggle.autoresizingMask = [.width, .maxYMargin]
+        container.addSubview(toggle)
+
+        // Table view between label and the toggle row
+        let scrollY = toggleY + toggleHeight + toggleGap
         let scrollHeight = height - margin - labelHeight - 4 - scrollY
         let scrollView = NSScrollView(frame: NSRect(x: margin, y: scrollY,
                                                      width: width - 2 * margin,
@@ -322,6 +340,10 @@ private final class StatusPriorityViewController: NSViewController, CRUDTableVie
         let spacing = tv.intercellSpacing.width * CGFloat(tv.numberOfColumns)
         let newWidth = scrollView.contentSize.width - Self.notifyColumnWidth - spacing
         patternColumn.width = newWidth
+    }
+
+    @objc private func showSubtitleToggleChanged(_ sender: NSButton) {
+        iTermUserDefaults.showSessionStatusInTabSubtitle = (sender.state == .on)
     }
 
     func undoableAdd(_ value: String, completion: @escaping (Int) -> ()) {


### PR DESCRIPTION
The colored dot on a tab already shows whether Claude (or anything writing tab status) is working, waiting, or idle. The text subtitle duplicates that signal and clashes with user-set tab colors. This adds an opt-out for the subtitle text without touching the dot, the toolbelt entry, or anything that writes status.

The preference defaults to ON, so existing installs see no change. It gates both `PTYTab`'s subtitle weaving and `psmTabStatusSubtitleColor`. Triggers, `cc-status`, OSC 21337, and `iterm2.set_status` keep writing the same payload, the gate is at the render layer only.

Two surfaces flip it: a checkbox on the "Using Session Status" installer step, and one in the Session Status toolbelt tool's gear popover. Both bind to the same key and post a change notification, so open tabs refresh immediately from either.
<img width="289" height="339" alt="Screenshot 2026-05-12 at 19 26 06" src="https://github.com/user-attachments/assets/ecfd8377-f386-4edf-9454-2bbb3f301e70" />

Tested by deploying locally and toggling from both surfaces. Subtitle text and its color tint disappear and reappear without restart, dot stays, custom tab colors unaffected.
<img width="476" height="79" alt="Screenshot 2026-05-12 at 19 37 05" src="https://github.com/user-attachments/assets/4814074e-6464-465a-9b0a-cb81d4866462" />

