### PR TITLE
Fix crash when tmux returns a nil state value

### DIFF
--- a/docs/notes-3.7.txt
+++ b/docs/notes-3.7.txt
@@ -497,6 +497,11 @@ Bug Fixes:
   prefer rich text.
 - Clicking in a porthole in an inactive split
   pane now activates that pane.
+- Fixed a crash (SIGABRT) when attaching with tmux
+  integration (tmux -CC) to a remote server whose
+  tmux version returns an unexpected state field.
+  iTerm2 now logs the bad field and continues
+  instead of aborting.
 - Fixed several crashes: registering a profile
   hotkey for a profile with no GUID, loading a
   profile whose default-bookmark value is a

--- a/iTerm2.xcodeproj/project.pbxproj
+++ b/iTerm2.xcodeproj/project.pbxproj
@@ -700,6 +700,7 @@
 		38C1ECCA9DCF67E64C50E1BC /* iTermRenderingComparer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A64098B399CE71B981E2C7 /* iTermRenderingComparer.swift */; };
 		398447BD6E0F4CA316672068 /* CompanionPairingWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8D4F38B871E9DA9C0AA5E10 /* CompanionPairingWindowController.swift */; };
 		3B049F12D648A9AFEEFCA7A1 /* OpenDirectory.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A60BD9181B3F5D76007D7F11 /* OpenDirectory.framework */; };
+		3B7D01668006EAF08D152B0C /* TmuxStateParserTest.m in Sources */ = {isa = PBXBuildFile; fileRef = AB48E99BCC4A9B8B45479CA0 /* TmuxStateParserTest.m */; };
 		3C8FED766F941C2CB0A070E4 /* iTermCharacterSets.h in Sources */ = {isa = PBXBuildFile; fileRef = 46019892B59C674931043643 /* iTermCharacterSets.h */; };
 		41087F6965EAA157F08289C5 /* iTermCursorBlinkFadeCurveIcon.m in Sources */ = {isa = PBXBuildFile; fileRef = 7057439196C1E9D6AFF58395 /* iTermCursorBlinkFadeCurveIcon.m */; };
 		43640225470B76F4D13E6E86 /* iTermSessionPreviewPanel.m in Sources */ = {isa = PBXBuildFile; fileRef = 434641A807C0B3035264BEF2 /* iTermSessionPreviewPanel.m */; };
@@ -9591,6 +9592,7 @@
 		A6FFAE742CF682D40031FB21 /* iTermDoubleWidthCharacterCache.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = iTermDoubleWidthCharacterCache.m; sourceTree = "<group>"; };
 		A955B14FF6B89D29018C2AEA /* CompanionPushRegistry.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CompanionPushRegistry.swift; sourceTree = "<group>"; };
 		A99A211B9CCCCDFA3692A5C4 /* CompanionSession.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CompanionSession.swift; sourceTree = "<group>"; };
+		AB48E99BCC4A9B8B45479CA0 /* TmuxStateParserTest.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TmuxStateParserTest.m; sourceTree = "<group>"; };
 		ADE0FD36EF2CD108D533CC26 /* CompanionMessages.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CompanionMessages.swift; sourceTree = "<group>"; };
 		AE6718DDCFD2CA382391CDFD /* iTermScreenshotPreviewOverlay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = iTermScreenshotPreviewOverlay.swift; sourceTree = "<group>"; };
 		AEDD42E885AF53FA8193D2E7 /* AILiveAttachmentMatrix.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AILiveAttachmentMatrix.swift; sourceTree = "<group>"; };
@@ -14505,6 +14507,7 @@
 				A60F6FEA270B7F1D0017A003 /* iTermModifyOtherKeys1Test.m */,
 				A603A96729B12CEA000E9E98 /* SearchTests.m */,
 				86FC661122588ABDA0EE3245 /* PTYTextViewAccessibilityTest.m */,
+				AB48E99BCC4A9B8B45479CA0 /* TmuxStateParserTest.m */,
 			);
 			path = iTerm2XCTests;
 			sourceTree = "<group>";
@@ -22055,6 +22058,7 @@
 				A60F6FEC270B7F640017A003 /* iTermModifyOtherKeys1Test.m in Sources */,
 				A608CD27214E09E1007A7B87 /* Model.xcdatamodeld in Sources */,
 				E8BAEA319661F3A7E51D77B1 /* PTYTextViewAccessibilityTest.m in Sources */,
+				3B7D01668006EAF08D152B0C /* TmuxStateParserTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iTerm2XCTests/TmuxStateParserTest.m
+++ b/iTerm2XCTests/TmuxStateParserTest.m
@@ -1,0 +1,88 @@
+//
+//  TmuxStateParserTest.m
+//  iTerm2
+//
+
+#import <XCTest/XCTest.h>
+#import "TmuxStateParser.h"
+
+@interface TmuxStateParserTest : XCTestCase
+@end
+
+@implementation TmuxStateParserTest
+
+// Build a minimal tab-delimited state string for pane 1 with the given
+// extra fields appended.
+- (NSString *)stateWithPaneId:(int)paneId extras:(NSString *)extras {
+    NSString *base = [NSString stringWithFormat:@"pane_id=%%%d", paneId];
+    if (extras.length == 0) {
+        return base;
+    }
+    return [base stringByAppendingFormat:@"\t%@", extras];
+}
+
+- (NSMutableDictionary *)parseState:(NSString *)state forPaneId:(int)paneId {
+    return [[TmuxStateParser sharedInstance] parsedStateFromString:state
+                                                         forPaneId:paneId
+                                                  workAroundTabBug:NO];
+}
+
+// Normal round-trip: known integer and string fields parse to expected types.
+- (void)testNormalParsing {
+    NSString *state = [self stateWithPaneId:1 extras:@"cursor_x=5\tcursor_y=10\twrap_flag=1"];
+    NSDictionary *dict = [self parseState:state forPaneId:1];
+
+    XCTAssertEqualObjects(dict[kStateDictCursorX], @5);
+    XCTAssertEqualObjects(dict[kStateDictCursorY], @10);
+    XCTAssertEqualObjects(dict[kStateDictWrapMode], @1);
+}
+
+// A KVP whose key is the empty string (i.e. the field starts with "=") must
+// be silently skipped rather than inserted into the dictionary with a zero-
+// length key (which could cause downstream keyed lookups to misbehave).
+- (void)testEmptyKeyIsSkipped {
+    // "=orphan_value" has an empty key — this should not crash and the
+    // returned dict should not contain an empty-string key.
+    NSString *state = [self stateWithPaneId:2 extras:@"=orphan_value\tcursor_x=3"];
+    NSDictionary *dict = [self parseState:state forPaneId:2];
+
+    XCTAssertNil(dict[@""], @"Empty key must not be inserted into result");
+    XCTAssertEqualObjects(dict[kStateDictCursorX], @3,
+                          @"Fields after the bad entry must still be parsed");
+}
+
+// An unknown key (one not in fieldTypes) is passed through as a raw NSString.
+// This covers future tmux fields that iTerm2 doesn't yet know about.
+- (void)testUnknownKeyIsPreservedAsString {
+    NSString *state = [self stateWithPaneId:3 extras:@"future_tmux_key=somevalue\tcursor_x=7"];
+    NSDictionary *dict = [self parseState:state forPaneId:3];
+
+    XCTAssertEqualObjects(dict[@"future_tmux_key"], @"somevalue");
+    XCTAssertEqualObjects(dict[kStateDictCursorX], @7);
+}
+
+// A field with no "=" must not crash (already handled before our change, but
+// regression-test it explicitly so we know it stays working).
+- (void)testFieldWithNoEqualsIsIgnored {
+    NSString *state = [self stateWithPaneId:4 extras:@"bogus_no_equals\tcursor_x=2"];
+    NSDictionary *dict = [self parseState:state forPaneId:4];
+
+    XCTAssertNil(dict[@"bogus_no_equals"]);
+    XCTAssertEqualObjects(dict[kStateDictCursorX], @2);
+}
+
+// When the state string contains multiple panes, only the requested pane is
+// returned.
+- (void)testCorrectPaneIsSelected {
+    NSString *pane1 = @"pane_id=%1\tcursor_x=10";
+    NSString *pane2 = @"pane_id=%2\tcursor_x=20";
+    NSString *state = [NSString stringWithFormat:@"%@\n%@", pane1, pane2];
+
+    NSDictionary *dict1 = [self parseState:state forPaneId:1];
+    NSDictionary *dict2 = [self parseState:state forPaneId:2];
+
+    XCTAssertEqualObjects(dict1[kStateDictCursorX], @10);
+    XCTAssertEqualObjects(dict2[kStateDictCursorX], @20);
+}
+
+@end

--- a/sources/tmux/TmuxStateParser.m
+++ b/sources/tmux/TmuxStateParser.m
@@ -155,13 +155,23 @@ NSString *kStateDictPaneKeyMode = @"pane_key_mode";  // tmux 3.5+; reports per-p
         if (eq.location != NSNotFound) {
             NSString *key = [kvp substringToIndex:eq.location];
             NSString *value = [kvp substringFromIndex:eq.location + 1];
+            if (key.length == 0) {
+                continue;
+            }
             NSString *converter = [fieldTypes objectForKey:key];
+            id objectToStore = value;
             if (converter) {
                 SEL sel = NSSelectorFromString(converter);
-                id convertedValue = [value performSelector:sel];
-                [result setObject:convertedValue forKey:key];
+                objectToStore = [value performSelector:sel];
+            }
+            // tmux is an external process (and, with `tmux -CC` to a remote host,
+            // potentially a different version than we expect). Never trust it to
+            // give us a non-nil value: a nil here would cause -setObject:forKey:
+            // to raise NSInvalidArgumentException and abort the whole app.
+            if (objectToStore) {
+                [result setObject:objectToStore forKey:key];
             } else {
-                [result setObject:value forKey:key];
+                NSLog(@"Ignoring nil value for key \"%@\" in tmux state \"%@\"", key, kvp);
             }
         } else if ([kvp length] > 0) {
             NSLog(@"Bogus result in control command: \"%@\"", kvp);


### PR DESCRIPTION
## Problem

iTerm2 aborts (`SIGABRT`) when attaching with tmux integration (`tmux -CC`) to a remote SSH server. The whole app dies, making integration unusable against that server. Plain `tmux` (without `-CC`) is unaffected.

GitLab issue: https://gitlab.com/gnachman/iterm2/-/work_items/12908

Backtrace:
```
-[__NSDictionaryM setObject:forKey:]   *** object cannot be nil
+[TmuxStateParser dictionaryForState:workAroundTabBug:]
-[TmuxStateParser parsedStateFromString:forPaneId:workAroundTabBug:]
-[TmuxWindowOpener dumpStateResponse:pane:]
-[TmuxGateway invokeCurrentCallbackWithError:]
-[TmuxGateway executeToken:]
-[VT100ScreenMutableState(TerminalDelegate) terminalHandleTmuxInput:]_block_invoke
```

## Cause

`+[TmuxStateParser dictionaryForState:workAroundTabBug:]` inserts each parsed pane-state field into an `NSMutableDictionary` with `-setObject:forKey:` and no nil check. tmux is an external process — and with `tmux -CC` to a remote host it may be a different version than expected — so a field can come back in a form that yields a nil object, which makes `-setObject:forKey:` raise `NSInvalidArgumentException`. Nothing catches it, so the app aborts.

## Fix

Guard the insertion in `sources/tmux/TmuxStateParser.m`:
- Skip KVPs with an empty key
- If the value (or its converter result) is nil, log it and skip the field rather than crashing

A bad/unknown field now degrades to iTerm2's existing defaults instead of killing the app. A `NSLog` diagnostic identifies the exact tmux field causing the nil when it fires:
```
Ignoring nil value for key "<KEY>" in tmux state "<KVP>"
```

## Tests

Added `iTerm2XCTests/TmuxStateParserTest.m` with five tests — all pass:

| Test | What it covers |
|------|----------------|
| `testNormalParsing` | Known integer/string fields round-trip correctly (regression) |
| `testEmptyKeyIsSkipped` | A `=value` field (empty key) is silently dropped, not inserted |
| `testUnknownKeyIsPreservedAsString` | Unknown future tmux fields pass through as raw NSString |
| `testFieldWithNoEqualsIsIgnored` | KVPs with no `=` don't crash (pre-existing guard, regression) |
| `testCorrectPaneIsSelected` | Multi-pane state returns only the requested pane |

Run with:
```
xcodebuild test -project iTerm2.xcodeproj -scheme iTerm2Tests \
  -only-testing:iTerm2XCTests/TmuxStateParserTest \
  CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
```