### PR TITLE
Bind ⌘⇧T to Shell > Undo Close

### DIFF
--- a/docs/notes-3.7.txt
+++ b/docs/notes-3.7.txt
@@ -210,6 +210,11 @@ Tabs, Windows, and UI:
   folder of images at a configurable interval.
   Pick a folder instead of a file in
   Settings > Profiles > Window > Background.
+- ⌘⇧T now triggers Shell > Undo Close,
+  matching the reopen-tab shortcut used by
+  web browsers. “Show Tabs in Fullscreen”
+  no longer has a default shortcut and can
+  be re-bound in Settings > Keys.
 
 
 Triggers Improvements:

--- a/sources/MainMenu/MainMenu.xib
+++ b/sources/MainMenu/MainMenu.xib
@@ -251,8 +251,8 @@
                             <menuItem isSeparatorItem="YES" id="9vB-1n-LfH">
                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                             </menuItem>
-                            <menuItem title="Undo Close" identifier="Undo Close" id="OIr-XE-oT1">
-                                <modifierMask key="keyEquivalentModifierMask"/>
+                            <menuItem title="Undo Close" keyEquivalent="t" identifier="Undo Close" id="OIr-XE-oT1">
+                                <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
                                 <connections>
                                     <action selector="undoCloseSession:" target="201" id="df0-of-sxF"/>
                                 </connections>
@@ -942,7 +942,7 @@ DQ
                 <menuItem title="View" id="802">
                     <menu key="submenu" title="View" id="803">
                         <items>
-                            <menuItem title="Show Tabs in Fullscreen" keyEquivalent="T" identifier="Show Tabs in Fullscreen" id="1257">
+                            <menuItem title="Show Tabs in Fullscreen" identifier="Show Tabs in Fullscreen" id="1257">
                                 <connections>
                                     <action selector="toggleFullScreenTabBar:" target="-1" id="1259"/>
                                 </connections>


### PR DESCRIPTION
Matches the reopen-tab shortcut used by Chrome, Safari, Firefox, and other browsers, so the muscle memory developed in browsers also restores the last closed session/tab/window here. The existing Undo Close behavior in iTermApplicationDelegate already restores into the original window when it still exists, mirroring Chrome.

Frees ⌘⇧T from View > Show Tabs in Fullscreen, which is a rarely-used set-and-forget toggle that remains reachable via the menu and can be re-bound in Settings > Keys.