### PR TITLE
Add "Confirm closing a tab" preference

### DIFF
--- a/docs/notes-3.7.txt
+++ b/docs/notes-3.7.txt
@@ -417,6 +417,9 @@ Settings Improvements:
   that works while another app is in
   front, without activating iTerm2 until
   you commit a selection.
+- A new “Confirm closing a tab” setting in
+  Settings > General > Closing prompts
+  before any tab is closed (off by default).
 
 Bug Fixes:
 - Pressing Enter to commit an IME

--- a/sources/Settings/GeneralPreferencesViewController.m
+++ b/sources/Settings/GeneralPreferencesViewController.m
@@ -60,6 +60,9 @@ enum {
     // Confirm closing multiple sessions
     IBOutlet id _confirmClosingMultipleSessions;
 
+    // Confirm closing a tab
+    IBOutlet id _confirmClosingTab;
+
     // Warn when quitting
     IBOutlet id _promptOnQuit;
     IBOutlet NSButton *_evenIfThereAreNoWindows;
@@ -366,6 +369,11 @@ enum {
 
     [self defineControl:_confirmClosingMultipleSessions
                     key:kPreferenceKeyConfirmClosingMultipleTabs
+            relatedView:nil
+                   type:kPreferenceInfoTypeCheckbox];
+
+    [self defineControl:_confirmClosingTab
+                    key:kPreferenceKeyConfirmClosingTab
             relatedView:nil
                    type:kPreferenceInfoTypeCheckbox];
 

--- a/sources/Settings/PreferencePanel.xib
+++ b/sources/Settings/PreferencePanel.xib
@@ -1328,6 +1328,7 @@ CA
                 <outlet property="_checkUpdate" destination="5048" id="Oi0-3Y-fu1"/>
                 <outlet property="_clickToSelectCommand" destination="2Pt-rH-WYj" id="kzN-to-jNw"/>
                 <outlet property="_confirmClosingMultipleSessions" destination="1996" id="1wi-R8-LGb"/>
+                <outlet property="_confirmClosingTab" destination="cTb-cl-Tab" id="cTo-cl-Tab"/>
                 <outlet property="_copyLastNewline" destination="5747" id="y4f-IT-rUT"/>
                 <outlet property="_customAIEndpoint" destination="1ex-YA-kns" id="0uj-2P-Lhd"/>
                 <outlet property="_customScriptsFolder" destination="llA-8R-abf" id="38A-bU-e4J"/>
@@ -6769,11 +6770,11 @@ See the [documentation](https://iterm2.com/automatic-profile-switching.html) for
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8ns-Nz-VFk" customClass="iTermPreferencesInnerTabContainerView">
-                                        <rect key="frame" x="88" y="563" width="581" height="137"/>
+                                        <rect key="frame" x="88" y="563" width="581" height="157"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                                         <subviews>
                                             <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1950">
-                                                <rect key="frame" x="135" y="101" width="227" height="18"/>
+                                                <rect key="frame" x="135" y="121" width="227" height="18"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                 <buttonCell key="cell" type="check" title="Quit when all windows are closed" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="1951">
                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -6784,7 +6785,7 @@ See the [documentation](https://iterm2.com/automatic-profile-switching.html) for
                                                 </connections>
                                             </button>
                                             <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1996">
-                                                <rect key="frame" x="135" y="81" width="229" height="18"/>
+                                                <rect key="frame" x="135" y="101" width="229" height="18"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                 <buttonCell key="cell" type="check" title="Confirm closing multiple sessions" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="1997">
                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -6792,7 +6793,19 @@ See the [documentation](https://iterm2.com/automatic-profile-switching.html) for
                                                 </buttonCell>
                                                 <connections>
                                                     <action selector="settingChanged:" target="9Se-ld-UJa" id="rss-OX-QhV"/>
-                                                    <outlet property="nextKeyView" destination="4757" id="5183"/>
+                                                    <outlet property="nextKeyView" destination="cTb-cl-Tab" id="5183"/>
+                                                </connections>
+                                            </button>
+                                            <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cTb-cl-Tab">
+                                                <rect key="frame" x="135" y="81" width="229" height="18"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                <buttonCell key="cell" type="check" title="Confirm closing a tab" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="cTc-cl-Tab">
+                                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                    <font key="font" metaFont="system"/>
+                                                </buttonCell>
+                                                <connections>
+                                                    <action selector="settingChanged:" target="9Se-ld-UJa" id="cTa-cl-Tab"/>
+                                                    <outlet property="nextKeyView" destination="4757" id="cTn-cl-Tab"/>
                                                 </connections>
                                             </button>
                                             <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4757">

--- a/sources/Settings/iTermPreferences.h
+++ b/sources/Settings/iTermPreferences.h
@@ -126,6 +126,7 @@ extern NSString *const kPreferenceKeyRestoreWindowsToSameSpaces;
 extern NSString *const kPreferenceKeyOpenNoWindowsAtStartup;
 extern NSString *const kPreferenceKeyQuitWhenAllWindowsClosed;
 extern NSString *const kPreferenceKeyConfirmClosingMultipleTabs;
+extern NSString *const kPreferenceKeyConfirmClosingTab;
 extern NSString *const kPreferenceKeyPromptOnQuit;
 extern NSString *const kPreferenceKeyPromptOnQuitEvenIfThereAreNoWindows;
 extern NSString *const kPreferenceKeyInstantReplayMemoryMegabytes;

--- a/sources/Settings/iTermPreferences.m
+++ b/sources/Settings/iTermPreferences.m
@@ -40,6 +40,7 @@ NSString *const kPreferenceKeyRestoreWindowsToSameSpaces = @"RestoreWindowsToSam
 NSString *const kPreferenceKeyOpenNoWindowsAtStartup = @"OpenNoWindowsAtStartup";
 NSString *const kPreferenceKeyQuitWhenAllWindowsClosed = @"QuitWhenAllWindowsClosed";
 NSString *const kPreferenceKeyConfirmClosingMultipleTabs = @"OnlyWhenMoreTabs";  // The key predates split panes
+NSString *const kPreferenceKeyConfirmClosingTab = @"PromptOnCloseTab";
 NSString *const kPreferenceKeyPromptOnQuit = @"PromptOnQuit";
 NSString *const kPreferenceKeyPromptOnQuitEvenIfThereAreNoWindows = @"PromptOnQuitEvenIfThereAreNoWindows";
 NSString *const kPreferenceKeyInstantReplayMemoryMegabytes = @"IRMemory";
@@ -487,6 +488,7 @@ static NSString *sPreviousVersion;
                   kPreferenceKeyOpenNoWindowsAtStartup: @NO,
                   kPreferenceKeyQuitWhenAllWindowsClosed: @NO,
                   kPreferenceKeyConfirmClosingMultipleTabs: @YES,
+                  kPreferenceKeyConfirmClosingTab: @NO,
                   kPreferenceKeyPromptOnQuit: @YES,
                   kPreferenceKeyPromptOnQuitEvenIfThereAreNoWindows: @NO,
                   kPreferenceKeyInstantReplayMemoryMegabytes: @4,

--- a/sources/TerminalView/PseudoTerminal.m
+++ b/sources/TerminalView/PseudoTerminal.m
@@ -2085,6 +2085,9 @@ ITERM_WEAKLY_REFERENCEABLE
         [iTermPreferences boolForKey:kPreferenceKeyConfirmClosingMultipleTabs]) {
         mustAsk = YES;
     }
+    if ([iTermPreferences boolForKey:kPreferenceKeyConfirmClosingTab]) {
+        mustAsk = YES;
+    }
 
     if (mustAsk && !suppressConfirmation) {
         const BOOL anyIsLocked = [[aTab sessions] anyWithBlock:^BOOL(PTYSession *anObject) {


### PR DESCRIPTION
A new opt-in checkbox under Settings > General > Closing prompts the user before any tab is closed (Cmd+W on the last pane, Cmd+Opt+W, middle-click, or the close button). Default is off to preserve existing behavior; the existing "Confirm closing multiple sessions" still applies independently.