### PR TITLE
Fix: oversized shadow in vertical tab bars

### DIFF
--- a/sources/TerminalView/PseudoTerminal.m
+++ b/sources/TerminalView/PseudoTerminal.m
@@ -11042,7 +11042,7 @@ static BOOL iTermApproximatelyEqualRects(NSRect lhs, NSRect rhs, double epsilon)
                                                           effectiveAppearance:self.window.effectiveAppearance];
     [_contentView.tabBarControl setStyle:style];
     [_contentView.tabBarControl setTabsHaveCloseButtons:[iTermPreferences boolForKey:kPreferenceKeyTabsHaveCloseButton]];
-    _contentView.tabBarControl.height = [self desiredTabBarHeight];
+    [_contentView.tabBarControl updateHeightWithDefault:[self desiredTabBarHeight]];
 
     [[self currentTab] recheckBlur];
     [self updateTabColors];

--- a/sources/TerminalView/iTermRootTerminalView.m
+++ b/sources/TerminalView/iTermRootTerminalView.m
@@ -1575,7 +1575,7 @@ NS_CLASS_AVAILABLE_MAC(10_14)
     const BOOL showToolbeltInline = self.shouldShowToolbelt;
     NSWindow *thisWindow = _delegate.window;
     if (!_tabBarControlOnLoan) {
-        self.tabBarControl.height = [_delegate rootTerminalViewHeightOfTabBar:self];
+        [self.tabBarControl updateHeightWithDefault:[_delegate rootTerminalViewHeightOfTabBar:self]];
     }
 
     _backgroundImage.frame = self.bounds;

--- a/sources/TerminalView/iTermTabBarControlView.h
+++ b/sources/TerminalView/iTermTabBarControlView.h
@@ -43,6 +43,11 @@
 // Call this when the result of iTermTabBarShouldFlash would change.
 - (void)updateFlashing;
 
+// Sets the tab bar height (the per-tab cell height when vertical). On macOS 26 vertical tab
+// bars take their cell height from the style; `defaultHeight` is the horizontal bar height,
+// which is used in all other cases.
+- (void)updateHeightWithDefault:(CGFloat)defaultHeight;
+
 - (void)setAlphaValue:(CGFloat)alphaValue animated:(BOOL)animated;
 
 @end

--- a/sources/TerminalView/iTermTabBarControlView.m
+++ b/sources/TerminalView/iTermTabBarControlView.m
@@ -283,6 +283,20 @@ typedef NS_ENUM(NSInteger, iTermTabBarFlashState) {
     self.showAddTabButton = ![iTermAdvancedSettingsModel removeAddTabButton] && (orientation == PSMTabBarHorizontalOrientation);
 }
 
+- (void)updateHeightWithDefault:(CGFloat)defaultHeight {
+    if (@available(macOS 26, *)) {
+        if (self.orientation == PSMTabBarVerticalOrientation) {
+            self.style.orientation = self.orientation;
+            const CGFloat styleHeight = self.style.tabBarHeight;
+            if (styleHeight > 0) {
+                self.height = styleHeight;
+                return;
+            }
+        }
+    }
+    self.height = defaultHeight;
+}
+
 #pragma mark - Private
 
 - (BOOL)cellAllowsTabProgressBar:(PSMTabBarCell *)cell {


### PR DESCRIPTION
## Summary

<img width="289" height="186" alt="Screenshot 2026-06-11 at 12 49 02 PM" src="https://github.com/user-attachments/assets/f37456b6-ae0c-4cd3-b9bf-53eb2baf0267" />

### Problem

With tabs on the left or right on macOS 26 (Tahoe tab style), creating a new tab renders the selected tab with an oversized shadow blob around its pill. The artifact disappears as soon as the tab bar sidebar is resized.

### Solution

The fix in this PR has the effect of always showing the tabs with the correct height.

### Testing

I was able to build this locally and visually test that it works as intended (see "after" video below).

## Before

https://github.com/user-attachments/assets/5356160f-0e02-4acb-8aa0-56476fcbb6b9

## After

https://github.com/user-attachments/assets/61efadcb-5a9b-414a-ba71-b08795d0bffd

