### PR TITLE
fix(tmux integration): reordered the format string for `resize-pane`.

### DIFF
--- a/sources/tmux/TmuxController.m
+++ b/sources/tmux/TmuxController.m
@@ -1889,8 +1889,8 @@ static NSDictionary *iTermTmuxControllerDefaultFontOverridesFromProfile(Profile 
             dir = @"U";
         }
     }
-    NSString *resizeStr = [NSString stringWithFormat:@"resize-pane -%@ -t \"%%%d\" %d",
-                           dir, wp, abs(amount)];
+    NSString *resizeStr = [NSString stringWithFormat:@"resize-pane -t \"%%%d\" -%@ %d ",
+                           wp, dir, abs(amount)];
     NSString *listStr = [self commandToListWindows];
     NSArray *commands = [NSArray arrayWithObjects:
                          [gateway_ dictionaryForCommand:resizeStr


### PR DESCRIPTION
`resize-pane` has undergone some slight api changes. Moved the format specifier for the size arguement so that it is recognized by the direction flag.