### PR TITLE
Add keyboard shortcuts to rename tabs/windows and cycle tab color

### DIFF
--- a/docs/notes-3.7.txt
+++ b/docs/notes-3.7.txt
@@ -12,6 +12,13 @@ Major New Features:
 - Tabs can now be placed on the right side
   of the window.
 
+- Keyboard shortcuts were added for quickly
+  organizing tabs and windows: ⌃⌘R renames
+  the current tab, ⌃⌥⌘R renames the window,
+  and ⌃⌘E cycles the current tab’s color
+  through the presets (then to no color).
+  Handy when many tabs look alike.
+
 - A new Tab Status system was added. Sessions
   can now report status that appears on their
   tab with a custom subtitle, color, and dot

--- a/sources/Infrastructure/Views/ColorsMenuItemView.h
+++ b/sources/Infrastructure/Views/ColorsMenuItemView.h
@@ -39,6 +39,10 @@
 
 + (NSSize)preferredSize;
 
+// The preset tab colors from the tabColorMenuOptions advanced setting (with a
+// hardcoded fallback if that string is unparseable).
++ (NSArray<NSColor *> *)presetTabColors;
+
 - (void)drawRect:(NSRect)rect;
 - (void)mouseUp:(NSEvent*) event;
 

--- a/sources/Infrastructure/Views/ColorsMenuItemView.m
+++ b/sources/Infrastructure/Views/ColorsMenuItemView.m
@@ -486,6 +486,10 @@ const CGFloat iTermColorsMenuItemViewDisabledAlpha = 0.3;
 }
 
 - (NSArray<NSColor *> *)colors {
+    return [ColorsMenuItemView presetTabColors];
+}
+
++ (NSArray<NSColor *> *)presetTabColors {
     NSArray<NSColor *> *result = [[[iTermAdvancedSettingsModel tabColorMenuOptions] componentsSeparatedByString:@" "] mapWithBlock:^id(NSString *anObject) {
         return [NSColor colorFromHexString:anObject];
     }];

--- a/sources/MainMenu/MainMenu.xib
+++ b/sources/MainMenu/MainMenu.xib
@@ -1655,8 +1655,8 @@ CQ
                                 </menu>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="8EB-Jn-Xxs"/>
-                            <menuItem title="Edit Window Title" identifier="Edit Window Title" id="STe-pB-R3v">
-                                <modifierMask key="keyEquivalentModifierMask"/>
+                            <menuItem title="Edit Window Title" keyEquivalent="r" identifier="Edit Window Title" id="STe-pB-R3v">
+                                <modifierMask key="keyEquivalentModifierMask" option="YES" control="YES" command="YES"/>
                                 <connections>
                                     <action selector="editWindowTitle:" target="-1" id="AQk-j6-utG"/>
                                 </connections>
@@ -1666,10 +1666,16 @@ CQ
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="Tab" id="cX5-Da-13x">
                                     <items>
-                                        <menuItem title="Edit Tab Title" identifier="Edit Tab Title" id="o4x-qQ-aC9">
-                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                        <menuItem title="Edit Tab Title" keyEquivalent="r" identifier="Edit Tab Title" id="o4x-qQ-aC9">
+                                            <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
                                             <connections>
                                                 <action selector="editTabTitle:" target="-1" id="tXR-UH-8S7"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Cycle Tab Color" keyEquivalent="e" identifier="Cycle Tab Color" id="ctc-Cy-001">
+                                            <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="cycleTabColor:" target="-1" id="ctc-Ac-001"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem title="Select Tab" id="847">

--- a/sources/TerminalView/PseudoTerminal.h
+++ b/sources/TerminalView/PseudoTerminal.h
@@ -392,6 +392,11 @@ extern NSString *const iTermDidCreateTerminalWindowNotification;
 - (void)closeTab:(PTYTab *)aTab;
 
 - (void)changeTabColorToMenuAction:(id)sender;
+
+// Cycle the current tab's color through the presets in the tabColorMenuOptions
+// advanced setting, then to no color, then back to the first preset.
+- (IBAction)cycleTabColor:(id)sender;
+
 - (void)moveSessionToWindow:(id)sender;
 
 - (void)addRevivedSession:(PTYSession *)session;

--- a/sources/TerminalView/PseudoTerminal.m
+++ b/sources/TerminalView/PseudoTerminal.m
@@ -11996,6 +11996,8 @@ typedef NS_ENUM(NSUInteger, iTermBroadcastCommand) {
         iTermTabColorMenuItem *colorMenuItem = [iTermTabColorMenuItem castFrom:item];
         colorMenuItem.colorsView.currentColor = self.currentSession.tabColor;
         return self.currentSession != nil;
+    } else if (item.action == @selector(cycleTabColor:)) {
+        return self.currentSession != nil;
     } else if (item.action == @selector(setWindowStyle:)) {
         iTermWindowType normalized = iTermWindowTypeNormalized(self.windowType);
         // For backward compatibility the main menu still makes a distinction between full-width/height
@@ -12422,6 +12424,19 @@ typedef NS_ENUM(NSUInteger, iTermBroadcastCommand) {
     return [PseudoTerminal castFrom:term];
 }
 
+// Apply a tab color (nil clears it) to every session in a tab, remember it as a
+// recently used color, and refresh the tab bar. Shared by the color menu and the
+// cycle-color keyboard shortcut.
+- (void)applyTabColor:(NSColor *)color toTab:(PTYTab *)tab {
+    for (PTYSession *aSession in [tab sessions]) {
+        [aSession setTabColor:color];
+    }
+    if (color) {
+        [[iTermRecentTabColors shared] addColor:color];
+    }
+    [self updateTabColors];
+}
+
 // Change the tab color to the selected menu color
 - (IBAction)changeTabColorToMenuAction:(id)sender {
     // If we got here because you right clicked on a tab, use the represented object.
@@ -12434,14 +12449,43 @@ typedef NS_ENUM(NSUInteger, iTermBroadcastCommand) {
     }
 
     ColorsMenuItemView *menuItem = (ColorsMenuItemView *)[sender view];
-    NSColor *color = menuItem.color;
-    for (PTYSession *aSession in [aTab sessions]) {
-        [aSession setTabColor:color];
+    [self applyTabColor:menuItem.color toTab:aTab];
+}
+
+// Cycle the current tab's color through the presets in the tabColorMenuOptions
+// advanced setting, then to no color, then back to the first preset. Gives a
+// one-keystroke way to visually distinguish tabs (e.g. when running many agents).
+- (IBAction)cycleTabColor:(id)sender {
+    PTYTab *tab = self.currentTab;
+    if (!tab) {
+        return;
     }
-    if (color) {
-        [[iTermRecentTabColors shared] addColor:color];
+    NSArray<NSColor *> *presets = [ColorsMenuItemView presetTabColors];
+    if (presets.count == 0) {
+        return;
     }
-    [self updateTabColors];
+    // Locate the current color in the cycle. -1 means “no color”, which also
+    // covers an unrecognized custom color (it restarts the cycle at presets[0]).
+    NSColor *current = tab.activeSession.tabColor;
+    NSInteger currentIndex = -1;
+    if (current) {
+        for (NSInteger i = 0; i < (NSInteger)presets.count; i++) {
+            if ([presets[i] isApproximatelyEqualToColor:current epsilon:0.01]) {
+                currentIndex = i;
+                break;
+            }
+        }
+    }
+    // Sequence: presets[0] … presets[n-1] → no color (nil) → presets[0] …
+    NSColor *next;
+    if (currentIndex < 0) {
+        next = presets[0];
+    } else if (currentIndex + 1 < (NSInteger)presets.count) {
+        next = presets[currentIndex + 1];
+    } else {
+        next = nil;
+    }
+    [self applyTabColor:next toTab:tab];
 }
 
 - (IBAction)compose:(id)sender {


### PR DESCRIPTION
Renaming a tab/window and setting a tab color already existed but were buried in the View menu with no key equivalents, which makes organizing a window full of tabs (e.g. many concurrent agents) slow.

This wires up default shortcuts and adds a one-keystroke color cycle:

- Edit Tab Title:    Ctrl-Cmd-R   (reuses editTabTitle:)
- Edit Window Title: Ctrl-Opt-Cmd-R (reuses editWindowTitle:)
- Cycle Tab Color:   Ctrl-Cmd-E   (new cycleTabColor: action)

cycleTabColor: steps the current tab through the tabColorMenuOptions presets, then to no color, then wraps around. The shared "apply a color to every session in a tab" logic is hoisted into applyTabColor:toTab:, used by both the color menu and the new shortcut. Preset parsing is extracted to +[ColorsMenuItemView presetTabColors] so the menu and the cycle share one source of truth.