### PR TITLE
Fix dead space in tabs when tab numbers are hidden

### DIFF
--- a/ThirdParty/PSMTabBarControl/source/PSMTahoeTabStyle.swift
+++ b/ThirdParty/PSMTabBarControl/source/PSMTahoeTabStyle.swift
@@ -1645,7 +1645,7 @@ class PSMTahoeTabStyle: NSObject, PSMTabStyle {
         
         // Counter
         let counterString = attributedObjectCountValue(forTabCell: cell)
-        if !counterString.string.isEmpty {
+        if cell.count > 0 && !counterString.string.isEmpty {
             let counterStringSize = counterString.size()
             let fontSize = self.fontSize
             let gravity: Gravity = orientation == .horizontalOrientation ? .center : .right


### PR DESCRIPTION
When the setting Appearance -> Tabs -> "Show tab numbers" is  unticked, there's just an empty space where the tab number should be, the tab title doesn't expand to fill the new-empty space.

The below (line 1659) `cell.count > 0` was copied to the layout reservation, which should clear up the dead/empty space around the tab titles.