### PR TITLE
Keep Full-Height Window on Tab Hide

### DIFF
--- a/docs/notes-3.7.txt
+++ b/docs/notes-3.7.txt
@@ -525,6 +525,9 @@ Settings Improvements:
   you commit a selection.
 
 Bug Fixes:
+- A full-height window no longer loses the tab
+  bar’s height from the bottom when the last
+  tab closes and the tab bar auto-hides.
 - Copying selected text from a porthole (such as
   rendered markdown) now works in apps that
   prefer rich text.

--- a/sources/TerminalView/PseudoTerminal.m
+++ b/sources/TerminalView/PseudoTerminal.m
@@ -7435,7 +7435,13 @@ hidingToolbeltShouldResizeWindow:(BOOL)hidingToolbeltShouldResizeWindow
         const BOOL preserveOnlyIfExcursion = [iTermPreferences boolForKey:kPreferenceKeyPreserveWindowSizeToKeepOnScreenWhenTabBarVisibilityChanges];
         const BOOL wouldCauseExcursion = willShowTabBar && [self fittingWindowToTabsWouldCauseExcursion];
         const BOOL preserveDueToShowing = generallyPreserveWindowSize && (!preserveOnlyIfExcursion || wouldCauseExcursion);
-        const BOOL preserveDueToHiding = willHideTabBar && _excursionPrevented;
+        NSScreen *windowScreen = self.window.screen;
+        const NSRect windowScreenVisibleFrame = windowScreen.visibleFrame;
+        const BOOL windowIsFullHeight = (windowScreen != nil &&
+                                         !self.anyFullScreen &&
+                                         NSMinY(self.window.frame) <= NSMinY(windowScreenVisibleFrame) + 1.0 &&
+                                         NSMaxY(self.window.frame) >= NSMaxY(windowScreenVisibleFrame) - 1.0);
+        const BOOL preserveDueToHiding = willHideTabBar && (_excursionPrevented || windowIsFullHeight);
         const BOOL actuallyPreserve = preserveDueToHiding || preserveDueToShowing;
         const BOOL shouldResizeWindow = _windowNeedsInitialSize || !actuallyPreserve;
 


### PR DESCRIPTION
## Problem

With the default "hide tab bar when there is only one tab" behavior: a window at full screen height that has a tab bar showing (two or more tabs) loses the tab bar's height from the bottom when you close down to one tab. The tab bar auto-hides and the window ends up shorter than the screen. This happens regardless of how the window came to be full-height-with-a-tab-bar (opening a second tab on an already-maximized window, maximizing a multi-tab window, etc.).

## Cause

When the tab bar's visibility changes, the window is resized to keep the terminal's row count constant. In `windowFrameForTabSize:` that resize is top-anchored: it holds the top edge fixed and moves the bottom (`result.frame.origin.y -= heightChange`). On hide, `heightChange` is negative, so the bottom rises by the tab bar's height. For a window that already spans the full screen height there is nowhere for the rows to "stay constant" — the window simply gets shorter from the bottom.

## Fix

In `tabViewDidChangeNumberOfTabViewItems:`, when the tab bar is hiding and the window currently spans the full visible height of its screen, preserve the window frame instead of shrinking it. The existing preserve path then re-lays-out the content (`repositionWidgets` → `layoutSubviews`), so the terminal rows grow to fill the space the tab bar vacated.

Windows that are not full height keep the existing keep-rows-constant behavior, and full-screen windows are excluded.

## Files

- `sources/TerminalView/PseudoTerminal.m` — preserve the frame on tab-bar hide when the window is full height.
- `docs/notes-3.7.txt` — release note.

## Testing

Local build is currently blocked by an Xcode version mismatch on my machine (a pre-build dependency gate), so this has not been built locally. The change is small and uses only APIs already used nearby; please verify in CI.