### PR TITLE
fix: quit Vim keep full scrollback buffer with iTerm2's tmux integration

### DIFF
--- a/docs/notes-3.7.txt
+++ b/docs/notes-3.7.txt
@@ -293,12 +293,6 @@ Tmux Improvements:
 - Bracketed paste state is restored on attach
   (prep for tmux’s upcoming bracket_paste_flag
   format).
-- Integrated tmux now preserves local scrollback
-  outside tmux’s captured history when unpausing
-  a pane.
-- Integrated tmux now saves the visible primary
-  screen to scrollback before a non-alternate-screen
-  full-screen app repaints from the home position.
 - The per-pane modifyOtherKeys state is now
   restored on attach (using tmux 3.5+’s
   pane_key_mode format), so reattaching while

--- a/docs/notes-3.7.txt
+++ b/docs/notes-3.7.txt
@@ -293,6 +293,12 @@ Tmux Improvements:
 - Bracketed paste state is restored on attach
   (prep for tmux’s upcoming bracket_paste_flag
   format).
+- Integrated tmux now preserves local scrollback
+  outside tmux’s captured history when unpausing
+  a pane.
+- Integrated tmux now saves the visible primary
+  screen to scrollback before a non-alternate-screen
+  full-screen app repaints from the home position.
 - The per-pane modifyOtherKeys state is now
   restored on attach (using tmux 3.5+’s
   pane_key_mode format), so reattaching while

--- a/sources/VT100Screen/VT100ScreenMutableState.m
+++ b/sources/VT100Screen/VT100ScreenMutableState.m
@@ -1531,9 +1531,8 @@ static const int64_t VT100ScreenMutableStateSideEffectFlagLineBufferDidDropLines
         if (x1 == 0 && yStart == 0 && [self shouldSaveScreenBeforeClearingFromHome]) {
             // Save the whole screen. This helps the "screen" terminal, where CSI H CSI J is used to
             // clear the screen.
-            // Also do it for integrated tmux clients when an interactive app has disabled hard
-            // alternate screen but still repaints from the home position.
-            // Don't do it if in a protection mode since that would defeat the purpose.
+            // Only do it in alternate screen mode to avoid doing this for zsh (issue 8822)
+            // And don't do it if in a protection mode since that would defeat the purpose.
             [self addSideEffect:^(id<VT100ScreenDelegate>  _Nonnull delegate) {
                 [delegate screenRemoveSelection];
             } name:@"erase in display"];

--- a/sources/VT100Screen/VT100ScreenMutableState.m
+++ b/sources/VT100Screen/VT100ScreenMutableState.m
@@ -1474,6 +1474,25 @@ static const int64_t VT100ScreenMutableStateSideEffectFlagLineBufferDidDropLines
     }
 }
 
+- (BOOL)tmuxClientIsRunningInteractiveAppWithoutAltScreen {
+    return (self.terminal.tmuxMode &&
+            !self.terminal.softAlternateScreenMode &&
+            (self.terminal.cursorMode ||
+             self.terminal.keypadMode ||
+             self.terminal.bracketedPasteMode ||
+             self.terminal.mouseMode != MOUSE_REPORTING_NONE));
+}
+
+- (BOOL)shouldSaveScreenBeforeClearingFromHome {
+    if (![iTermAdvancedSettingsModel saveScrollBufferWhenClearing]) {
+        return NO;
+    }
+    if (self.terminal.softAlternateScreenMode) {
+        return YES;
+    }
+    return [self tmuxClientIsRunningInteractiveAppWithoutAltScreen];
+}
+
 - (void)eraseInDisplayBeforeCursor:(BOOL)before afterCursor:(BOOL)after decProtect:(BOOL)dec {
     int x1, yStart, x2, y2;
     BOOL shouldHonorProtected = NO;
@@ -1509,11 +1528,12 @@ static const int64_t VT100ScreenMutableStateSideEffectFlagLineBufferDidDropLines
         yStart = self.currentGrid.cursor.y;
         x2 = self.currentGrid.size.width - 1;
         y2 = self.currentGrid.size.height - 1;
-        if (x1 == 0 && yStart == 0 && [iTermAdvancedSettingsModel saveScrollBufferWhenClearing] && self.terminal.softAlternateScreenMode) {
+        if (x1 == 0 && yStart == 0 && [self shouldSaveScreenBeforeClearingFromHome]) {
             // Save the whole screen. This helps the "screen" terminal, where CSI H CSI J is used to
             // clear the screen.
-            // Only do it in alternate screen mode to avoid doing this for zsh (issue 8822)
-            // And don't do it if in a protection mode since that would defeat the purpose.
+            // Also do it for integrated tmux clients when an interactive app has disabled hard
+            // alternate screen but still repaints from the home position.
+            // Don't do it if in a protection mode since that would defeat the purpose.
             [self addSideEffect:^(id<VT100ScreenDelegate>  _Nonnull delegate) {
                 [delegate screenRemoveSelection];
             } name:@"erase in display"];


### PR DESCRIPTION
fix the problem when using iTerm2’s integrated tmux, full-screen interactive applications like Vim can be configured not to enter the alternate screen. 
In this mode, the application repaints the main screen directly. When it clears from the home position, iTerm2 may discard part of the visible content instead of first preserving it in scrollback. This makes it “eats” part of the terminal history after quit Vim.