### PR TITLE
Add "Force new terminal keyboard" preference and related functionality

### DIFF
--- a/docs/notes-3.7.txt
+++ b/docs/notes-3.7.txt
@@ -1520,6 +1520,12 @@ Bug Fixes:
   silenceable, so you can make it
   always save to Downloads or always
   show a save panel. Issue 12897.
+- Settings > Keys > System adds “Force new
+  terminal keyboard”, which selects a
+  keyboard layout when a newly created
+  terminal first receives keyboard
+  focus. Restored sessions are not
+  affected.
 - Fix a bug where a pane could restore
   in your home directory instead of its
   previous working directory after

--- a/sources/Hacks/InputSourceForcer.swift
+++ b/sources/Hacks/InputSourceForcer.swift
@@ -74,6 +74,22 @@ class InputSourceForcer: NSObject {
         }
     }
 
+    @objc
+    func forceNewTerminalKeyboardForSessionIfNeeded(_ session: PTYSession) {
+        guard session.needsNewTerminalKeyboardForced else {
+            return
+        }
+        guard newTerminalKeyboardForcingEnabled else {
+            return
+        }
+        guard let locale = newTerminalKeyboardDesiredLocale else {
+            return
+        }
+        session.needsNewTerminalKeyboardForced = false
+        RLog("Force new terminal keyboard to \(locale) for session \(session.guid)")
+        setInputLocale(locale)
+    }
+
     @objc private func appDidBecomeActive(notification: Notification) {
         DLog("App did become active in forcer")
         systemLocale = Self.currentSystemLocale
@@ -114,11 +130,26 @@ class InputSourceForcer: NSObject {
         return iTermPreferences.bool(forKey: kPreferenceKeyForceKeyboard)
     }
 
+    private var newTerminalKeyboardForcingEnabled: Bool {
+        return iTermPreferences.bool(forKey: kPreferenceKeyForceNewTerminalKeyboard)
+    }
+
     private var desiredLocale: String? {
         if !forcingEnabled {
             return nil
         }
         return iTermPreferences.string(forKey: kPreferenceKeyKeyboardLocale)
+    }
+
+    private var newTerminalKeyboardDesiredLocale: String? {
+        if !newTerminalKeyboardForcingEnabled {
+            return nil
+        }
+        let locale = iTermPreferences.string(forKey: kPreferenceKeyNewTerminalKeyboardLocale)
+        if locale?.isEmpty == true {
+            return nil
+        }
+        return locale
     }
 
     private func update() {
@@ -140,7 +171,7 @@ class InputSourceForcer: NSObject {
 
     private func setInputLocale(_ keyboardID: String) {
         DLog("System locale is \(systemLocale ?? "none"), switch to \(keyboardID)")
-        precondition(forcingEnabled)
+        precondition(forcingEnabled || newTerminalKeyboardForcingEnabled)
         let inputSources = TISCreateInputSourceList(nil, false).takeRetainedValue() as! [TISInputSource]
         if let inputSource = inputSources.first(where: { inputSource in
             guard let idProperty = TISGetInputSourceProperty(inputSource, kTISPropertyInputSourceID) else {

--- a/sources/PTYSession/PTYSession.h
+++ b/sources/PTYSession/PTYSession.h
@@ -677,6 +677,7 @@ backgroundColor:(nullable NSColor *)backgroundColor;
 @property(nonatomic, readonly) iTermEchoProbe *echoProbe;
 @property(nonatomic, readonly) BOOL canOpenPasswordManager;
 @property(nonatomic) BOOL shortLivedSingleUse;
+@property(nonatomic) BOOL needsNewTerminalKeyboardForced;
 
 // nil unless this session has an active workgroup instance.
 @property(nonatomic, readonly, nullable) NSArray<iTermSessionToolbarItem *> *desiredToolbarItems;

--- a/sources/PTYSession/PTYSession.m
+++ b/sources/PTYSession/PTYSession.m
@@ -12688,6 +12688,7 @@ typedef NS_ENUM(NSUInteger, PTYSessionTmuxReport) {
 
 - (void)textViewDidBecomeFirstResponder {
     DLog(@"textViewDidBecomeFirstResponder for %@", self);
+    [[iTermInputSourceForcer sharedInstance] forceNewTerminalKeyboardForSessionIfNeeded:self];
     [self notifyActive];
 }
 

--- a/sources/SessionCreation/iTermSessionFactory.m
+++ b/sources/SessionCreation/iTermSessionFactory.m
@@ -343,6 +343,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     // Initialize a new session
     aSession = [[PTYSession alloc] initSynthetic:NO];
+    aSession.needsNewTerminalKeyboardForced = YES;
 
     if ([[NSNumber castFrom:profile[KEY_SHORT_LIVED_SINGLE_USE]] boolValue]) {
         aSession.shortLivedSingleUse = YES;

--- a/sources/Settings/KeysPreferencesViewController.m
+++ b/sources/Settings/KeysPreferencesViewController.m
@@ -94,6 +94,8 @@ static NSString *const kKeyCode0MitigationSuffixGlobal = @"Global";
 
     IBOutlet NSButton *_forceKeyboard;
     IBOutlet NSPopUpButton *_keyboardLocale;
+    IBOutlet NSButton *_forceNewTerminalKeyboard;
+    IBOutlet NSPopUpButton *_newTerminalKeyboardLocale;
     IBOutlet NSButton *_allowSymbolicHotKeys;
 
     IBOutlet NSButton *_repairKeyMappingsButton;
@@ -242,6 +244,12 @@ static NSString *const kKeyCode0MitigationSuffixGlobal = @"Global";
                           type:kPreferenceInfoTypeCheckbox];
     info.observer = ^() { [weakSelf updateKeyboardLocaleEnabled]; };
 
+    info = [self defineControl:_forceNewTerminalKeyboard
+                           key:kPreferenceKeyForceNewTerminalKeyboard
+                   relatedView:nil
+                          type:kPreferenceInfoTypeCheckbox];
+    info.observer = ^() { [weakSelf updateKeyboardLocaleEnabled]; };
+
     info = [self defineControl:_allowSymbolicHotKeys
                            key:kPreferenceKeyAllowSymbolicHotKeys
                    relatedView:nil
@@ -250,6 +258,11 @@ static NSString *const kKeyCode0MitigationSuffixGlobal = @"Global";
     info = [self defineControl:_keyboardLocale
                            key:kPreferenceKeyKeyboardLocale
                    displayName:@"Keyboard locale"
+                          type:kPreferenceInfoTypeStringPopup];
+
+    info = [self defineControl:_newTerminalKeyboardLocale
+                           key:kPreferenceKeyNewTerminalKeyboardLocale
+                   displayName:@"New terminal keyboard locale"
                           type:kPreferenceInfoTypeStringPopup];
 
     [self defineControl:_remapModifiersGlobally
@@ -275,8 +288,14 @@ static NSString *const kKeyCode0MitigationSuffixGlobal = @"Global";
 }
 
 - (void)rebuildKeyboardLocales {
-    while (_keyboardLocale.menu.numberOfItems > 0) {
-        [_keyboardLocale.menu removeItemAtIndex:0];
+    [self populateKeyboardLocalePopup:_keyboardLocale forKey:kPreferenceKeyKeyboardLocale];
+    [self populateKeyboardLocalePopup:_newTerminalKeyboardLocale
+                               forKey:kPreferenceKeyNewTerminalKeyboardLocale];
+}
+
+- (void)populateKeyboardLocalePopup:(NSPopUpButton *)popup forKey:(NSString *)key {
+    while (popup.menu.numberOfItems > 0) {
+        [popup.menu removeItemAtIndex:0];
     }
 
     // Convert system input sources into (display name, identifier) tuples.
@@ -309,19 +328,20 @@ static NSString *const kKeyCode0MitigationSuffixGlobal = @"Global";
                                                       action:nil
                                                keyEquivalent:@""];
         item.representedObject = tuple.secondObject;
-        [_keyboardLocale.menu addItem:item];
+        [popup.menu addItem:item];
     }];
 
-    NSString *identifier = [self stringForKey:kPreferenceKeyKeyboardLocale];
+    NSString *identifier = [self stringForKey:key];
     NSInteger i = -1;
     if (identifier) {
-        i = [_keyboardLocale indexOfItemWithRepresentedObject:identifier];
+        i = [popup indexOfItemWithRepresentedObject:identifier];
     }
-    [_keyboardLocale selectItemAtIndex:i];
+    [popup selectItemAtIndex:i];
 }
 
 - (void)updateKeyboardLocaleEnabled {
     _keyboardLocale.enabled = [self boolForKey:kPreferenceKeyForceKeyboard];
+    _newTerminalKeyboardLocale.enabled = [self boolForKey:kPreferenceKeyForceNewTerminalKeyboard];
 }
 
 - (void)viewWillAppear {

--- a/sources/Settings/PreferencePanel.xib
+++ b/sources/Settings/PreferencePanel.xib
@@ -1467,6 +1467,7 @@ CA
                 <outlet property="_configureHotKeyWindow" destination="yqL-PV-QBa" id="ujI-sN-AKS"/>
                 <outlet property="_emulateUSKeyboard" destination="xcI-Ej-rao" id="ikw-qr-450"/>
                 <outlet property="_forceKeyboard" destination="hSH-Ji-OlD" id="R9x-Iy-4Pu"/>
+                <outlet property="_forceNewTerminalKeyboard" destination="NtK-Fc-1Kb" id="NtK-Fc-1Kl"/>
                 <outlet property="_functionButton" destination="0ov-Pi-2Zd" id="Rou-hw-bgx"/>
                 <outlet property="_functionButtonLabel" destination="oJW-wG-mC7" id="qGu-Ez-3jT"/>
                 <outlet property="_hotkeyEnabled" destination="5104" id="QVB-Xu-fmz"/>
@@ -1475,6 +1476,7 @@ CA
                 <outlet property="_keyMappingView" destination="zLA-QA-WQd" id="SJH-CO-sM8"/>
                 <outlet property="_keyMappingViewController" destination="4x3-hD-7hx" id="XhT-BU-0nz"/>
                 <outlet property="_keyboardLocale" destination="3aL-H1-fwF" id="zmk-bH-99v"/>
+                <outlet property="_newTerminalKeyboardLocale" destination="NtK-Fc-1Ke" id="NtK-Fc-1Km"/>
                 <outlet property="_languageAgnosticKeyBindings" destination="1qT-GT-9CH" id="VVz-rT-500"/>
                 <outlet property="_leader" destination="VaP-HN-lHT" id="rt6-SX-aE4"/>
                 <outlet property="_leaderHelpButton" destination="wLd-OV-msN" id="OfG-s4-Npc"/>
@@ -10018,11 +10020,11 @@ You can choose to define the characters considered part of a word with a regular
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="P18-Ge-wyU" customClass="iTermPreferencesInnerTabContainerView">
-                                        <rect key="frame" x="226" y="301" width="590" height="112"/>
+                                        <rect key="frame" x="226" y="237" width="590" height="176"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                                         <subviews>
                                             <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hSH-Ji-OlD">
-                                                <rect key="frame" x="18" y="90" width="120" height="18"/>
+                                                <rect key="frame" x="18" y="154" width="120" height="18"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                 <buttonCell key="cell" type="check" title="Force keyboard" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Fic-QZ-ulj">
                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -10033,7 +10035,7 @@ You can choose to define the characters considered part of a word with a regular
                                                 </connections>
                                             </button>
                                             <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3aL-H1-fwF">
-                                                <rect key="frame" x="143" y="87" width="279" height="25"/>
+                                                <rect key="frame" x="143" y="151" width="279" height="25"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                 <popUpButtonCell key="cell" type="push" title="Item 1" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="m0f-x6-kjR" id="PuV-7d-Dgv">
                                                     <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -10051,12 +10053,52 @@ You can choose to define the characters considered part of a word with a regular
                                                 </connections>
                                             </popUpButton>
                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="g3a-qr-3gt">
-                                                <rect key="frame" x="38" y="48" width="382" height="32"/>
+                                                <rect key="frame" x="38" y="112" width="382" height="32"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                 <textFieldCell key="cell" lineBreakMode="clipping" id="7dn-rM-ht2">
                                                     <font key="font" metaFont="system"/>
                                                     <string key="title">This will force iTerm2 to use the specified keyboard locale
 instead of the system keyboard.</string>
+                                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                </textFieldCell>
+                                            </textField>
+                                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NtK-Fc-1Kb">
+                                                <rect key="frame" x="18" y="90" width="200" height="18"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                <buttonCell key="cell" type="check" title="Force new terminal keyboard" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="NtK-Fc-1Kc">
+                                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                    <font key="font" metaFont="system"/>
+                                                </buttonCell>
+                                                <connections>
+                                                    <action selector="settingChanged:" target="8TE-cq-5cL" id="NtK-Fc-1Kd"/>
+                                                </connections>
+                                            </button>
+                                            <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NtK-Fc-1Ke">
+                                                <rect key="frame" x="223" y="87" width="279" height="25"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                <popUpButtonCell key="cell" type="push" title="Item 1" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="NtK-Fc-1Kf" id="NtK-Fc-1Kg">
+                                                    <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                                    <font key="font" metaFont="message"/>
+                                                    <menu key="menu" id="NtK-Fc-1Kh">
+                                                        <items>
+                                                            <menuItem title="Item 1" state="on" id="NtK-Fc-1Kf"/>
+                                                            <menuItem title="Item 2" id="NtK-Fc-1Ki"/>
+                                                            <menuItem title="Item 3" id="NtK-Fc-1Kj"/>
+                                                        </items>
+                                                    </menu>
+                                                </popUpButtonCell>
+                                                <connections>
+                                                    <action selector="settingChanged:" target="8TE-cq-5cL" id="NtK-Fc-1Kk"/>
+                                                </connections>
+                                            </popUpButton>
+                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NtK-Fc-1Kn">
+                                                <rect key="frame" x="38" y="48" width="520" height="32"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                <textFieldCell key="cell" lineBreakMode="clipping" id="NtK-Fc-1Ko">
+                                                    <font key="font" metaFont="system"/>
+                                                    <string key="title">This will select the specified keyboard locale when a newly
+created terminal first receives keyboard focus.</string>
                                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                 </textFieldCell>

--- a/sources/Settings/iTermPreferences.h
+++ b/sources/Settings/iTermPreferences.h
@@ -303,8 +303,10 @@ extern NSString *const kPreferenceKeyEmulateUSKeyboard;  // See issue 6994
 
 extern NSString *const kPreferenceKeyHotkeyEnabled;
 extern NSString *const kPreferenceKeyForceKeyboard;
+extern NSString *const kPreferenceKeyForceNewTerminalKeyboard;
 extern NSString *const kPreferenceKeyAllowSymbolicHotKeys;
 extern NSString *const kPreferenceKeyKeyboardLocale;
+extern NSString *const kPreferenceKeyNewTerminalKeyboardLocale;
 extern NSString *const kPreferenceKeyHotKeyCode;
 extern NSString *const kPreferenceKeyHotkeyCharacter;
 extern NSString *const kPreferenceKeyHotkeyModifiers;

--- a/sources/Settings/iTermPreferences.m
+++ b/sources/Settings/iTermPreferences.m
@@ -166,8 +166,10 @@ NSString *const kPreferenceKeyEnableSoundForEsc = @"SoundForEsc";
 NSString *const kPreferenceKeyVisualIndicatorForEsc = @"VisualIndicatorForEsc";
 NSString *const kPreferenceKeyLanguageAgnosticKeyBindings = @"LanguageAgnosticKeyBindings";
 NSString *const kPreferenceKeyForceKeyboard = @"ForceKeyboard";  // bool
+NSString *const kPreferenceKeyForceNewTerminalKeyboard = @"ForceNewTerminalKeyboard";  // bool
 NSString *const kPreferenceKeyAllowSymbolicHotKeys = @"AllowSymbolicHotKeys";  // bool
 NSString *const kPreferenceKeyKeyboardLocale = @"KeyboardLocale";  // string
+NSString *const kPreferenceKeyNewTerminalKeyboardLocale = @"NewTerminalKeyboardLocale";  // string
 NSString *const kPreferenceKeyRemapModifiersGlobally = @"RemapModifiersGlobally";  // bool
 NSString *const kPreferenceKeyHotKeyTogglesWindow_Deprecated = @"HotKeyTogglesWindow";  // deprecated
 NSString *const kPreferenceKeyHotkeyProfileGuid_Deprecated = @"HotKeyBookmark";  // deprecated
@@ -802,7 +804,8 @@ static NSString *sPreviousVersion;
                   kPreferenceKeyLeftControlRemapping: @(kPreferencesModifierTagLeftControl),
                   kPreferenceKeyRightControlRemapping: @(kPreferencesModifierTagRightControl),
                   kPreferenceKeyKeyboardLocale: [NSNull null],
-                  
+                  kPreferenceKeyNewTerminalKeyboardLocale: [NSNull null],
+
                   kPreferenceKeyLeftOptionRemapping: @(kPreferencesModifierTagLeftOption),
                   kPreferenceKeyRightOptionRemapping: @(kPreferencesModifierTagRightOption),
                   kPreferenceKeyLeftCommandRemapping: @(kPreferencesModifierTagLeftCommand),
@@ -815,6 +818,7 @@ static NSString *sPreviousVersion;
                   kPreferenceKeyHotkeyEnabled: @NO,
                   kPreferenceKeyRemapModifiersGlobally: @YES,
                   kPreferenceKeyForceKeyboard: @NO,
+                  kPreferenceKeyForceNewTerminalKeyboard: @NO,
                   kPreferenceKeyAllowSymbolicHotKeys: @YES,
                   kPreferenceKeyHotKeyCode: @0,
                   kPreferenceKeyHotkeyCharacter: @0,


### PR DESCRIPTION
This update introduces a new setting in the Keys Preferences to enable a specific keyboard layout for newly created terminal sessions. The implementation includes:

- New preference keys: `kPreferenceKeyForceNewTerminalKeyboard` and `kPreferenceKeyNewTerminalKeyboardLocale`.
- UI elements in the Keys Preferences view for user interaction.
- Logic in `InputSourceForcer` to apply the selected keyboard layout when a new terminal session is created.
- Updates to session management to ensure the new setting is respected.

This feature allows users to have a consistent keyboard layout experience across new terminal sessions, enhancing usability.