### PR TITLE
Add option to open tmux windows in background

### DIFF
--- a/docs/notes-3.7.txt
+++ b/docs/notes-3.7.txt
@@ -391,6 +391,8 @@ SSH Integration Improvements:
   improved.
 
 Tmux Improvements:
+- Add an advanced setting to open tmux
+  windows and tabs without taking focus.
 - Bracketed paste state is restored on attach
   (prep for tmux’s upcoming bracket_paste_flag
   format).

--- a/sources/Settings/iTermAdvancedSettingsModel.h
+++ b/sources/Settings/iTermAdvancedSettingsModel.h
@@ -384,6 +384,7 @@ extern NSString *const iTermAdvancedSettingsDidChange;
 + (double)quickPasteDelayBetweenCalls;
 + (BOOL)remapModifiersWithoutEventTap;
 + (BOOL)rememberTmuxWindowSizes;
++ (BOOL)tmuxWindowsOpenInBackground;
 + (BOOL)removeAddTabButton;
 + (BOOL)reportOnFirstMouse;
 + (BOOL)restrictSemanticHistoryPrefixAndSuffixToLogicalWindow;

--- a/sources/Settings/iTermAdvancedSettingsModel.m
+++ b/sources/Settings/iTermAdvancedSettingsModel.m
@@ -701,6 +701,7 @@ DEFINE_BOOL(pollForTmuxForegroundJob, NO, SECTION_TMUX @"Poll for foreground job
 DEFINE_STRING(tmuxTitlePrefix, @"↣ ", SECTION_TMUX @"Insert this string at the start of tab and window titles to indicate tmux integration.");
 DEFINE_BOOL(tmuxIncludeClientNameInWindowTitle, YES, SECTION_TMUX @"When using tmux integration, should the tmux client name (typically the name of the attaching session or the host name) appear in brackets in the window title?");
 DEFINE_BOOL(rememberTmuxWindowSizes, YES, SECTION_TMUX @"Remember window sizes in tmux integration?\nRequires tmux 2.9 or later. The “variable window size” advanced setting must be enabled.");
+DEFINE_BOOL(tmuxWindowsOpenInBackground, NO, SECTION_TMUX @"Open tmux windows and tabs in the background?\nWhen enabled, attaching with tmux -CC (or when tmux creates a new window) will reveal the window or tab without moving keyboard focus to it. Focus stays on the attaching session.");
 
 #define SECTION_SSH @"SSH Integration: "
 

--- a/sources/TerminalView/PseudoTerminal.m
+++ b/sources/TerminalView/PseudoTerminal.m
@@ -391,6 +391,11 @@ typedef NS_ENUM(int, iTermShouldHaveTitleSeparator) {
     BOOL _anyPaneIsTransparent;
     BOOL _windowDidResize;
     iTermSuppressMakeCurrentTerminal _suppressMakeCurrentTerminal;
+
+    // Set while a tmux tab/window is being inserted and the user has asked that
+    // tmux windows open in the background. Causes -insertTab:atIndex: to reveal
+    // the tab/window without moving keyboard focus to it.
+    BOOL _openingTmuxTabOrWindowInBackground;
     BOOL _deallocing;
     iTermOrderEnforcer *_proxyIconOrderEnforcer;
     BOOL _restorableStateInvalid;
@@ -3631,11 +3636,19 @@ ITERM_WEAKLY_REFERENCEABLE
                   name:(NSString *)name {
     DLog(@"begin loadTmuxLayout");
     [self beginTmuxOriginatedResize];
-    PTYTab *tab = [PTYTab openTabWithTmuxLayout:parseTree
-                                  visibleLayout:visibleParseTree
-                                     inTerminal:self
-                                     tmuxWindow:window
-                                 tmuxController:tmuxController];
+    const BOOL savedOpeningTmuxTabOrWindowInBackground = _openingTmuxTabOrWindowInBackground;
+    _openingTmuxTabOrWindowInBackground = [iTermAdvancedSettingsModel tmuxWindowsOpenInBackground];
+    PTYTab *tab = nil;
+    @try {
+        tab = [PTYTab openTabWithTmuxLayout:parseTree
+                              visibleLayout:visibleParseTree
+                                 inTerminal:self
+                                 tmuxWindow:window
+                             tmuxController:tmuxController];
+    }
+    @finally {
+        _openingTmuxTabOrWindowInBackground = savedOpeningTmuxTabOrWindowInBackground;
+    }
     [tab setTmuxWindowName:name];
     [tab setReportIdealSizeAsCurrent:YES];
     DLog(@"loadTmuxLayout: window frame before lazyFitWindowToTabs=%@", NSStringFromRect(self.window.frame));
@@ -11520,6 +11533,7 @@ static BOOL iTermApproximatelyEqualRects(NSRect lhs, NSRect rhs, double epsilon)
     PtyLog(@"insertTab:atIndex:%d", anIndex);
     assert(aTab);
     if ([_contentView.tabView indexOfTabViewItemWithIdentifier:aTab] == NSNotFound) {
+        const BOOL openingInBackground = _openingTmuxTabOrWindowInBackground;
         for (PTYSession* aSession in [aTab sessions]) {
             [aSession setIgnoreResizeNotifications:YES];
         }
@@ -11531,7 +11545,14 @@ static BOOL iTermApproximatelyEqualRects(NSRect lhs, NSRect rhs, double epsilon)
         const int safeIndex = MAX(0, MIN(_contentView.tabView.tabViewItems.count, anIndex));
         [_contentView.tabView insertTabViewItem:aTabViewItem atIndex:safeIndex];
         [aTabViewItem release];
-        if (_automaticallySelectNewTabs || _contentView.tabView.tabViewItems.count == 1) {
+        BOOL selectNewTab = (_automaticallySelectNewTabs ||
+                             _contentView.tabView.tabViewItems.count == 1);
+        if (openingInBackground && _contentView.tabView.tabViewItems.count > 1) {
+            // The user asked that tmux tabs open in the background. Leave the
+            // currently selected tab focused.
+            selectNewTab = NO;
+        }
+        if (selectNewTab) {
             [_contentView.tabView selectTabViewItemAtIndex:safeIndex];
         }
         if (self.windowInitialized && !_restoringWindow) {
@@ -11552,6 +11573,14 @@ static BOOL iTermApproximatelyEqualRects(NSRect lhs, NSRect rhs, double epsilon)
                 } else {
                     DLog(@"already rolling in or still being created - no need to do anything");
                 }
+            } else if (openingInBackground) {
+                DLog(@"Opening tmux window in background. Reveal it without taking key focus.");
+                NSWindow *keyWindow = NSApp.keyWindow;
+                if (keyWindow && keyWindow != self.window) {
+                    [self.window orderWindow:NSWindowBelow relativeTo:keyWindow.windowNumber];
+                } else {
+                    [[self window] orderFront:self];
+                }
             } else {
                 DLog(@"not a hidden hotkey window. Just order front.");
                 [[self window] makeKeyAndOrderFront:self];
@@ -11559,7 +11588,8 @@ static BOOL iTermApproximatelyEqualRects(NSRect lhs, NSRect rhs, double epsilon)
         } else {
             PtyLog(@"window not initialized, is fullscreen, or is being restored. Stack:\n%@", [NSThread callStackSymbols]);
         }
-        if (_suppressMakeCurrentTerminal == iTermSuppressMakeCurrentTerminalNone) {
+        if (_suppressMakeCurrentTerminal == iTermSuppressMakeCurrentTerminalNone &&
+            !openingInBackground) {
             [[iTermController sharedInstance] setCurrentTerminal:self];
         }
     }


### PR DESCRIPTION
Adds an advanced setting to open new or restored tmux windows and tabs in the background without taking keyboard focus.

This is useful with tmux -CC or automatically created tmux windows, allowing users to continue working in the current session without unexpected focus changes.