### PR TITLE
Sort JSON keys in Responses API request for prompt-cache stability

### DIFF
--- a/docs/notes-3.7.txt
+++ b/docs/notes-3.7.txt
@@ -1452,3 +1452,7 @@ Bug Fixes:
   status rollup was borrowing the
   session's identity and clearing it
   when the visible peer changed.
+- Sort JSON keys in the Responses API
+  request so OpenAI prompt caching gets
+  a stable prefix and reliably hits the
+  cache.

--- a/sources/AITerm/ResponsesAPIRequest.swift
+++ b/sources/AITerm/ResponsesAPIRequest.swift
@@ -1872,6 +1872,13 @@ struct ResponsesBodyRequestBuilder {
             }
         }
         let bodyEncoder = JSONEncoder()
+        // OpenAI prompt caching needs a byte-exact prefix match, and the
+        // tools array serializes [String: Property] / [String: AnyCodable]
+        // dictionaries whose iteration order is randomized per process.
+        // Without .sortedKeys the same tool list can serialize with keys
+        // shuffled, silently breaking the cache_read path. See the
+        // matching note on the Anthropic path in CompletionsAnthropic.swift.
+        bodyEncoder.outputFormatting = [.sortedKeys]
         let bodyData = try! bodyEncoder.encode(body)
         DLog("REQUEST:\n\(bodyData.lossyString)")
 //        print(bodyData.lossyString)


### PR DESCRIPTION
The Responses API request body is encoded with a bare `JSONEncoder()` that doesn't set `.sortedKeys`. The tools array serializes Swift dictionaries (`JSONSchema.properties: [String: Property]` and `rawJSONStorage: [String: AnyCodable]`), and dictionary iteration order is randomized per process. So the same tool list can serialize with its keys in a different order from one run to the next.

OpenAI prompt caching keys on a byte-exact prefix match, and the tools live in that cached prefix. Reordered keys change the bytes without changing the meaning, so the cache_read path silently stops firing and every request pays full price.

The fix is to set `outputFormatting = [.sortedKeys]` on that encoder, mirroring what's already done on the Anthropic path in `CompletionsAnthropic.swift`, which has a comment explaining the same caching concern. The wire shape is unchanged; only key order becomes deterministic.

I couldn't build or run this locally since it needs Xcode, so I've kept the change minimal and am relying on CI to verify it compiles. Two edits only: the encoder change in `ResponsesAPIRequest.swift` and a one-line release-notes entry.