### PR TITLE
Add a Lock Layout advanced setting

### DIFF
--- a/docs/notes-3.7.txt
+++ b/docs/notes-3.7.txt
@@ -206,6 +206,14 @@ Tabs, Windows, and UI:
   highlight the focused pane.
 - New Lock Size menu item and per-profile
   preference to prevent window resizing.
+- New Lock Layout advanced setting that
+  freezes a window’s layout: it prevents
+  splitting, adding or closing tabs,
+  reordering tabs, closing or dragging
+  panes, and moving panes or tabs to
+  other windows. Resizing panes, opening
+  new windows, and closing the window
+  still work.
 - You can now choose to show a Proxy icon in
   Compact and Minimal themes.
 - The tab color menu now has a color picker,

--- a/sources/AppKit/iTermApplicationDelegate.m
+++ b/sources/AppKit/iTermApplicationDelegate.m
@@ -420,6 +420,15 @@ static NSModalResponse iTermCompareRenderingRunModal(id self, SEL _cmd) {
 }
 
 - (BOOL)validateMenuItem:(NSMenuItem *)menuItem {
+    if ([iTermAdvancedSettingsModel lockLayout] &&
+        [menuItem action] == @selector(newSessionInTabAtIndex:)) {
+        // Frozen layout: refuse to add a tab to a window that already has one.
+        // Opening a new window (no current terminal, or one with no tabs) is fine.
+        PseudoTerminal *term = [[iTermController sharedInstance] currentTerminal];
+        if (term && term.tabs.count > 0) {
+            return NO;
+        }
+    }
     if ([menuItem action] == @selector(toggleUseBackgroundPatternIndicator:)) {
       [menuItem setState:[self useBackgroundPatternIndicator]];
       return YES;

--- a/sources/Settings/iTermAdvancedSettingsModel.h
+++ b/sources/Settings/iTermAdvancedSettingsModel.h
@@ -250,6 +250,7 @@ extern NSString *const iTermAdvancedSettingsDidChange;
 + (BOOL)laxNilPolicyInInterpolatedStrings;
 + (BOOL)leftAlignTitleBarMinimalTahoe;
 + (double)lightModeInactiveTabDarkness;
++ (BOOL)lockLayout;
 + (NSString *)llmPlatform;
 + (BOOL)logDrawingPerformance;
 + (BOOL)logRestorableStateSize;

--- a/sources/Settings/iTermAdvancedSettingsModel.m
+++ b/sources/Settings/iTermAdvancedSettingsModel.m
@@ -683,6 +683,7 @@ DEFINE_BOOL(bordersOnlyInLightMode, YES, SECTION_WINDOWS @"Opaque windows have a
 DEFINE_BOOL(allowLiveResize, YES, SECTION_WINDOWS @"Allow window resizing by dragging edges and corners?");
 DEFINE_SETTABLE_BOOL(showSecureKeyboardEntryIndicator, ShowSecureKeyboardEntryIndicator, YES, SECTION_WINDOWS @"Show secure keyboard entry indicator?");
 DEFINE_BOOL(leftAlignTitleBarMinimalTahoe, YES, SECTION_WINDOWS @"Left-align title bar in Minimal and Compact themes in macOS 26 and later?");
+DEFINE_BOOL(lockLayout, NO, SECTION_WINDOWS @"Lock window layout?\nWhen enabled, freezes a window’s layout: prevents splitting panes, adding tabs, closing panes and tabs, reordering tabs, dragging panes, and moving panes or tabs to other windows. Resizing panes by dragging the divider, opening new windows, and closing the whole window still work. Useful for preventing accidental layout changes from a stray click or drag.");
 
 #pragma mark tmux
 

--- a/sources/TerminalView/MovePaneController.m
+++ b/sources/TerminalView/MovePaneController.m
@@ -6,6 +6,7 @@
 
 #import "MovePaneController.h"
 #import "DebugLogging.h"
+#import "iTermAdvancedSettingsModel.h"
 #import "iTermController.h"
 #import "iTermPreferences.h"
 #import "NSObject+iTerm.h"
@@ -68,6 +69,10 @@ NSString *const iTermSessionDidChangeTabNotification = @"iTermSessionDidChangeTa
 
 - (void)movePane:(PTYSession *)session {
     DLog(@"movePane:%@", session);
+    if ([iTermAdvancedSettingsModel lockLayout]) {
+        DLog(@"Layout is locked, refusing to move");
+        return;
+    }
     if (session.locked) {
         DLog(@"Session is locked, refusing to move");
         return;
@@ -77,6 +82,10 @@ NSString *const iTermSessionDidChangeTabNotification = @"iTermSessionDidChangeTa
 
 - (void)swapPane:(PTYSession *)session {
     DLog(@"swapPane:%@", session);
+    if ([iTermAdvancedSettingsModel lockLayout]) {
+        DLog(@"Layout is locked, refusing to swap");
+        return;
+    }
     if (session.locked) {
         DLog(@"Session is locked, refusing to swap");
         return;
@@ -296,6 +305,10 @@ NSString *const iTermSessionDidChangeTabNotification = @"iTermSessionDidChangeTa
 
 - (void)beginDrag:(PTYSession *)session {
     DLog(@"beginDrag:%@", session);
+    if ([iTermAdvancedSettingsModel lockLayout]) {
+        DLog(@"Layout is locked, refusing to drag");
+        return;
+    }
     if (session.locked) {
         DLog(@"Session is locked, refusing to drag");
         return;

--- a/sources/TerminalView/PTYTab.m
+++ b/sources/TerminalView/PTYTab.m
@@ -6918,6 +6918,11 @@ typedef struct {
 - (BOOL)session:(PTYSession *)session performDragOperation:(id<NSDraggingInfo>)sender {
     DLog(@"session:%@ performDragOperation:%@", session, sender);
 
+    if ([iTermAdvancedSettingsModel lockLayout]) {
+        DLog(@"Layout is locked, refusing drag operation");
+        return NO;
+    }
+
     // self is the destination tab. session is the session that's moving.
     if ([[[sender draggingPasteboard] types] indexOfObject:iTermMovePaneDragType] != NSNotFound) {
         if ([[MovePaneController sharedInstance] isMovingSession:session]) {

--- a/sources/TerminalView/PseudoTerminal.m
+++ b/sources/TerminalView/PseudoTerminal.m
@@ -2445,6 +2445,10 @@ ITERM_WEAKLY_REFERENCEABLE
 }
 
 - (BOOL)closeSessionWithConfirmation:(PTYSession *)aSession {
+    if ([iTermAdvancedSettingsModel lockLayout]) {
+        DLog(@"Layout is locked, refusing to close session");
+        return NO;
+    }
     PTYTab *tab = [self tabForSession:aSession];
     if ([[tab sessions] count] == 1) {
         return [self closeTabIfConfirmed:tab];
@@ -7145,6 +7149,9 @@ hidingToolbeltShouldResizeWindow:(BOOL)hidingToolbeltShouldResizeWindow
 // This isn't a delegate method, but I need the functionality with the added suppressConfirmation
 // flag to avoid showing two warnings in tmux integration mode.
 - (BOOL)tabView:(NSTabView*)tabView shouldCloseTabViewItem:(NSTabViewItem *)tabViewItem suppressConfirmation:(BOOL)suppressConfirmation {
+    if ([iTermAdvancedSettingsModel lockLayout]) {
+        return NO;
+    }
     PTYTab *aTab = [tabViewItem identifier];
     if (aTab == nil) {
         return NO;
@@ -7157,6 +7164,9 @@ hidingToolbeltShouldResizeWindow:(BOOL)hidingToolbeltShouldResizeWindow
     shouldDragTabViewItem:(NSTabViewItem *)tabViewItem
                fromTabBar:(PSMTabBarControl *)tabBarControl
 {
+    if ([iTermAdvancedSettingsModel lockLayout]) {
+        return NO;
+    }
     return YES;
 }
 
@@ -9542,6 +9552,16 @@ static CGFloat iTermDimmingAmount(PSMTabBarControl *tabView) {
                targetSession:(PTYSession *)targetSession
                   completion:(void (^)(PTYSession *, BOOL ok))completion
                        ready:(void (^)(PTYSession *, BOOL ok))ready {
+    if ([iTermAdvancedSettingsModel lockLayout]) {
+        DLog(@"Layout is locked, refusing to split");
+        if (ready) {
+            ready(nil, NO);
+        }
+        if (completion) {
+            completion(nil, NO);
+        }
+        return;
+    }
     if ([targetSession isTmuxClient]) {
         [self willSplitTmuxPane];
         TmuxController *controller = [targetSession tmuxController];
@@ -10332,6 +10352,10 @@ typedef struct {
 }
 
 - (void)moveTabAtIndex:(NSInteger)selectedIndex toIndex:(NSInteger)destinationIndex {
+    if ([iTermAdvancedSettingsModel lockLayout]) {
+        DLog(@"Layout is locked, refusing to move tab");
+        return;
+    }
     if (destinationIndex < 0) {
         destinationIndex = [_contentView.tabView numberOfTabViewItems] - 1;
     }
@@ -11769,6 +11793,24 @@ typedef NS_ENUM(NSUInteger, iTermBroadcastCommand) {
 
 // Returns true if the given menu item is selectable.
 - (BOOL)validateMenuItem:(NSMenuItem *)item {
+    if ([iTermAdvancedSettingsModel lockLayout]) {
+        const SEL action = [item action];
+        if (action == @selector(closeCurrentTab:) ||
+            action == @selector(closeCurrentSession:) ||
+            action == @selector(splitVertically:) ||
+            action == @selector(splitHorizontally:) ||
+            action == @selector(openSplitHorizontallySheet:) ||
+            action == @selector(openSplitVerticallySheet:) ||
+            action == @selector(moveTabLeft:) ||
+            action == @selector(moveTabRight:) ||
+            action == @selector(moveTabToNewWindow:) ||
+            action == @selector(moveTabToNewWindowContextualMenuAction:) ||
+            action == @selector(newTabToTheRight:) ||
+            action == @selector(closeOtherTabs:) ||
+            action == @selector(closeTabsToTheRight:)) {
+            return NO;
+        }
+    }
     BOOL result = YES;
     if ([item action] == @selector(detachTmux:) ||
         [item action] == @selector(newTmuxWindow:) ||
@@ -12345,6 +12387,10 @@ typedef NS_ENUM(NSUInteger, iTermBroadcastCommand) {
 // the -tabs array immediately for tmux tabs.
 - (void)closeOtherTabs:(id)sender
 {
+    if ([iTermAdvancedSettingsModel lockLayout]) {
+        DLog(@"Layout is locked, refusing to close other tabs");
+        return;
+    }
     NSTabViewItem *aTabViewItem = [sender representedObject];
     PTYTab *tabToKeep = [aTabViewItem identifier];
     NSMutableArray *tabsToRemove = [[[self tabs] mutableCopy] autorelease];
@@ -12359,6 +12405,10 @@ typedef NS_ENUM(NSUInteger, iTermBroadcastCommand) {
 
 - (void)closeTabsToTheRight:(id)sender
 {
+    if ([iTermAdvancedSettingsModel lockLayout]) {
+        DLog(@"Layout is locked, refusing to close tabs to the right");
+        return;
+    }
     NSTabViewItem *aTabViewItem = [sender representedObject];
     PTYTab *tabToKeep = [aTabViewItem identifier];
 
@@ -12389,6 +12439,10 @@ typedef NS_ENUM(NSUInteger, iTermBroadcastCommand) {
 }
 
 - (PseudoTerminal *)it_moveTabToNewWindow:(PTYTab *)aTab {
+    if ([iTermAdvancedSettingsModel lockLayout]) {
+        DLog(@"Layout is locked, refusing to move tab to a new window");
+        return nil;
+    }
     if (aTab == nil) {
         return nil;
     }
@@ -12742,6 +12796,16 @@ typedef NS_ENUM(NSUInteger, iTermBroadcastCommand) {
         objectType = iTermWindowObject;
     } else {
         objectType = iTermTabObject;
+    }
+    // When the layout is locked, refuse to add a tab to a window that already
+    // has one (a frozen layout can't grow). The first tab of a brand-new window
+    // (objectType == iTermWindowObject) is still allowed.
+    if ([iTermAdvancedSettingsModel lockLayout] && objectType == iTermTabObject) {
+        DLog(@"Layout is locked, refusing to add a tab");
+        if (completion) {
+            completion(nil, NO);
+        }
+        return nil;
     }
     if (command) {
         profile = [[profile


### PR DESCRIPTION
## Summary

Adds a “Lock window layout?” advanced setting (Windows section, default off). When enabled, it freezes a window’s layout so an accidental click or drag can’t rearrange or destroy it.

**Prevented while locked:**
- Splitting panes
- Adding tabs
- Closing panes and tabs (including “Close Other Tabs” / “Close Tabs to the Right”)
- Reordering tabs
- Dragging panes within a tab
- Moving panes or tabs to other windows

**Still allowed:**
- Resizing panes by dragging the divider
- Opening new windows (a new window still gets its first tab — you just can’t add a second while locked)
- Closing the whole window

## Implementation

Enforcement is centralized at a small number of choke points rather than spread across every action, so the lock holds regardless of how an operation is triggered — menu, keyboard shortcut, context menu, drag, or the scripting/Python API. `validateMenuItem:` additionally greys out the corresponding menu commands for clear feedback.

`createTabWithProfile:` only blocks adding a tab when the window already has one (`objectType == iTermTabObject`), so opening a new window and its first tab is unaffected.

## Notes / open questions

- Implemented as an advanced setting for low friction, but it could just as easily be a Window-menu toggle if you’d prefer it more discoverable.
- The lock intentionally applies to the scripting API too (“locked means locked”). Happy to scope it to UI-only if you’d rather scripts bypass it.
- Default is off; no behavior change unless enabled.

## Testing

- Builds clean (Development).
- Manually verified in a dev build: each blocked operation is inert and its menu item greyed; resizing panes, opening new windows, and closing the window still work; toggling the setting off restores normal behavior.
