### PR TITLE
Honor OSC 22 pointer shapes while mouse reporting is enabled

### DIFF
--- a/sources/PTYSession/PTYSession.m
+++ b/sources/PTYSession/PTYSession.m
@@ -17115,17 +17115,32 @@ typedef NS_ENUM(NSUInteger, PTYSessionTmuxReport) {
 
 - (void)screenSetPointerShape:(NSString *)pointerShape {
     NSDictionary *cursors = @{
-        @"X_cursor": ^{ return [NSCursor arrowCursor]; },
+        @"X_cursor": ^{ return [NSCursor operationNotAllowedCursor]; },
         @"arrow": ^{ return[NSCursor arrowCursor]; },
         @"based_arrow_down": ^{ return[NSCursor resizeDownCursor]; },
         @"based_arrow_up": ^{ return[NSCursor resizeUpCursor]; },
         @"cross": ^{ return[NSCursor crosshairCursor]; },
         @"cross_reverse": ^{ return[NSCursor crosshairCursor]; },
         @"crosshair": ^{ return[NSCursor crosshairCursor]; },
+        @"fleur": ^{ return[NSCursor openHandCursor]; },
         @"hand1": ^{ return[NSCursor pointingHandCursor]; },
         @"hand2": ^{ return[NSCursor pointingHandCursor]; },
         @"left_ptr": ^{ return[NSCursor arrowCursor]; },
         @"left_side": ^{ return[NSCursor resizeLeftCursor]; },
+        @"minus": ^{
+            if (@available(macOS 15.0, *)) {
+                return [NSCursor zoomOutCursor];
+            } else {
+                return [NSCursor crosshairCursor];
+            }
+        },
+        @"plus": ^{
+            if (@available(macOS 15.0, *)) {
+                return [NSCursor zoomInCursor];
+            } else {
+                return [NSCursor crosshairCursor];
+            }
+        },
         @"right_side": ^{ return[NSCursor resizeRightCursor]; },
         @"sb_h_double_arrow": ^{ return[NSCursor resizeLeftRightCursor]; },
         @"sb_left_arrow": ^{ return[NSCursor resizeLeftCursor]; },
@@ -17133,6 +17148,7 @@ typedef NS_ENUM(NSUInteger, PTYSessionTmuxReport) {
         @"sb_up_arrow": ^{ return[NSCursor resizeUpCursor]; },
         @"sb_v_double_arrow": ^{ return[NSCursor resizeUpDownCursor]; },
         @"tcross": ^{ return[NSCursor crosshairCursor]; },
+        @"watch": ^{ return[NSCursor arrowCursor]; },
         @"xterm": ^{ return [iTermMouseCursor mouseCursorOfType:iTermMouseCursorTypeIBeam]; },
     };
     NSCursor *(^f)(void) = cursors[pointerShape];

--- a/sources/TerminalView/PTYTextView+ARC.m
+++ b/sources/TerminalView/PTYTextView+ARC.m
@@ -731,7 +731,13 @@ iTermCommandInfoViewControllerDelegate>
         changed = [self setCursor:[NSCursor arrowCursor]];
     } else if ([_mouseHandler mouseReportingAllowedForEvent:event] &&
                [_mouseHandler terminalWantsMouseReports]) {
-        changed = [self setCursor:[iTermMouseCursor mouseCursorOfType:iTermMouseCursorTypeIBeamWithCircle]];
+        // If the app explicitly requested a pointer shape via OSC 22, honor it
+        // even while mouse reporting is enabled: an app that sets pointer
+        // shapes is mouse-aware, and hover-driven shapes (e.g. Turbo Vision,
+        // vim mouse support) inherently require any-motion reporting. The
+        // IBeamWithCircle affordance remains the fallback when no shape was
+        // requested.
+        changed = [self setCursor:self.delegate.textViewDefaultPointer ?: [iTermMouseCursor mouseCursorOfType:iTermMouseCursorTypeIBeamWithCircle]];
     } else if ([self contextMenu:_contextMenuHelper offscreenCommandLineForClickAt:event.locationInWindow]) {
         changed = [self setCursor:[NSCursor arrowCursor]];
     } else if ([self mouseIsOverButtonInEvent:event]) {


### PR DESCRIPTION
## Summary

Applications can set the mouse pointer shape with OSC 22 (kitty pointer-shape protocol), which iTerm2 parses and stores. However, `-[PTYTextView updateCursor:action:]` short-circuits to the IBeamWithCircle cursor whenever the app has mouse reporting enabled and never consults the stored shape, which is only reached in the final `else` branch. Since hover-dependent pointer shapes require any-motion reporting (DECSET 1003) to detect hovering in the first place, the feature could never be seen exactly when mouse-aware applications need it: the requested shape only appeared once the application disabled mouse reporting.

## Changes

- `PTYTextView+ARC.m`, `updateCursor:action:`: in the mouse-reporting branch, prefer the app-requested pointer
  (`self.delegate.textViewDefaultPointer`) and keep IBeamWithCircle as the fallback when no shape was requested. The IBeamWithCircle cursor exists to tell the user that mouse input is being sent to the running application.
  An application that requests a pointer shape via OSC 22 clearly handles mouse input already, so that hint is unnecessary and the requested pointer can be shown instead. Behavior with no OSC 22 shape set is unchanged.
- `PTYSession.m`, `screenSetPointerShape:`: add missing X cursor font names from the kitty spec — `fleur` (open hand), `watch` (arrow), `plus` / `minus` (zoom in/out) — and map `X_cursor` to `operationNotAllowedCursor` instead of the arrow. The zoom cursors are macOS 15 API, so they are `@available(macOS 15.0, *)`-guarded with a crosshair fallback to respect the 12.4 deployment target.

## Reproduction

Run inside iTerm2 and move the mouse pointer within the window:

```sh
#!/usr/bin/env bash
# Mode 1003 makes the terminal send a report to stdin for every mouse
# movement. Disable echo so the reports are not printed, and drain them so
# they are not delivered to the shell when the script exits.
old_stty=$(stty -g)
stty -echo -icanon min 0 time 0
drain() { while IFS= read -rs -t 0.05 -n 512 _; do :; done; }
trap 'drain; stty "$old_stty"' EXIT

printf 'Enabling any-motion mouse reporting (CSI ?1003h)\n'
printf '\033[?1003h'
printf 'Requesting pointing-hand pointer via OSC 22 (hand2)\n'
printf '\033]22;hand2\a'
printf 'Watch the pointer for 5 seconds: it stays the default pointer (in unpatched version)\n'
sleep 5
drain # optional, prevent mouse movement info output to stdout
printf 'Disabling any-motion mouse reporting (CSI ?1003l)\n'
printf '\033[?1003l'
printf 'Watch the pointer for 5 seconds: it only NOW becomes the pointing hand (in unpatched version)\n'
sleep 5
printf 'Resetting the pointer shape\n'
printf '\033]22;\a'
printf 'Done\n'
```

## Testing

- Built the Development configuration and compared against an unpatched build using the script above: unpatched shows the hand only after `1003 l`; patched shows it immediately while 1003 is active.
- Verified end to end with a TUI application (Turbo Vision fork) that enables 1003, tracks hover, and emits OSC 22 on hover changes: pointer shapes (hand, I-beam, crosshair) now follow hover live. Resetting with `OSC 22 ;` and disabling mouse reporting restore the default pointer.
- No change in behavior for applications that never emit OSC 22.
