### PR TITLE
Add user-configurable custom HTTP headers for AI backend requests

### DIFF
--- a/iTerm2.xcodeproj/project.pbxproj
+++ b/iTerm2.xcodeproj/project.pbxproj
@@ -5304,6 +5304,7 @@
 		ADC7FB502202FA2C5A67E470 /* iTermWorkgroupPeerPort.swift in Sources */ = {isa = PBXBuildFile; fileRef = B048AAFA78F22F2C8CB157F3 /* iTermWorkgroupPeerPort.swift */; };
 		B2CA85E23B4CCCC3391BA025 /* NotifyingDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877B9444B69DE32D9CF87354 /* NotifyingDictionary.swift */; };
 		B3E079E1F626A259EDC76153 /* PeerSessionSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3298E60BA3D410B4C3FC1A98 /* PeerSessionSettingsViewController.swift */; };
+		B3F134FF5266734ED326399E /* AICustomHeaders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E6892F33EA732E982A1991D /* AICustomHeaders.swift */; };
 		B89533C4F0E3E8C415065AAC /* iTermLayoutResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D079EA4C9132883E833B9974 /* iTermLayoutResolver.swift */; };
 		B947C485FA069D07B72E94CC /* iTermWorkgroupToolbarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = A07263500827075018158DEC /* iTermWorkgroupToolbarItem.swift */; };
 		B9B050C66BE98825D6AFEE47 /* cloak-page-world.js in Resources */ = {isa = PBXBuildFile; fileRef = ED1DEABF73F84ABCF9B2FDC8 /* cloak-page-world.js */; };
@@ -6165,6 +6166,7 @@
 		3335AD96138BA74CC79D25A8 /* iTermUnicodeNormalization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = iTermUnicodeNormalization.h; sourceTree = "<group>"; };
 		39A91EF453B797BB100AD508 /* SessionNoteModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SessionNoteModel.swift; sourceTree = "<group>"; };
 		3C05599DA2E4F97B75124672 /* iTermOpenDirectory+MainApp.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "iTermOpenDirectory+MainApp.m"; sourceTree = "<group>"; };
+		3E6892F33EA732E982A1991D /* AICustomHeaders.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AICustomHeaders.swift; sourceTree = "<group>"; };
 		3F20922E7C56B246576E589A /* iTermPasswordInputDebouncer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = iTermPasswordInputDebouncer.swift; sourceTree = "<group>"; };
 		40D246CFCEDD7927D320BF51 /* MovePaneController+API.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "MovePaneController+API.swift"; sourceTree = "<group>"; };
 		46019892B59C674931043643 /* iTermCharacterSets.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = iTermCharacterSets.h; sourceTree = "<group>"; };
@@ -10987,6 +10989,7 @@
 				A65618712D6BDFEF0059CD35 /* TerminalCommandMessageCellView.swift */,
 				A6631A182D6E4C7A006C603B /* TypingIndicatorCellView.swift */,
 				099C8A86522346410F6224B1 /* ChatManualStackView.swift */,
+				3E6892F33EA732E982A1991D /* AICustomHeaders.swift */,
 			);
 			path = AITerm;
 			sourceTree = "<group>";
@@ -21283,6 +21286,7 @@
 				79F784C0D62EE69089FB4CD2 /* WorkgroupToolbarShortcut.swift in Sources */,
 				A1F1A091602C6C5597DFE2B6 /* iTermOpenQuicklyHotKeyProvider.swift in Sources */,
 				355C6FC60EEF61A2C69E8D0E /* ArchiveClippingsBuiltInFunction.swift in Sources */,
+				B3F134FF5266734ED326399E /* AICustomHeaders.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/last-xcode-version
+++ b/last-xcode-version
@@ -1,2 +1,2 @@
-Xcode 26.4
-Build version 17E192
+Xcode 26.5
+Build version 17F42

--- a/sources/AITerm/AICustomHeaders.swift
+++ b/sources/AITerm/AICustomHeaders.swift
@@ -1,0 +1,23 @@
+//
+//  AICustomHeaders.swift
+//  iTerm2
+//
+
+struct AICustomHeaders {
+    static func merged(into base: [String: String]) -> [String: String] {
+        guard iTermPreferences.bool(forKey: kPreferenceKeyAICustomHeadersEnabled),
+              let raw = iTermPreferences.object(forKey: kPreferenceKeyAICustomHeaders) as? [[String: String]] else {
+            return base
+        }
+        var result = base
+        for entry in raw {
+            guard let name = entry["name"], !name.isEmpty else { continue }
+            let value = entry["value"] ?? ""
+            if result[name] != nil {
+                DLog("AI custom header overrides built-in header field \"\(name)\"")
+            }
+            result[name] = value
+        }
+        return result
+    }
+}

--- a/sources/AITerm/LLMFiles.swift
+++ b/sources/AITerm/LLMFiles.swift
@@ -75,6 +75,7 @@ struct ResponsesFileUploadBuilder {
         var result = LLMAuthorizationProvider(provider: provider,
                                               apiKey: apiKey).headers
         result["Content-Type"] = "multipart/form-data; boundary=\(boundary)"
+        result = AICustomHeaders.merged(into: result)
         return result
     }
 

--- a/sources/AITerm/LLMRequestBuilder.swift
+++ b/sources/AITerm/LLMRequestBuilder.swift
@@ -18,6 +18,7 @@ struct LLMRequestBuilder {
     var headers: [String: String] {
         var result = LLMAuthorizationProvider(provider: provider, apiKey: apiKey).headers
         result["Content-Type"] = "application/json"
+        result = AICustomHeaders.merged(into: result)
         return result
     }
 

--- a/sources/AITerm/LLMVectorStore.swift
+++ b/sources/AITerm/LLMVectorStore.swift
@@ -26,8 +26,9 @@ struct LLMVectorStoreBatchStatusChecker {
     }
 
     var headers: [String: String] {
-        return LLMAuthorizationProvider(provider: provider,
-                                        apiKey: apiKey).headers
+        var result = LLMAuthorizationProvider(provider: provider, apiKey: apiKey).headers
+        result = AICustomHeaders.merged(into: result)
+        return result
     }
 
     var method: String { "GET" }
@@ -86,6 +87,7 @@ struct LLMVectorStoreAdder {
         var result = LLMAuthorizationProvider(provider: provider,
                                               apiKey: apiKey).headers
         result["Content-Type"] = "application/json"
+        result = AICustomHeaders.merged(into: result)
         return result
     }
 
@@ -155,6 +157,7 @@ struct LLMVectorStoreCreator {
     var headers: [String: String] {
         var result = LLMAuthorizationProvider(provider: provider, apiKey: apiKey).headers
         result["Content-Type"] = "application/json"
+        result = AICustomHeaders.merged(into: result)
         return result
     }
     var method: String { "POST" }

--- a/sources/Settings/GeneralPreferencesViewController.m
+++ b/sources/Settings/GeneralPreferencesViewController.m
@@ -30,6 +30,9 @@
 #import "iTermWarning.h"
 #import <SSKeychain/SSKeychain.h>
 
+@interface GeneralPreferencesViewController () <NSTableViewDataSource, NSTableViewDelegate>
+@end
+
 enum {
     kUseSystemWindowRestorationSettingTag = 0,
     kOpenDefaultWindowArrangementTag = 1,
@@ -236,6 +239,13 @@ enum {
     IBOutlet NSButton *_sshIntegrationForURLs;
 
     NSString *_lastModel;
+
+    // Custom headers section (created programmatically)
+    NSButton *_aiCustomHeadersEnabled;
+    NSTableView *_aiCustomHeadersTableView;
+    NSButton *_aiAddCustomHeader;
+    NSButton *_aiRemoveCustomHeader;
+    NSMutableArray<NSMutableDictionary *> *_customHeaders;
 }
 
 - (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
@@ -272,6 +282,7 @@ enum {
 }
 
 - (void)awakeFromNib {
+    [self setupCustomHeadersSection];
     PreferenceInfo *info;
 
     __weak __typeof(self) weakSelf = self;
@@ -991,6 +1002,11 @@ enum {
                    type:kPreferenceInfoTypeCheckbox];
     _aiSafetyCheck.enabled = [iTermAIAvailabilityProbe check];
 
+    [self defineControl:_aiCustomHeadersEnabled
+                    key:kPreferenceKeyAICustomHeadersEnabled
+            relatedView:nil
+                   type:kPreferenceInfoTypeCheckbox];
+
     // ---------------------------------------------------------------------------------------------
     [self defineControl:_enableRTL
                     key:kPreferenceKeyBidi
@@ -1318,6 +1334,167 @@ enum {
             }
         }
     }];
+}
+
+#pragma mark - Custom Headers
+
+- (void)setupCustomHeadersSection {
+    if (_aiCustomHeadersEnabled != nil) {
+        return;
+    }
+    if (!_manualAISettings) {
+        return;
+    }
+
+    NSView *effectView = _manualAISettings.subviews.firstObject;
+    if (!effectView) {
+        return;
+    }
+
+    const CGFloat kNewSectionHeight = 200.0;
+    const CGFloat kLeft = 18.0;
+    const CGFloat kViewWidth = _manualAISettings.frame.size.width;
+    const CGFloat kContentWidth = kViewWidth - kLeft * 2;
+
+    // Extend _manualAISettings. The NSVisualEffectView (effectView) carries
+    // heightSizable+widthSizable so it fills the parent automatically.
+    // Its subviews carry flexibleMinY so they stay anchored to the top,
+    // freeing the bottom kNewSectionHeight pt for the new controls.
+    NSRect manualFrame = _manualAISettings.frame;
+    manualFrame.size.height += kNewSectionHeight;
+    _manualAISettings.frame = manualFrame;
+
+    CGFloat y = 8.0;
+
+    // Disclaimer label
+    NSTextField *disclaimerLabel = [NSTextField labelWithString:@"Custom headers replace built-in headers with the same name."];
+    disclaimerLabel.font = [NSFont systemFontOfSize:[NSFont smallSystemFontSize]];
+    disclaimerLabel.textColor = [NSColor secondaryLabelColor];
+    disclaimerLabel.frame = NSMakeRect(kLeft, y, kContentWidth, 14.0);
+    [effectView addSubview:disclaimerLabel];
+    y += 18.0;
+
+    // + / − buttons
+    NSButton *addButton = [NSButton buttonWithTitle:@"" target:self action:@selector(addCustomHeader:)];
+    addButton.image = [NSImage imageNamed:NSImageNameAddTemplate];
+    addButton.bezelStyle = NSBezelStyleSmallSquare;
+    addButton.frame = NSMakeRect(kLeft, y, 21.0, 21.0);
+    [effectView addSubview:addButton];
+    _aiAddCustomHeader = addButton;
+
+    NSButton *removeButton = [NSButton buttonWithTitle:@"" target:self action:@selector(removeCustomHeader:)];
+    removeButton.image = [NSImage imageNamed:NSImageNameRemoveTemplate];
+    removeButton.bezelStyle = NSBezelStyleSmallSquare;
+    removeButton.frame = NSMakeRect(kLeft + 22.0, y, 21.0, 21.0);
+    [effectView addSubview:removeButton];
+    _aiRemoveCustomHeader = removeButton;
+    y += 25.0;
+
+    // Scroll view + table view
+    NSScrollView *scrollView = [[NSScrollView alloc] initWithFrame:NSMakeRect(kLeft, y, kContentWidth, 100.0)];
+    scrollView.hasVerticalScroller = YES;
+    scrollView.autohidesScrollers = YES;
+    scrollView.borderType = NSLineBorder;
+
+    NSTableView *tableView = [[NSTableView alloc] initWithFrame:NSMakeRect(0, 0, kContentWidth, 100.0)];
+    tableView.style = NSTableViewStyleInset;
+    tableView.allowsColumnReordering = NO;
+    tableView.allowsColumnSelection = NO;
+    tableView.allowsMultipleSelection = NO;
+    tableView.usesAlternatingRowBackgroundColors = YES;
+    tableView.gridStyleMask = NSTableViewSolidVerticalGridLineMask;
+
+    NSTableColumn *nameColumn = [[NSTableColumn alloc] initWithIdentifier:@"name"];
+    nameColumn.title = @"Name";
+    nameColumn.width = kContentWidth / 2.0 - 2.0;
+    nameColumn.editable = YES;
+    nameColumn.resizingMask = NSTableColumnUserResizingMask | NSTableColumnAutoresizingMask;
+    [tableView addTableColumn:nameColumn];
+
+    NSTableColumn *valueColumn = [[NSTableColumn alloc] initWithIdentifier:@"value"];
+    valueColumn.title = @"Value";
+    valueColumn.width = kContentWidth / 2.0 - 2.0;
+    valueColumn.editable = YES;
+    valueColumn.resizingMask = NSTableColumnUserResizingMask | NSTableColumnAutoresizingMask;
+    [tableView addTableColumn:valueColumn];
+
+    tableView.dataSource = self;
+    tableView.delegate = self;
+
+    scrollView.documentView = tableView;
+    [effectView addSubview:scrollView];
+    _aiCustomHeadersTableView = tableView;
+    y += 104.0;
+
+    // Checkbox
+    NSButton *enableCheckbox = [NSButton checkboxWithTitle:@"Append custom headers to AI requests"
+                                                    target:self
+                                                    action:@selector(settingChanged:)];
+    enableCheckbox.frame = NSMakeRect(kLeft, y, kContentWidth, 18.0);
+    [effectView addSubview:enableCheckbox];
+    _aiCustomHeadersEnabled = enableCheckbox;
+
+    // Load saved headers
+    id saved = [iTermPreferences objectForKey:kPreferenceKeyAICustomHeaders];
+    if ([saved isKindOfClass:[NSArray class]]) {
+        _customHeaders = [NSMutableArray array];
+        for (id entry in (NSArray *)saved) {
+            if ([entry isKindOfClass:[NSDictionary class]]) {
+                [_customHeaders addObject:[entry mutableCopy]];
+            }
+        }
+    } else {
+        _customHeaders = [NSMutableArray array];
+    }
+}
+
+- (void)saveCustomHeaders {
+    [iTermPreferences setObject:[_customHeaders copy] forKey:kPreferenceKeyAICustomHeaders];
+}
+
+- (IBAction)addCustomHeader:(id)sender {
+    [_customHeaders addObject:[@{@"name": @"", @"value": @""} mutableCopy]];
+    [self saveCustomHeaders];
+    [_aiCustomHeadersTableView reloadData];
+    NSInteger newRow = (NSInteger)_customHeaders.count - 1;
+    [_aiCustomHeadersTableView selectRowIndexes:[NSIndexSet indexSetWithIndex:(NSUInteger)newRow]
+                           byExtendingSelection:NO];
+    [_aiCustomHeadersTableView editColumn:0 row:newRow withEvent:nil select:YES];
+}
+
+- (IBAction)removeCustomHeader:(id)sender {
+    NSInteger row = _aiCustomHeadersTableView.selectedRow;
+    if (row < 0 || row >= (NSInteger)_customHeaders.count) {
+        return;
+    }
+    [_customHeaders removeObjectAtIndex:(NSUInteger)row];
+    [self saveCustomHeaders];
+    [_aiCustomHeadersTableView reloadData];
+}
+
+#pragma mark - NSTableViewDataSource
+
+- (NSInteger)numberOfRowsInTableView:(NSTableView *)tableView {
+    return (NSInteger)_customHeaders.count;
+}
+
+- (id)tableView:(NSTableView *)tableView objectValueForTableColumn:(NSTableColumn *)tableColumn row:(NSInteger)row {
+    NSMutableDictionary *entry = _customHeaders[(NSUInteger)row];
+    return entry[tableColumn.identifier];
+}
+
+- (void)tableView:(NSTableView *)tableView setObjectValue:(id)object forTableColumn:(NSTableColumn *)tableColumn row:(NSInteger)row {
+    NSMutableDictionary *entry = _customHeaders[(NSUInteger)row];
+    entry[tableColumn.identifier] = object ?: @"";
+    [self saveCustomHeaders];
+}
+
+#pragma mark - NSTableViewDelegate
+
+- (void)tableViewSelectionDidChange:(NSNotification *)notification {
+    if (notification.object == _aiCustomHeadersTableView) {
+        _aiRemoveCustomHeader.enabled = (_aiCustomHeadersTableView.selectedRow >= 0);
+    }
 }
 
 - (IBAction)showManualAIConfigurationPanel:(NSButton *)button {

--- a/sources/Settings/iTermPreferences.h
+++ b/sources/Settings/iTermPreferences.h
@@ -207,6 +207,8 @@ extern NSString *const kPreferenceKeyAIVectorStore;
 extern NSString *const kPreferenceKeyUseRecommendedAIModel;
 extern NSString *const kPreferenceKeyAIVendor;  // iTermAIVendor
 extern NSString *const kPreferenceKeyAISafetyCheck;  // boolean
+extern NSString *const kPreferenceKeyAICustomHeadersEnabled;  // boolean
+extern NSString *const kPreferenceKeyAICustomHeaders;  // NSArray of NSDictionary with "name"/"value" NSString entries
 extern NSString *const kPreferenceKeyOpenTmuxWindowsAsTabsInAttachingWindow;  // PHONY
 extern NSString *const kPreferenceKeyOpenUnrecognizedTmuxWindowsIn;  // PHONY
 

--- a/sources/Settings/iTermPreferences.m
+++ b/sources/Settings/iTermPreferences.m
@@ -253,6 +253,8 @@ NSString *const kPreferenceKeyAIVectorStore = @"AIVectorStore";
 NSString *const kPreferenceKeyUseRecommendedAIModel = @"UseRecommendedAIModel";
 NSString *const kPreferenceKeyAIVendor = @"AIVendor";
 NSString *const kPreferenceKeyAISafetyCheck = @"AI Safety Check";
+NSString *const kPreferenceKeyAICustomHeadersEnabled = @"AICustomHeadersEnabled";
+NSString *const kPreferenceKeyAICustomHeaders = @"AICustomHeaders";
 
 NSString *const kPreferenceKeyAIPermissionCheckTerminalState = @"AIPermissionCheckTerminalState";
 NSString *const kPreferenceKeyAIPermissionRunCommands = @"AIPermissionRunCommands";
@@ -564,6 +566,8 @@ static NSString *sPreviousVersion;
                   kPreferenceKeyAIVectorStore: @0,
                   kPreferenceKeyAIVendor: @(iTermAIVendorOpenAI),
                   kPreferenceKeyAISafetyCheck: @NO,
+                  kPreferenceKeyAICustomHeadersEnabled: @NO,
+                  kPreferenceKeyAICustomHeaders: @[],
 
                   kPreferenceKeyAIPermissionCheckTerminalState: @(iTermAIPermissionAsk),
                   kPreferenceKeyAIPermissionRunCommands: @(iTermAIPermissionAsk),


### PR DESCRIPTION
Adds a key/value table in the "Configure AI Model Manually…" popover where users can define extra headers (e.g. proxy auth, routing tags) that are appended to every AI request when the master toggle is on. Custom headers override built-in headers on collision (DLog warning is emitted). Covers chat/completion, vector store, and file upload paths.