### PR TITLE
Fix VoiceOver QuickNav, stale content, and review-cursor jumps in the terminal

### DIFF
--- a/docs/notes-3.7.txt
+++ b/docs/notes-3.7.txt
@@ -2243,3 +2243,14 @@ Bug Fixes:
   these keys to tmux by name so tmux encodes
   them just as it does outside control mode,
   honoring its extended-keys-format.
+- Fix VoiceOver QuickNav navigation not
+  engaging after interacting with the
+  terminal, which previously required
+  toggling QuickNav off and on.
+- Fix VoiceOver reading stale terminal
+  text when the screen was cleared and
+  new output arrived while interacting.
+- Fix VoiceOver focus jumping to the top
+  of the terminal when new output
+  arrived, and make new output reachable
+  without re-interacting.

--- a/sources/TerminalView/PTYTextView.m
+++ b/sources/TerminalView/PTYTextView.m
@@ -3215,17 +3215,6 @@ static NSString *iTermStringForEventPhase(NSEventPhase eventPhase) {
     _accessibilityPendingOutputCursorLineString = nil;
 }
 
-- (void)accessibilityPostOutputLayoutChangedNotification {
-    NSDictionary *info = @{
-        NSAccessibilityUIElementsKey: @[ self ],
-        NSAccessibilityPriorityKey: @(NSAccessibilityPriorityLow)
-    };
-    NSAccessibilityPostNotificationWithUserInfo(
-        self,
-        NSAccessibilityLayoutChangedNotification,
-        info);
-}
-
 + (NSArray<NSString *> *)accessibilityAnnouncementLinesForTrimmedLines:(NSArray<NSString *> *)trimmedLines
                                                      firstAbsoluteLine:(long long)firstAbsoluteLine
                                                        oldAbsoluteCursorY:(long long)oldAbsoluteCursorY
@@ -3278,12 +3267,8 @@ static NSString *iTermStringForEventPhase(NSEventPhase eventPhase) {
 
     AccLog(@"Output settle: firstAbsY=%lld lastAbsY=%lld cursorAbsY=%lld overflow=%lld", firstAbsY, lastAbsY, absCursorY, overflow);
 
-    if (firstAbsY > lastAbsY) {
-        AccLog(@"No lines to announce (firstAbsY > lastAbsY)");
-        [self accessibilityClearPendingOutputState];
-        return;
-    }
-
+    // When firstAbsY > lastAbsY (e.g. a bare clear) the loop collects nothing and no
+    // announcement is made, but the clear+refresh tail below must still run.
     NSMutableArray<NSString *> *trimmedLines = [NSMutableArray array];
     for (long long absLine = firstAbsY; absLine <= lastAbsY; absLine++) {
         int relativeIndex = (int)(absLine - overflow);
@@ -3300,10 +3285,27 @@ static NSString *iTermStringForEventPhase(NSEventPhase eventPhase) {
     AccLog(@"Filtered %@ lines down to %@ (oldCursorLine=\"%@\")", @(trimmedLines.count), @(outputLines.count), _accessibilityPendingOutputCursorLineString);
     if (outputLines.count > 0) {
         [self accessibilityAnnounce:[outputLines componentsJoinedByString:@"\n"] target:NSApp];
-        [self accessibilityPostOutputLayoutChangedNotification];
     }
 
     [self accessibilityClearPendingOutputState];
+
+    // Must come after the announcement so VoiceOver does not read the prompt line
+    // first — the same premature read the in-burst suppression in
+    // -refreshAccessibility exists to prevent.
+    [self accessibilityPostSettleContentRefresh];
+}
+
+// Refresh VoiceOver's cached content after an output burst settles so an active
+// QuickNav interaction can reach the new text. Value-changed alone updates the cached
+// text but VoiceOver does not extend its navigable model until the accompanying
+// selected-text-changed arrives (the same pair -refreshAccessibility posts when not
+// suppressed). Do not post NSAccessibilityLayoutChangedNotification here: with
+// NSAccessibilityUIElementsKey it directs VoiceOver to move its cursor to the listed
+// element, relocating the user's review cursor to the top of the terminal.
+- (void)accessibilityPostSettleContentRefresh {
+    AccLog(@"Post notification: value changed + selected text changed (post-settle)");
+    NSAccessibilityPostNotification(self, NSAccessibilityValueChangedNotification);
+    NSAccessibilityPostNotification(self, NSAccessibilitySelectedTextChangedNotification);
 }
 
 // Update accessibility, to be called periodically.
@@ -6886,6 +6888,25 @@ extendResultsAcrossSoftBoundaries:(BOOL)extendResultsAcrossSoftBoundaries {
 
 - (BOOL)isAccessibilityElement {
     return YES;
+}
+
+// Match Terminal.app's text-area accessibility surface while VoiceOver runs: Terminal
+// exposes neither AXDocument nor a settable AXValue. Advertising them (AXValue is
+// settable only because of the no-op setter kept for Full Keyboard Access, Issue
+// 10023) makes VoiceOver treat the terminal as more than a plain text area and wedges
+// QuickNav when the user interacts with it. The gate keeps Full Keyboard Access
+// working while VoiceOver is off; when both run at once, hiding AXValue wins because
+// QuickNav breaks otherwise. The sibling setAccessibilityContents: needs no gate:
+// AXContents is not advertised at all (it has no getter).
+- (BOOL)isAccessibilitySelectorAllowed:(SEL)selector {
+    // Check the selector first: this method runs for every accessibility attribute
+    // operation, and isVoiceOverEnabled is a preferences lookup, not an ivar read.
+    if ((selector == @selector(accessibilityDocument) ||
+         selector == @selector(setAccessibilityValue:)) &&
+        [[NSWorkspace sharedWorkspace] isVoiceOverEnabled]) {
+        return NO;
+    }
+    return [super isAccessibilitySelectorAllowed:selector];
 }
 
 - (NSInteger)accessibilityLineForIndex:(NSInteger)index {


### PR DESCRIPTION
Fixes three VoiceOver problems when interacting with terminal content, none of which occur in Terminal.app. Reported in https://gitlab.com/gnachman/iterm2/-/issues/12920.

1. QuickNav navigation does not engage after VO-interacting with the terminal until QuickNav is toggled off and on.
2. Content goes stale during an active interaction: after Cmd+K and a new command, VoiceOver keeps reading the pre-clear text and cannot reach the new output without re-interacting.
3. The VoiceOver review cursor jumps to the top of the terminal whenever a command produces output.

Causes and fixes:

- The terminal advertises an AXDocument attribute and a settable AXValue (settable only because of the no-op setter kept for Full Keyboard Access, Issue 10023). That makes VoiceOver treat the view as more than a plain text area, which wedges QuickNav on interaction. Fixed by hiding both from the accessibility surface while VoiceOver is running via isAccessibilitySelectorAllowed:. Full Keyboard Access is unaffected while VoiceOver is off; when both run at once, hiding AXValue wins because QuickNav breaks otherwise.
- The announce-new-output path suppresses value-changed notifications during an output burst and posted layout-changed with NSAccessibilityUIElementsKey once output settled. That notification directs VoiceOver to move its cursor to the listed element — the jump to the top — and since no content notification was re-posted at settle, VoiceOver's cached text went stale during interaction. Fixed by replacing the layout-changed with a value-changed + selected-text-changed pair posted after the announcement: the pair makes VoiceOver refresh its cached content and extend its navigable model (value-changed alone does not) without moving the review cursor. Terminal.app posts the same pair for output and never posts layout-changed for it.

Testing: verified with VoiceOver on macOS 26.5.2 — QuickNav engages immediately on interaction; output announcements still speak; the review cursor holds its position when new output arrives and the new output is reachable by navigating down; shell command history at the prompt and deleted-character announcements are unaffected. Release notes updated.
