### PR TITLE
Add support for videos as background images

### DIFF
--- a/docs/notes-3.7.txt
+++ b/docs/notes-3.7.txt
@@ -91,6 +91,13 @@ Major New Features:
   code review or perform in-terminal diffs of a
   git repo.
 
+- Background images can now be videos (mp4 or
+  mov). Videos play muted in a seamless loop
+  and respect the blend and scaling settings.
+  They work with both the GPU and legacy
+  renderers, and panes showing the same video
+  share one decoder.
+
 - Clippings is a new side panel that contains a
   list of items formatted as markdown. They're a
   useful place to store text that you need

--- a/docs/notes-3.7.txt
+++ b/docs/notes-3.7.txt
@@ -93,10 +93,14 @@ Major New Features:
 
 - Background images can now be videos (mp4 or
   mov). Videos play muted in a seamless loop
-  and respect the blend and scaling settings.
-  They work with both the GPU and legacy
-  renderers, and panes showing the same video
-  share one decoder.
+  and respect the blend and scaling settings,
+  except tiling, which is not offered for
+  videos. They work with both the GPU and
+  legacy renderers, and panes showing the same
+  video share one decoder. Playback pauses
+  when no window can show it, so a covered,
+  minimized, or off-Space window costs
+  nothing.
 
 - Clippings is a new side panel that contains a
   list of items formatted as markdown. They're a

--- a/sources/Drawing/iTermSharedImageStore.h
+++ b/sources/Drawing/iTermSharedImageStore.h
@@ -6,6 +6,8 @@
 //
 
 #import <AppKit/AppKit.h>
+#import <AVFoundation/AVFoundation.h>
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -18,9 +20,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) CGImageRef cgimage;
 // Size of largest rep
 @property (nonatomic, readonly) NSSize scaledSize;
+// When the wrapped file is a video, image holds a placeholder (the poster
+// frame, once it loads asynchronously) and videoURL locates the file so views
+// can play it. Playback happens in iTermImageView; renderers that can only
+// draw still images fall back to the poster frame.
+@property (nonatomic, readonly, nullable) NSURL *videoURL;
+@property (nonatomic, readonly) BOOL isVideo;
 
 + (instancetype _Nullable)withContentsOfFile:(NSString *)path;
 + (instancetype)withImage:(NSImage *)image;
+
+// Container formats AVFoundation can reliably decode for background videos.
++ (NSArray<UTType *> *)videoContentTypes;
++ (BOOL)pathIsVideo:(NSString *)path;
+
+// One muted, looping player is shared by every consumer of this wrapper —
+// AVPlayerLayers in image views and the Metal renderer alike — so a video
+// used in several panes decodes once. Playback runs while at least one
+// consumer holds an interest. Call these on the main queue.
+- (void)retainVideoPlaybackInterest;
+- (void)releaseVideoPlaybackInterest;
+// Nil for non-videos. Created on first access; main queue only.
+@property (nonatomic, readonly, nullable) AVQueuePlayer *videoPlayer;
+// The output vends BGRA pixel buffers for the Metal renderer. Nil until
+// videoPlayer or a playback interest has created the player. Safe to read
+// from the render thread; AVPlayerItemVideoOutput itself is thread-safe.
+@property (atomic, readonly, nullable) AVPlayerItemVideoOutput *videoOutput;
 
 - (instancetype)initWithImage:(NSImage *)image NS_DESIGNATED_INITIALIZER;
 - (instancetype)init NS_UNAVAILABLE;

--- a/sources/Drawing/iTermSharedImageStore.h
+++ b/sources/Drawing/iTermSharedImageStore.h
@@ -7,7 +7,11 @@
 
 #import <AppKit/AppKit.h>
 #import <AVFoundation/AVFoundation.h>
+#import <CoreVideo/CoreVideo.h>
+#import <CoreVideo/CVMetalTextureCache.h>
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
+
+@protocol MTLDevice;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -22,8 +26,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) NSSize scaledSize;
 // When the wrapped file is a video, image holds a placeholder (the poster
 // frame, once it loads asynchronously) and videoURL locates the file so views
-// can play it. Playback happens in iTermImageView; renderers that can only
-// draw still images fall back to the poster frame.
+// can play it. iTermImageView plays it with an AVPlayerLayer and the GPU
+// renderer samples frames through copyVideoPixelBufferForHostTime:generation:;
+// consumers that can only draw still images fall back to the poster frame.
 @property (nonatomic, readonly, nullable) NSURL *videoURL;
 @property (nonatomic, readonly) BOOL isVideo;
 
@@ -42,10 +47,32 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)releaseVideoPlaybackInterest;
 // Nil for non-videos. Created on first access; main queue only.
 @property (nonatomic, readonly, nullable) AVQueuePlayer *videoPlayer;
-// The output vends BGRA pixel buffers for the Metal renderer. Nil until
-// videoPlayer or a playback interest has created the player. Safe to read
-// from the render thread; AVPlayerItemVideoOutput itself is thread-safe.
-@property (atomic, readonly, nullable) AVPlayerItemVideoOutput *videoOutput;
+
+// Vends the Metal texture for the video frame that should be visible at
+// hostTime, for GPU renderers drawing on the given device.
+//
+// An AVPlayerItemVideoOutput is single-consumer: copying a pixel buffer marks
+// it acquired, so if each pane's renderer pulled from the output directly, only
+// the first pane to ask would get any given frame and the others would be stuck
+// one frame behind — visible as a flickering seam at split dividers when panes
+// share one background image. Instead this owns the pull, dequeueing at most
+// once per display refresh, and vends one texture per frame so every pane
+// sampling this wrapper in a given refresh samples the identical texture.
+//
+// generation identifies the frame the caller is showing: pass 0 if it has none.
+// Returns NULL when no frame has decoded yet or when the visible frame is still
+// the one identified by *generation — either way the caller should keep showing
+// what it has. Otherwise returns a texture the caller owns (release it with
+// CFRelease, and keep it alive for as long as the GPU may sample it) and sets
+// *generation to identify it.
+//
+// A texture is cached per device, so a second GPU — an eGPU, or the discrete
+// GPU on a dual-GPU Mac — gets its own. Safe to call from any thread; does not
+// create the player, so playback must already be under way (see
+// retainVideoPlaybackInterest).
+- (nullable CVMetalTextureRef)copyVideoMetalTextureForHostTime:(CFTimeInterval)hostTime
+                                                        device:(id<MTLDevice>)device
+                                                    generation:(inout NSInteger *)generation CF_RETURNS_RETAINED;
 
 - (instancetype)initWithImage:(NSImage *)image NS_DESIGNATED_INITIALIZER;
 - (instancetype)init NS_UNAVAILABLE;

--- a/sources/Drawing/iTermSharedImageStore.m
+++ b/sources/Drawing/iTermSharedImageStore.m
@@ -11,6 +11,7 @@
 #import "NSArray+iTerm.h"
 #import "NSImage+iTerm.h"
 #import "NSObject+iTerm.h"
+#import <AVFoundation/AVFoundation.h>
 #import <QuartzCore/QuartzCore.h>
 
 @interface NSFileManager(CachedImage)
@@ -111,13 +112,25 @@
 
 @end
 
+static void *iTermImageWrapperCurrentItemContext = &iTermImageWrapperCurrentItemContext;
+
 @implementation iTermImageWrapper {
     id _cgimage;
     NSMutableDictionary<NSNumber *, NSImage *> *_tilingImages;
     NSMutableDictionary<NSString *, NSBitmapImageRep *> *_reps;
+
+    AVQueuePlayer *_videoPlayer;
+    AVPlayerLooper *_videoLooper;
+    AVPlayerItemVideoOutput *_videoOutput;
+    NSInteger _videoPlaybackInterestCount;
 }
 
+@synthesize videoOutput = _videoOutput;
+
 + (instancetype)withContentsOfFile:(NSString *)path {
+    if ([self pathIsVideo:path]) {
+        return [[self alloc] initWithVideoURL:[NSURL fileURLWithPath:path]];
+    }
     NSImage *image = [[NSImage alloc] initWithContentsOfFile:path];
     if (!image) {
         return nil;
@@ -127,6 +140,142 @@
 
 + (instancetype)withImage:(NSImage *)image {
     return [[self alloc] initWithImage:image];
+}
+
++ (NSArray<UTType *> *)videoContentTypes {
+    return @[ UTTypeMPEG4Movie, UTTypeQuickTimeMovie ];
+}
+
++ (BOOL)pathIsVideo:(NSString *)path {
+    NSString *extension = path.pathExtension;
+    if (extension.length == 0) {
+        return NO;
+    }
+    UTType *type = [UTType typeWithFilenameExtension:extension];
+    if (!type) {
+        return NO;
+    }
+    for (UTType *videoType in [self videoContentTypes]) {
+        if ([type conformsToType:videoType]) {
+            return YES;
+        }
+    }
+    return NO;
+}
+
+- (instancetype)initWithVideoURL:(NSURL *)url {
+    // The placeholder keeps image-only consumers working until the poster
+    // frame arrives; views that can play video ignore it.
+    self = [self initWithImage:[[NSImage alloc] initWithSize:NSMakeSize(1, 1)]];
+    if (self) {
+        _videoURL = [url copy];
+        [self loadPosterFrame];
+    }
+    return self;
+}
+
+- (BOOL)isVideo {
+    return _videoURL != nil;
+}
+
+- (void)loadPosterFrame {
+    AVURLAsset *asset = [AVURLAsset URLAssetWithURL:_videoURL options:nil];
+    AVAssetImageGenerator *generator = [[AVAssetImageGenerator alloc] initWithAsset:asset];
+    generator.appliesPreferredTrackTransform = YES;
+    __weak __typeof(self) weakSelf = self;
+    [generator generateCGImagesAsynchronouslyForTimes:@[ [NSValue valueWithCMTime:kCMTimeZero] ]
+                                    completionHandler:^(CMTime requestedTime,
+                                                        CGImageRef _Nullable cgImage,
+                                                        CMTime actualTime,
+                                                        AVAssetImageGeneratorResult result,
+                                                        NSError * _Nullable error) {
+        if (result != AVAssetImageGeneratorSucceeded || !cgImage) {
+            DLog(@"Failed to generate poster frame: %@", error);
+            return;
+        }
+        NSImage *poster = [[NSImage alloc] initWithCGImage:cgImage
+                                                      size:NSMakeSize(CGImageGetWidth(cgImage),
+                                                                      CGImageGetHeight(cgImage))];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [weakSelf setPosterFrame:poster];
+        });
+    }];
+}
+
+// Main queue only. Replaces the placeholder and invalidates derived caches.
+- (void)setPosterFrame:(NSImage *)poster {
+    _image = poster;
+    _cgimage = nil;
+    [_tilingImages removeAllObjects];
+    [_reps removeAllObjects];
+}
+
+#pragma mark - Video playback
+
+- (AVQueuePlayer *)videoPlayer {
+    if (!self.isVideo) {
+        return nil;
+    }
+    if (!_videoPlayer) {
+        AVPlayerItem *item = [AVPlayerItem playerItemWithURL:_videoURL];
+        _videoPlayer = [AVQueuePlayer queuePlayerWithItems:@[ item ]];
+        _videoPlayer.muted = YES;
+        _videoPlayer.preventsDisplaySleepDuringVideoPlayback = NO;
+        _videoLooper = [AVPlayerLooper playerLooperWithPlayer:_videoPlayer templateItem:item];
+        _videoOutput = [[AVPlayerItemVideoOutput alloc] initWithPixelBufferAttributes:@{
+            (id)kCVPixelBufferPixelFormatTypeKey: @(kCVPixelFormatType_32BGRA),
+            (id)kCVPixelBufferMetalCompatibilityKey: @YES
+        }];
+        // AVPlayerLooper rotates through replica items, so the output must
+        // chase the current item; observing with Initial covers the first one.
+        [_videoPlayer addObserver:self
+                       forKeyPath:@"currentItem"
+                          options:NSKeyValueObservingOptionInitial | NSKeyValueObservingOptionNew
+                          context:iTermImageWrapperCurrentItemContext];
+    }
+    return _videoPlayer;
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath
+                      ofObject:(id)object
+                        change:(NSDictionary *)change
+                       context:(void *)context {
+    if (context != iTermImageWrapperCurrentItemContext) {
+        [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
+        return;
+    }
+    AVPlayerItem *item = _videoPlayer.currentItem;
+    if (item && _videoOutput && ![item.outputs containsObject:_videoOutput]) {
+        [item addOutput:_videoOutput];
+    }
+}
+
+- (void)retainVideoPlaybackInterest {
+    if (!self.isVideo) {
+        return;
+    }
+    _videoPlaybackInterestCount += 1;
+    if (_videoPlaybackInterestCount == 1) {
+        [self.videoPlayer play];
+    }
+}
+
+- (void)releaseVideoPlaybackInterest {
+    if (!self.isVideo) {
+        return;
+    }
+    _videoPlaybackInterestCount = MAX(0, _videoPlaybackInterestCount - 1);
+    if (_videoPlaybackInterestCount == 0) {
+        [_videoPlayer pause];
+    }
+}
+
+- (void)dealloc {
+    if (_videoPlayer) {
+        [_videoPlayer removeObserver:self
+                          forKeyPath:@"currentItem"
+                             context:iTermImageWrapperCurrentItemContext];
+    }
 }
 
 - (instancetype)initWithImage:(NSImage *)unsafeImage {

--- a/sources/Drawing/iTermSharedImageStore.m
+++ b/sources/Drawing/iTermSharedImageStore.m
@@ -12,7 +12,9 @@
 #import "NSImage+iTerm.h"
 #import "NSObject+iTerm.h"
 #import <AVFoundation/AVFoundation.h>
+#import <Metal/Metal.h>
 #import <QuartzCore/QuartzCore.h>
+#import <os/lock.h>
 
 @interface NSFileManager(CachedImage)
 - (NSDate *)lastModifiedDateOfFile:(NSString *)path;
@@ -113,6 +115,85 @@
 @end
 
 static void *iTermImageWrapperCurrentItemContext = &iTermImageWrapperCurrentItemContext;
+static const CFTimeInterval iTermImageWrapperDefaultDisplayRefreshPeriod = 1.0 / 60.0;
+
+// A Metal texture cache for one GPU, plus the texture it produced for the frame
+// currently latched. Every pane drawing on that GPU shares the texture, so a
+// frame is wrapped once no matter how many panes show it. Not thread safe; the
+// wrapper calls into it under its own lock.
+@interface iTermVideoTextureCache: NSObject
+- (nullable instancetype)initWithDevice:(id<MTLDevice>)device NS_DESIGNATED_INITIALIZER;
+- (instancetype)init NS_UNAVAILABLE;
+// Returns a retained texture for pixelBuffer, reusing the previous one when
+// generation is unchanged.
+- (nullable CVMetalTextureRef)copyTextureForPixelBuffer:(CVPixelBufferRef)pixelBuffer
+                                             generation:(NSInteger)generation CF_RETURNS_RETAINED;
+@end
+
+@implementation iTermVideoTextureCache {
+    CVMetalTextureCacheRef _cache;
+    CVMetalTextureRef _texture;
+    NSInteger _generation;
+}
+
+- (instancetype)initWithDevice:(id<MTLDevice>)device {
+    self = [super init];
+    if (self) {
+        const CVReturn err = CVMetalTextureCacheCreate(kCFAllocatorDefault,
+                                                       NULL,
+                                                       device,
+                                                       NULL,
+                                                       &_cache);
+        if (err != kCVReturnSuccess || !_cache) {
+            DLog(@"CVMetalTextureCacheCreate failed: %d", err);
+            return nil;
+        }
+    }
+    return self;
+}
+
+- (void)dealloc {
+    if (_texture) {
+        CFRelease(_texture);
+    }
+    if (_cache) {
+        CFRelease(_cache);
+    }
+}
+
+- (CVMetalTextureRef)copyTextureForPixelBuffer:(CVPixelBufferRef)pixelBuffer
+                                     generation:(NSInteger)generation {
+    if (_texture && _generation == generation) {
+        return (CVMetalTextureRef)CFRetain(_texture);
+    }
+    CVMetalTextureRef texture = NULL;
+    const CVReturn err =
+        CVMetalTextureCacheCreateTextureFromImage(kCFAllocatorDefault,
+                                                  _cache,
+                                                  pixelBuffer,
+                                                  NULL,
+                                                  MTLPixelFormatBGRA8Unorm,
+                                                  CVPixelBufferGetWidth(pixelBuffer),
+                                                  CVPixelBufferGetHeight(pixelBuffer),
+                                                  0,
+                                                  &texture);
+    if (err != kCVReturnSuccess || !texture) {
+        DLog(@"CVMetalTextureCacheCreateTextureFromImage failed: %d", err);
+        return NULL;
+    }
+    if (_texture) {
+        CFRelease(_texture);
+    }
+    _texture = texture;
+    _generation = generation;
+    // Textures for retired frames sit in the cache until it is flushed, and a
+    // frame change is the only time one can be retired. Anything a renderer
+    // still holds a reference to survives this.
+    CVMetalTextureCacheFlush(_cache, 0);
+    return (CVMetalTextureRef)CFRetain(_texture);
+}
+
+@end
 
 @implementation iTermImageWrapper {
     id _cgimage;
@@ -123,9 +204,21 @@ static void *iTermImageWrapperCurrentItemContext = &iTermImageWrapperCurrentItem
     AVPlayerLooper *_videoLooper;
     AVPlayerItemVideoOutput *_videoOutput;
     NSInteger _videoPlaybackInterestCount;
-}
 
-@synthesize videoOutput = _videoOutput;
+    // Guards everything below. The main queue creates and mutates the player
+    // while renderers pull frames on their metal drivers’ private queues.
+    // _videoOutput is only ever written on the main queue, so main-queue code
+    // may read it without the lock; anything off the main queue must not.
+    os_unfair_lock _videoLock;
+    // The frame every consumer sees until the next display refresh, the refresh
+    // it was latched for, and a counter that changes only when the frame does.
+    CVPixelBufferRef _latchedPixelBuffer;
+    int64_t _latchedTick;
+    NSInteger _videoFrameGeneration;
+    CFTimeInterval _displayRefreshPeriod;
+    // Keyed by MTLDevice registry ID.
+    NSMutableDictionary<NSNumber *, iTermVideoTextureCache *> *_videoTextureCaches;
+}
 
 + (instancetype)withContentsOfFile:(NSString *)path {
     if ([self pathIsVideo:path]) {
@@ -222,15 +315,20 @@ static void *iTermImageWrapperCurrentItemContext = &iTermImageWrapperCurrentItem
         _videoPlayer.muted = YES;
         _videoPlayer.preventsDisplaySleepDuringVideoPlayback = NO;
         _videoLooper = [AVPlayerLooper playerLooperWithPlayer:_videoPlayer templateItem:item];
-        _videoOutput = [[AVPlayerItemVideoOutput alloc] initWithPixelBufferAttributes:@{
+        AVPlayerItemVideoOutput *output = [[AVPlayerItemVideoOutput alloc] initWithPixelBufferAttributes:@{
             (id)kCVPixelBufferPixelFormatTypeKey: @(kCVPixelFormatType_32BGRA),
             (id)kCVPixelBufferMetalCompatibilityKey: @YES
         }];
+        os_unfair_lock_lock(&_videoLock);
+        _videoOutput = output;
+        os_unfair_lock_unlock(&_videoLock);
         // AVPlayerLooper rotates through replica items, so the output must
         // chase the current item; observing with Initial covers the first one.
         [_videoPlayer addObserver:self
                        forKeyPath:@"currentItem"
-                          options:NSKeyValueObservingOptionInitial | NSKeyValueObservingOptionNew
+                          options:(NSKeyValueObservingOptionInitial |
+                                   NSKeyValueObservingOptionOld |
+                                   NSKeyValueObservingOptionNew)
                           context:iTermImageWrapperCurrentItemContext];
     }
     return _videoPlayer;
@@ -244,10 +342,101 @@ static void *iTermImageWrapperCurrentItemContext = &iTermImageWrapperCurrentItem
         [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
         return;
     }
+    if (!_videoOutput) {
+        return;
+    }
+    // An AVPlayerItemVideoOutput may be attached to only one AVPlayerItem at a
+    // time, and AVPlayerLooper keeps its replica items alive and rotates
+    // currentItem among them as the video loops. Detach from the item being
+    // left before attaching to the new one; otherwise the wrap either stops the
+    // output vending buffers or throws for a double attachment.
+    AVPlayerItem *previous = [AVPlayerItem castFrom:change[NSKeyValueChangeOldKey]];
+    if (previous && [previous.outputs containsObject:_videoOutput]) {
+        [previous removeOutput:_videoOutput];
+    }
     AVPlayerItem *item = _videoPlayer.currentItem;
-    if (item && _videoOutput && ![item.outputs containsObject:_videoOutput]) {
+    if (item && ![item.outputs containsObject:_videoOutput]) {
         [item addOutput:_videoOutput];
     }
+}
+
+// The latch below advances once per display refresh, so it needs a refresh
+// rate. The main screen’s is an approximation — a wrapper can be shown on
+// several screens at once — and resampling it whenever playback starts is
+// enough to pick up a move between a 60Hz and a ProMotion display. Being stale
+// only caps the frame rate at the other screen’s. Main queue only.
+- (void)updateDisplayRefreshPeriod {
+    const NSInteger fps = NSScreen.mainScreen.maximumFramesPerSecond;
+    const CFTimeInterval period = fps > 0 ? 1.0 / (CFTimeInterval)fps : iTermImageWrapperDefaultDisplayRefreshPeriod;
+    os_unfair_lock_lock(&_videoLock);
+    _displayRefreshPeriod = period;
+    os_unfair_lock_unlock(&_videoLock);
+}
+
+// Advances the shared frame at most once per display refresh. Call with
+// _videoLock held.
+- (void)latchVideoFrameForHostTime:(CFTimeInterval)hostTime {
+    AVPlayerItemVideoOutput *output = _videoOutput;
+    if (!output) {
+        return;
+    }
+    const int64_t tick = (int64_t)floor(hostTime / _displayRefreshPeriod);
+    if (tick == _latchedTick) {
+        return;
+    }
+    // First consumer to ask for this refresh does the dequeue; the rest get
+    // what it latched. Mark the refresh as handled even when no new frame was
+    // ready so the others don’t each re-ask the output.
+    _latchedTick = tick;
+    const CMTime itemTime = [output itemTimeForHostTime:hostTime];
+    if (![output hasNewPixelBufferForItemTime:itemTime]) {
+        return;
+    }
+    CVPixelBufferRef pixelBuffer = [output copyPixelBufferForItemTime:itemTime
+                                                  itemTimeForDisplay:NULL];
+    if (!pixelBuffer) {
+        return;
+    }
+    if (_latchedPixelBuffer) {
+        CVPixelBufferRelease(_latchedPixelBuffer);
+    }
+    _latchedPixelBuffer = pixelBuffer;
+    _videoFrameGeneration += 1;
+}
+
+- (CVMetalTextureRef)copyVideoMetalTextureForHostTime:(CFTimeInterval)hostTime
+                                               device:(id<MTLDevice>)device
+                                           generation:(inout NSInteger *)generation {
+    if (!self.isVideo || !device) {
+        return NULL;
+    }
+    os_unfair_lock_lock(&_videoLock);
+    [self latchVideoFrameForHostTime:hostTime];
+    if (!_latchedPixelBuffer || (generation && *generation == _videoFrameGeneration)) {
+        // Nothing decoded yet, or the caller is already showing this frame.
+        os_unfair_lock_unlock(&_videoLock);
+        return NULL;
+    }
+    NSNumber *key = @(device.registryID);
+    iTermVideoTextureCache *cache = _videoTextureCaches[key];
+    if (!cache) {
+        cache = [[iTermVideoTextureCache alloc] initWithDevice:device];
+        if (!cache) {
+            os_unfair_lock_unlock(&_videoLock);
+            return NULL;
+        }
+        if (!_videoTextureCaches) {
+            _videoTextureCaches = [NSMutableDictionary dictionary];
+        }
+        _videoTextureCaches[key] = cache;
+    }
+    CVMetalTextureRef texture = [cache copyTextureForPixelBuffer:_latchedPixelBuffer
+                                                      generation:_videoFrameGeneration];
+    if (texture && generation) {
+        *generation = _videoFrameGeneration;
+    }
+    os_unfair_lock_unlock(&_videoLock);
+    return texture;
 }
 
 - (void)retainVideoPlaybackInterest {
@@ -257,6 +446,7 @@ static void *iTermImageWrapperCurrentItemContext = &iTermImageWrapperCurrentItem
     _videoPlaybackInterestCount += 1;
     if (_videoPlaybackInterestCount == 1) {
         [self.videoPlayer play];
+        [self updateDisplayRefreshPeriod];
     }
 }
 
@@ -276,6 +466,9 @@ static void *iTermImageWrapperCurrentItemContext = &iTermImageWrapperCurrentItem
                           forKeyPath:@"currentItem"
                              context:iTermImageWrapperCurrentItemContext];
     }
+    if (_latchedPixelBuffer) {
+        CVPixelBufferRelease(_latchedPixelBuffer);
+    }
 }
 
 - (instancetype)initWithImage:(NSImage *)unsafeImage {
@@ -283,6 +476,9 @@ static void *iTermImageWrapperCurrentItemContext = &iTermImageWrapperCurrentItem
     if (self) {
         _reps = [NSMutableDictionary dictionary];
         _tilingImages = [NSMutableDictionary dictionary];
+        _videoLock = OS_UNFAIR_LOCK_INIT;
+        _latchedTick = INT64_MIN;
+        _displayRefreshPeriod = iTermImageWrapperDefaultDisplayRefreshPeriod;
         NSImage *image = unsafeImage;
         if (unsafeImage.size.height > 0 && unsafeImage.size.width > 0) {
             // Downscale to deal with issue 9346

--- a/sources/MetalRenderer/Renderers/iTermBackgroundImageRenderer.m
+++ b/sources/MetalRenderer/Renderers/iTermBackgroundImageRenderer.m
@@ -9,6 +9,9 @@
 #import "iTermShaderTypes.h"
 #import "iTermSharedImageStore.h"
 
+#import <AVFoundation/AVFoundation.h>
+#import <CoreVideo/CoreVideo.h>
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface iTermBackgroundImageRendererTransientState ()
@@ -55,6 +58,14 @@ NS_ASSUME_NONNULL_BEGIN
     CGRect _frame;
     CGRect _containerFrame;
     vector_float4 _color;
+
+    // Video backgrounds: pixel buffers from the wrapper's AVPlayerItemVideoOutput
+    // are wrapped as Metal textures through this cache. The CVMetalTexture that
+    // backs the current and previous frame must stay alive until the GPU is done
+    // sampling them, hence the keep-alive references.
+    CVMetalTextureCacheRef _videoTextureCache;
+    id _videoTextureKeepAlive;
+    id _previousVideoTextureKeepAlive;
 }
 
 - (nullable instancetype)initWithDevice:(id<MTLDevice>)device {
@@ -78,6 +89,12 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (void)dealloc {
+    if (_videoTextureCache) {
+        CFRelease(_videoTextureCache);
+    }
+}
+
 - (BOOL)rendererDisabled {
     return NO;
 }
@@ -93,17 +110,83 @@ NS_ASSUME_NONNULL_BEGIN
            color:(vector_float4)defaultBackgroundColor
       colorSpace:(NSColorSpace *)colorSpace
          context:(nullable iTermMetalBufferPoolContext *)context {
-    DLog(@"setImage:%@ mode:%@ frame:%@ containerRect:%@", 
+    DLog(@"setImage:%@ mode:%@ frame:%@ containerRect:%@",
          image.image, @(mode), NSStringFromRect(frame), NSStringFromRect(containerRect));
     if (image != _image) {
         RLog(@"Will create texture from image");
+        // For videos this is the poster frame; it covers the gap until the
+        // first decoded frame arrives below.
         _texture = image ? [_metalRenderer textureFromImage:image context:context colorSpace:colorSpace] : nil;
+        _videoTextureKeepAlive = nil;
+        _previousVideoTextureKeepAlive = nil;
+    }
+    if (image.isVideo) {
+        id<MTLTexture> videoTexture = [self dequeueVideoTextureForImage:image];
+        if (videoTexture) {
+            _texture = videoTexture;
+        }
     }
     _frame = frame;
     _color = defaultBackgroundColor;
     _containerFrame = containerRect;
     _image = image;
     _mode = mode;
+}
+
+// Returns a texture for the video frame that should be visible now, or nil
+// to keep showing the previous one.
+- (nullable id<MTLTexture>)dequeueVideoTextureForImage:(iTermImageWrapper *)image {
+    AVPlayerItemVideoOutput *output = image.videoOutput;
+    if (!output) {
+        return nil;
+    }
+    const CMTime itemTime = [output itemTimeForHostTime:CACurrentMediaTime()];
+    if (![output hasNewPixelBufferForItemTime:itemTime]) {
+        return nil;
+    }
+    CVPixelBufferRef pixelBuffer = [output copyPixelBufferForItemTime:itemTime itemTimeForDisplay:NULL];
+    if (!pixelBuffer) {
+        return nil;
+    }
+    id<MTLTexture> texture = [self textureFromPixelBuffer:pixelBuffer];
+    CVPixelBufferRelease(pixelBuffer);
+    return texture;
+}
+
+- (nullable id<MTLTexture>)textureFromPixelBuffer:(CVPixelBufferRef)pixelBuffer {
+    if (!_videoTextureCache) {
+        const CVReturn err = CVMetalTextureCacheCreate(kCFAllocatorDefault,
+                                                       NULL,
+                                                       _metalRenderer.device,
+                                                       NULL,
+                                                       &_videoTextureCache);
+        if (err != kCVReturnSuccess) {
+            DLog(@"CVMetalTextureCacheCreate failed: %d", err);
+            return nil;
+        }
+    }
+    const size_t width = CVPixelBufferGetWidth(pixelBuffer);
+    const size_t height = CVPixelBufferGetHeight(pixelBuffer);
+    CVMetalTextureRef cvTexture = NULL;
+    const CVReturn err = CVMetalTextureCacheCreateTextureFromImage(kCFAllocatorDefault,
+                                                                   _videoTextureCache,
+                                                                   pixelBuffer,
+                                                                   NULL,
+                                                                   MTLPixelFormatBGRA8Unorm,
+                                                                   width,
+                                                                   height,
+                                                                   0,
+                                                                   &cvTexture);
+    if (err != kCVReturnSuccess || !cvTexture) {
+        DLog(@"CVMetalTextureCacheCreateTextureFromImage failed: %d", err);
+        return nil;
+    }
+    id<MTLTexture> texture = CVMetalTextureGetTexture(cvTexture);
+    // The previous frame's GPU work has completed by the time a new frame
+    // replaces the previous keep-alive, so retaining two generations is enough.
+    _previousVideoTextureKeepAlive = _videoTextureKeepAlive;
+    _videoTextureKeepAlive = (__bridge_transfer id)cvTexture;
+    return texture;
 }
 
 #if ENABLE_TRANSPARENT_METAL_WINDOWS

--- a/sources/MetalRenderer/Renderers/iTermBackgroundImageRenderer.m
+++ b/sources/MetalRenderer/Renderers/iTermBackgroundImageRenderer.m
@@ -9,8 +9,8 @@
 #import "iTermShaderTypes.h"
 #import "iTermSharedImageStore.h"
 
-#import <AVFoundation/AVFoundation.h>
 #import <CoreVideo/CoreVideo.h>
+#import <QuartzCore/QuartzCore.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -25,6 +25,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) vector_float4 defaultBackgroundColor;
 @property (nullable, nonatomic, strong) id<MTLBuffer> box1;
 @property (nullable, nonatomic, strong) id<MTLBuffer> box2;
+// The CVMetalTexture that backs texture when it holds a video frame. texture
+// does not retain it, so it is parked here to keep the underlying IOSurface
+// alive for as long as this state lives — which is until the frame’s command
+// buffer completes, however many frames the driver keeps in flight.
+@property (nullable, nonatomic, strong) id videoTextureKeepAlive;
 @end
 
 @implementation iTermBackgroundImageRendererTransientState
@@ -59,13 +64,14 @@ NS_ASSUME_NONNULL_BEGIN
     CGRect _containerFrame;
     vector_float4 _color;
 
-    // Video backgrounds: pixel buffers from the wrapper's AVPlayerItemVideoOutput
-    // are wrapped as Metal textures through this cache. The CVMetalTexture that
-    // backs the current and previous frame must stay alive until the GPU is done
-    // sampling them, hence the keep-alive references.
-    CVMetalTextureCacheRef _videoTextureCache;
+    // Video backgrounds: the wrapper owns the decode and vends one Metal
+    // texture per frame, shared by every pane drawing that video on this
+    // device, so all of them sample the same frame. Each transient state takes
+    // its own reference to the CVMetalTexture it samples, so this only has to
+    // hold the one _texture currently points at.
     id _videoTextureKeepAlive;
-    id _previousVideoTextureKeepAlive;
+    // Which of the wrapper's frames _texture was built from. 0 means none.
+    NSInteger _videoFrameGeneration;
 }
 
 - (nullable instancetype)initWithDevice:(id<MTLDevice>)device {
@@ -87,12 +93,6 @@ NS_ASSUME_NONNULL_BEGIN
         _solidColorPool = [[iTermMetalBufferPool alloc] initWithDevice:device bufferSize:sizeof(vector_float4)];
     }
     return self;
-}
-
-- (void)dealloc {
-    if (_videoTextureCache) {
-        CFRelease(_videoTextureCache);
-    }
 }
 
 - (BOOL)rendererDisabled {
@@ -118,7 +118,7 @@ NS_ASSUME_NONNULL_BEGIN
         // first decoded frame arrives below.
         _texture = image ? [_metalRenderer textureFromImage:image context:context colorSpace:colorSpace] : nil;
         _videoTextureKeepAlive = nil;
-        _previousVideoTextureKeepAlive = nil;
+        _videoFrameGeneration = 0;
     }
     if (image.isVideo) {
         id<MTLTexture> videoTexture = [self dequeueVideoTextureForImage:image];
@@ -136,55 +136,17 @@ NS_ASSUME_NONNULL_BEGIN
 // Returns a texture for the video frame that should be visible now, or nil
 // to keep showing the previous one.
 - (nullable id<MTLTexture>)dequeueVideoTextureForImage:(iTermImageWrapper *)image {
-    AVPlayerItemVideoOutput *output = image.videoOutput;
-    if (!output) {
-        return nil;
-    }
-    const CMTime itemTime = [output itemTimeForHostTime:CACurrentMediaTime()];
-    if (![output hasNewPixelBufferForItemTime:itemTime]) {
-        return nil;
-    }
-    CVPixelBufferRef pixelBuffer = [output copyPixelBufferForItemTime:itemTime itemTimeForDisplay:NULL];
-    if (!pixelBuffer) {
-        return nil;
-    }
-    id<MTLTexture> texture = [self textureFromPixelBuffer:pixelBuffer];
-    CVPixelBufferRelease(pixelBuffer);
-    return texture;
-}
-
-- (nullable id<MTLTexture>)textureFromPixelBuffer:(CVPixelBufferRef)pixelBuffer {
-    if (!_videoTextureCache) {
-        const CVReturn err = CVMetalTextureCacheCreate(kCFAllocatorDefault,
-                                                       NULL,
-                                                       _metalRenderer.device,
-                                                       NULL,
-                                                       &_videoTextureCache);
-        if (err != kCVReturnSuccess) {
-            DLog(@"CVMetalTextureCacheCreate failed: %d", err);
-            return nil;
-        }
-    }
-    const size_t width = CVPixelBufferGetWidth(pixelBuffer);
-    const size_t height = CVPixelBufferGetHeight(pixelBuffer);
-    CVMetalTextureRef cvTexture = NULL;
-    const CVReturn err = CVMetalTextureCacheCreateTextureFromImage(kCFAllocatorDefault,
-                                                                   _videoTextureCache,
-                                                                   pixelBuffer,
-                                                                   NULL,
-                                                                   MTLPixelFormatBGRA8Unorm,
-                                                                   width,
-                                                                   height,
-                                                                   0,
-                                                                   &cvTexture);
-    if (err != kCVReturnSuccess || !cvTexture) {
-        DLog(@"CVMetalTextureCacheCreateTextureFromImage failed: %d", err);
+    CVMetalTextureRef cvTexture = [image copyVideoMetalTextureForHostTime:CACurrentMediaTime()
+                                                                   device:_metalRenderer.device
+                                                               generation:&_videoFrameGeneration];
+    if (!cvTexture) {
         return nil;
     }
     id<MTLTexture> texture = CVMetalTextureGetTexture(cvTexture);
-    // The previous frame's GPU work has completed by the time a new frame
-    // replaces the previous keep-alive, so retaining two generations is enough.
-    _previousVideoTextureKeepAlive = _videoTextureKeepAlive;
+    if (!texture) {
+        CFRelease(cvTexture);
+        return nil;
+    }
     _videoTextureKeepAlive = (__bridge_transfer id)cvTexture;
     return texture;
 }
@@ -312,6 +274,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)initializeTransientState:(iTermBackgroundImageRendererTransientState *)tState {
     tState.texture = _texture;
+    tState.videoTextureKeepAlive = _videoTextureKeepAlive;
     tState.mode = _mode;
     tState.imageSize = _image.image.size;
     tState.imageScale = [_image.image recommendedLayerContentsScale:tState.configuration.scale];

--- a/sources/PTYSession/PTYSession.m
+++ b/sources/PTYSession/PTYSession.m
@@ -621,6 +621,12 @@ typedef NS_ENUM(NSUInteger, PTYSessionTurdType) {
     iTermSwiftyString *_subtitleSwiftyString;
     iTermSwiftyString *_backgroundImageSwiftyString;
 
+    // Retained while this session keeps its video background playing for the
+    // Metal renderer. The layer path (iTermImageView) holds its own interest,
+    // so this is only non-nil when Metal draws the video. Reconciled in
+    // updateVideoBackgroundPlaybackInterest.
+    iTermImageWrapper *_videoBackgroundInterestImage;
+
     iTermSessionTabStatus *_tabStatus;
 
     iTermBackgroundDrawingHelper *_backgroundDrawingHelper;
@@ -1092,6 +1098,8 @@ ITERM_WEAKLY_REFERENCEABLE
     _nonTextPasteHelper.delegate = nil;
     [_nonTextPasteHelper release];
     [_backgroundImage release];
+    [_videoBackgroundInterestImage releaseVideoPlaybackInterest];
+    [_videoBackgroundInterestImage release];
     [_antiIdleTimer invalidate];
     [_cadenceController release];
     [_originalProfile release];
@@ -6294,6 +6302,22 @@ webViewConfiguration:(WKWebViewConfiguration *)webViewConfiguration
     [_backgroundImage autorelease];
     _backgroundImage = [backgroundImage retain];
     [self updateViewBackgroundImage];
+    [self updateVideoBackgroundPlaybackInterest];
+}
+
+// While the Metal renderer displays a video background, hold a playback
+// interest on the wrapper so its shared player runs. The layer path takes
+// care of itself through iTermImageView's visibility tracking.
+- (void)updateVideoBackgroundPlaybackInterest {
+    iTermImageWrapper *effective = self.effectiveBackgroundImage;
+    iTermImageWrapper *desired = (_useMetal && effective.isVideo) ? effective : nil;
+    if (desired == _videoBackgroundInterestImage) {
+        return;
+    }
+    [_videoBackgroundInterestImage releaseVideoPlaybackInterest];
+    [_videoBackgroundInterestImage release];
+    _videoBackgroundInterestImage = [desired retain];
+    [_videoBackgroundInterestImage retainVideoPlaybackInterest];
 }
 
 - (void)setSmartCursorColor:(BOOL)value {
@@ -6983,9 +7007,17 @@ webViewConfiguration:(WKWebViewConfiguration *)webViewConfiguration
     const BOOL transientTitle = _delegate.realParentWindow.isShowingTransientTitle;
     const BOOL animationPlaying = _textview.getAndResetDrawingAnimatedImageFlag;
 
+    // A video background needs frames drawn at the display cadence even when
+    // the terminal itself is quiet, just like inline animated GIFs.
+    [self updateVideoBackgroundPlaybackInterest];
+    const BOOL videoBackgroundPlaying = (_videoBackgroundInterestImage != nil);
+    if (videoBackgroundPlaying) {
+        [_view.metalView setNeedsDisplay:YES];
+    }
+
     // Even if "active" isn't changing we need the side effect of setActive: that updates the
     // cadence since we might have just become idle.
-    self.active = (somethingIsBlinking || transientTitle || animationPlaying);
+    self.active = (somethingIsBlinking || transientTitle || animationPlaying || videoBackgroundPlaying);
 
     if (_view.findViewIsHidden) {
         [_tailFindController stopContinuousTailFind];
@@ -8820,6 +8852,7 @@ extendResultsAcrossSoftBoundaries:(BOOL)extendResultsAcrossSoftBoundaries {
     }
     [_textview requestDelegateRedraw];
     [_cadenceController changeCadenceIfNeeded];
+    [self updateVideoBackgroundPlaybackInterest];
 
     if (useMetal) {
         [self renderTwoMetalFramesAndShowMetalView];

--- a/sources/PTYSession/PTYSession.m
+++ b/sources/PTYSession/PTYSession.m
@@ -1028,6 +1028,10 @@ typedef NS_ENUM(NSUInteger, PTYSessionTurdType) {
                                                  selector:@selector(broadcastDomainsDidChange:)
                                                      name:iTermBroadcastDomainsDidChangeNotification
                                                    object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(windowOcclusionDidChange:)
+                                                     name:NSWindowDidChangeOcclusionStateNotification
+                                                   object:nil];
         [[[NSWorkspace sharedWorkspace] notificationCenter] addObserver:self
                                                                selector:@selector(activeSpaceDidChange:)
                                                                    name:NSWorkspaceActiveSpaceDidChangeNotification
@@ -6310,7 +6314,10 @@ webViewConfiguration:(WKWebViewConfiguration *)webViewConfiguration
 // care of itself through iTermImageView's visibility tracking.
 - (void)updateVideoBackgroundPlaybackInterest {
     iTermImageWrapper *effective = self.effectiveBackgroundImage;
-    iTermImageWrapper *desired = (_useMetal && effective.isVideo) ? effective : nil;
+    const BOOL wanted = (_useMetal &&
+                         effective.isVideo &&
+                         [self videoBackgroundIsOnScreen]);
+    iTermImageWrapper *desired = wanted ? effective : nil;
     if (desired == _videoBackgroundInterestImage) {
         return;
     }
@@ -6318,6 +6325,30 @@ webViewConfiguration:(WKWebViewConfiguration *)webViewConfiguration
     [_videoBackgroundInterestImage release];
     _videoBackgroundInterestImage = [desired retain];
     [_videoBackgroundInterestImage retainVideoPlaybackInterest];
+    if (_videoBackgroundInterestImage) {
+        // Nothing else kicks the first frame when the terminal is quiet: the
+        // cadence only speeds up once it has seen the video playing, and
+        // -updateDisplayBecause: is what notices. Without this, setting a video
+        // on an idle session decodes but shows a frozen frame until some
+        // unrelated event forces a redraw.
+        self.active = YES;
+        [_view.metalView setNeedsDisplay:YES];
+    }
+}
+
+// A video only needs to decode while somebody can see it. occlusionState
+// reports not-visible for a window that is fully covered, miniaturized, or on
+// another Space — none of which the view hierarchy reveals.
+- (BOOL)videoBackgroundIsOnScreen {
+    NSWindow *window = self.view.window;
+    if (!window) {
+        return NO;
+    }
+    return (window.occlusionState & NSWindowOcclusionStateVisible) != 0;
+}
+
+- (void)windowOcclusionDidChange:(NSNotification *)notification {
+    [self updateVideoBackgroundPlaybackInterest];
 }
 
 - (void)setSmartCursorColor:(BOOL)value {

--- a/sources/Settings/ProfilesWindowPreferencesViewController.m
+++ b/sources/Settings/ProfilesWindowPreferencesViewController.m
@@ -13,6 +13,7 @@
 #import "iTermFunctionCallTextFieldDelegate.h"
 #import "iTermImageWell.h"
 #import "iTermPreferences.h"
+#import "iTermSharedImageStore.h"
 #import "iTermSizeRememberingView.h"
 #import "iTerm2SharedARC-Swift.h"
 #import "iTermSystemVersion.h"
@@ -24,6 +25,7 @@
 #import "NSTextField+iTerm.h"
 #import "NSView+iTerm.h"
 #import "PreferencePanel.h"
+#import <AVFoundation/AVFoundation.h>
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 
 // On macOS 10.13, we see that blur over 26 can turn red (issue 6138).
@@ -818,12 +820,13 @@ typedef NS_ENUM(NSUInteger, iTermWindowUnitsTag) {
     panel.canChooseFiles = YES;
     panel.allowsMultipleSelection = NO;
     panel.treatsFilePackagesAsDirectories = NO;
-    panel.message = @"Choose an image for the background, or a folder to rotate through its images.";
-    // Image-only filter dims non-image files. Folders stay selectable because
+    panel.message = @"Choose an image or short video for the background, or a folder to rotate through its images.";
+    // Image/video-only filter dims other files. Folders stay selectable because
     // canChooseDirectories=YES treats them as containers, not content.
-    panel.allowedContentTypes = [NSImage.imageTypes mapWithBlock:^id _Nullable(NSString *ext) {
+    NSArray<UTType *> *imageTypes = [NSImage.imageTypes mapWithBlock:^id _Nullable(NSString *ext) {
         return [UTType typeWithIdentifier:ext];
     }];
+    panel.allowedContentTypes = [imageTypes arrayByAddingObjectsFromArray:[iTermImageWrapper videoContentTypes]];
 
     void (^completion)(NSInteger) = ^(NSInteger result) {
         if (result == NSModalResponseOK) {
@@ -871,6 +874,26 @@ typedef NS_ENUM(NSUInteger, iTermWindowUnitsTag) {
         [self setUnsignedInteger:iTermBackgroundImageSourceModeFolderRotation
                           forKey:KEY_BACKGROUND_IMAGE_SOURCE_MODE];
         [self updateControlForKey:KEY_BACKGROUND_IMAGE_FOLDER_LOCATION];
+    } else if ([iTermImageWrapper pathIsVideo:path]) {
+        __weak __typeof(self) weakSelf = self;
+        [self checkVideo:path completion:^(BOOL ok) {
+            __strong __typeof(weakSelf) strongSelf = weakSelf;
+            if (!strongSelf) {
+                return;
+            }
+            if (!ok) {
+                [strongSelf loadBackgroundImageForCurrentSource];
+                return;
+            }
+            [strongSelf setString:path forKey:KEY_BACKGROUND_IMAGE_LOCATION];
+            [strongSelf setUnsignedInteger:iTermBackgroundImageSourceModeSingleImage
+                                    forKey:KEY_BACKGROUND_IMAGE_SOURCE_MODE];
+            [strongSelf updateControlForKey:KEY_BACKGROUND_IMAGE_LOCATION];
+            [strongSelf synchronizeBackgroundImageEnabledState];
+            [strongSelf loadBackgroundImageForCurrentSource];
+            [strongSelf updateBackgroundImageUI];
+        }];
+        return;
     } else {
         [self checkImage:path];
         [self setString:path forKey:KEY_BACKGROUND_IMAGE_LOCATION];
@@ -938,6 +961,10 @@ typedef NS_ENUM(NSUInteger, iTermWindowUnitsTag) {
 
 // Sets _backgroundImagePreview and _useBackgroundImage.
 - (void)loadBackgroundImageWithFilename:(NSString *)filename {
+    if (filename.length > 0 && [iTermImageWrapper pathIsVideo:filename]) {
+        [self loadBackgroundVideoPreviewWithFilename:filename];
+        return;
+    }
     NSImage *anImage = filename.length > 0 ? [[NSImage alloc] initWithContentsOfFile:[filename stringByExpandingTildeInPath]] : nil;
     if (anImage) {
         [_backgroundImagePreview setImage:anImage];
@@ -949,6 +976,36 @@ typedef NS_ENUM(NSUInteger, iTermWindowUnitsTag) {
     [self updatePrivateNonDefaultInicators];
 }
 
+// Shows the video’s first frame in _backgroundImagePreview.
+- (void)loadBackgroundVideoPreviewWithFilename:(NSString *)filename {
+    self.backgroundImageFilename = filename;
+    AVURLAsset *asset = [AVURLAsset URLAssetWithURL:[NSURL fileURLWithPath:[filename stringByExpandingTildeInPath]] options:nil];
+    AVAssetImageGenerator *generator = [[AVAssetImageGenerator alloc] initWithAsset:asset];
+    generator.appliesPreferredTrackTransform = YES;
+    __weak __typeof(self) weakSelf = self;
+    [generator generateCGImagesAsynchronouslyForTimes:@[ [NSValue valueWithCMTime:kCMTimeZero] ]
+                                    completionHandler:^(CMTime requestedTime,
+                                                        CGImageRef _Nullable cgImage,
+                                                        CMTime actualTime,
+                                                        AVAssetImageGeneratorResult result,
+                                                        NSError * _Nullable error) {
+        NSImage *thumbnail = nil;
+        if (result == AVAssetImageGeneratorSucceeded && cgImage) {
+            thumbnail = [[NSImage alloc] initWithCGImage:cgImage
+                                                    size:NSMakeSize(CGImageGetWidth(cgImage),
+                                                                    CGImageGetHeight(cgImage))];
+        }
+        dispatch_async(dispatch_get_main_queue(), ^{
+            __strong __typeof(weakSelf) strongSelf = weakSelf;
+            if (!strongSelf || ![strongSelf.backgroundImageFilename isEqualToString:filename]) {
+                return;
+            }
+            [strongSelf->_backgroundImagePreview setImage:thumbnail];
+            [strongSelf updatePrivateNonDefaultInicators];
+        });
+    }];
+}
+
 - (void)updateNonDefaultIndicators {
     [super updateNonDefaultIndicators];
     [self updatePrivateNonDefaultInicators];
@@ -956,6 +1013,42 @@ typedef NS_ENUM(NSUInteger, iTermWindowUnitsTag) {
 
 - (void)updatePrivateNonDefaultInicators {
     _useBackgroundImage.it_showNonDefaultIndicator = [iTermPreferences boolForKey:kPreferenceKeyIndicateNonDefaultValues] && _useBackgroundImage.state == NSControlStateValueOn;
+}
+
+// Calls completion on the main queue with YES if the video is usable as a background.
+- (void)checkVideo:(NSString *)filename completion:(void (^)(BOOL))completion {
+    AVURLAsset *asset = [AVURLAsset URLAssetWithURL:[NSURL fileURLWithPath:filename] options:nil];
+    __weak __typeof(self) weakSelf = self;
+    [asset loadValuesAsynchronouslyForKeys:@[ @"playable" ] completionHandler:^{
+        dispatch_async(dispatch_get_main_queue(), ^{
+            __strong __typeof(weakSelf) strongSelf = weakSelf;
+            if (!strongSelf) {
+                completion(NO);
+                return;
+            }
+            NSError *error = nil;
+            const BOOL loaded = [asset statusOfValueForKey:@"playable" error:&error] == AVKeyValueStatusLoaded;
+            if (!loaded || !asset.isPlayable) {
+                [iTermWarning showWarningWithTitle:[NSString stringWithFormat:@"The video “%@” could not be loaded because it is corrupt or not a supported format.", filename.lastPathComponent]
+                                           actions:@[ @"OK" ]
+                                         accessory:nil
+                                        identifier:@"BackgroundVideoUnreadable"
+                                       silenceable:kiTermWarningTypePersistent
+                                           heading:@"Problem Loading Video"
+                                            window:strongSelf.view.window];
+                completion(NO);
+                return;
+            }
+            [iTermWarning showWarningWithTitle:@"Background videos play continuously while the window is visible. High-resolution or high-frame-rate videos increase energy use, which matters most on battery power."
+                                       actions:@[ @"OK" ]
+                                     accessory:nil
+                                    identifier:@"BackgroundVideoEnergyUse"
+                                   silenceable:kiTermWarningTypePermanentlySilenceable
+                                       heading:@"Video Backgrounds and Energy"
+                                        window:strongSelf.view.window];
+            completion(YES);
+        });
+    }];
 }
 
 - (BOOL)checkImage:(NSString *)filename {

--- a/sources/Settings/ProfilesWindowPreferencesViewController.m
+++ b/sources/Settings/ProfilesWindowPreferencesViewController.m
@@ -889,6 +889,7 @@ typedef NS_ENUM(NSUInteger, iTermWindowUnitsTag) {
             [strongSelf setUnsignedInteger:iTermBackgroundImageSourceModeSingleImage
                                     forKey:KEY_BACKGROUND_IMAGE_SOURCE_MODE];
             [strongSelf updateControlForKey:KEY_BACKGROUND_IMAGE_LOCATION];
+            [strongSelf updateControlForKey:KEY_BACKGROUND_IMAGE_SOURCE_MODE];
             [strongSelf synchronizeBackgroundImageEnabledState];
             [strongSelf loadBackgroundImageForCurrentSource];
             [strongSelf updateBackgroundImageUI];
@@ -941,6 +942,14 @@ typedef NS_ENUM(NSUInteger, iTermWindowUnitsTag) {
     _backgroundImageFolderIntervalLabel.labelEnabled = usesFolderRotation;
     _rotationIntervalUnitsLabel.labelEnabled = usesFolderRotation;
     _backgroundImageFolderIntervalField.enabled = usesFolderRotation;
+
+    // Both renderers fall back to Scale to Fill when asked to tile a video, so
+    // don't offer a mode that won't be honored. The stored value is deliberately
+    // left alone: going back to a still image restores what the user picked.
+    NSString *path = usesFolderRotation ? nil : [self stringForKey:KEY_BACKGROUND_IMAGE_LOCATION];
+    const BOOL isVideo = path.length > 0 && [iTermImageWrapper pathIsVideo:path];
+    NSPopUpButton *modePopup = [NSPopUpButton castFrom:_backgroundImageMode];
+    [modePopup.menu itemWithTag:iTermBackgroundImageModeTile].enabled = !isVideo;
 }
 
 - (void)synchronizeBackgroundImageEnabledState {
@@ -1047,13 +1056,19 @@ typedef NS_ENUM(NSUInteger, iTermWindowUnitsTag) {
                 completion(NO);
                 return;
             }
-            [iTermWarning showWarningWithTitle:@"Background videos play continuously while the window is visible. High-resolution or high-frame-rate videos increase energy use, which matters most on battery power."
-                                       actions:@[ @"OK" ]
-                                     accessory:nil
-                                    identifier:@"BackgroundVideoEnergyUse"
-                                   silenceable:kiTermWarningTypePermanentlySilenceable
-                                       heading:@"Video Backgrounds and Energy"
-                                        window:strongSelf.view.window];
+            // Re-picking the video that is already configured is a normal thing
+            // to do, and nagging about energy again for a setting the user has
+            // not changed just trains them to silence the notice.
+            NSString *current = [strongSelf stringForKey:KEY_BACKGROUND_IMAGE_LOCATION];
+            if (![filename isEqualToString:current]) {
+                [iTermWarning showWarningWithTitle:@"Background videos play continuously while the window is visible. High-resolution or high-frame-rate videos increase energy use, which matters most on battery power."
+                                           actions:@[ @"OK" ]
+                                         accessory:nil
+                                        identifier:@"BackgroundVideoEnergyUse"
+                                       silenceable:kiTermWarningTypePermanentlySilenceable
+                                           heading:@"Video Backgrounds and Energy"
+                                            window:strongSelf.view.window];
+            }
             completion(YES);
         });
     }];

--- a/sources/Settings/ProfilesWindowPreferencesViewController.m
+++ b/sources/Settings/ProfilesWindowPreferencesViewController.m
@@ -1019,7 +1019,7 @@ typedef NS_ENUM(NSUInteger, iTermWindowUnitsTag) {
 - (void)checkVideo:(NSString *)filename completion:(void (^)(BOOL))completion {
     AVURLAsset *asset = [AVURLAsset URLAssetWithURL:[NSURL fileURLWithPath:filename] options:nil];
     __weak __typeof(self) weakSelf = self;
-    [asset loadValuesAsynchronouslyForKeys:@[ @"playable" ] completionHandler:^{
+    [asset loadValuesAsynchronouslyForKeys:@[ @"playable", @"tracks" ] completionHandler:^{
         dispatch_async(dispatch_get_main_queue(), ^{
             __strong __typeof(weakSelf) strongSelf = weakSelf;
             if (!strongSelf) {
@@ -1027,9 +1027,17 @@ typedef NS_ENUM(NSUInteger, iTermWindowUnitsTag) {
                 return;
             }
             NSError *error = nil;
-            const BOOL loaded = [asset statusOfValueForKey:@"playable" error:&error] == AVKeyValueStatusLoaded;
-            if (!loaded || !asset.isPlayable) {
-                [iTermWarning showWarningWithTitle:[NSString stringWithFormat:@"The video “%@” could not be loaded because it is corrupt or not a supported format.", filename.lastPathComponent]
+            const BOOL loaded = ([asset statusOfValueForKey:@"playable" error:&error] == AVKeyValueStatusLoaded &&
+                                 [asset statusOfValueForKey:@"tracks" error:&error] == AVKeyValueStatusLoaded);
+            // isPlayable is also YES for an asset with no usable video track —
+            // an audio-only .mov, for instance. Accepting one would store it as
+            // the background, produce no poster frame, and then render black
+            // with nothing to explain why, so require a video track too.
+            const BOOL usable = (loaded &&
+                                 asset.isPlayable &&
+                                 [asset tracksWithMediaType:AVMediaTypeVideo].count > 0);
+            if (!usable) {
+                [iTermWarning showWarningWithTitle:[NSString stringWithFormat:@"The video “%@” could not be loaded because it is corrupt, is not a supported format, or has no video track.", filename.lastPathComponent]
                                            actions:@[ @"OK" ]
                                          accessory:nil
                                         identifier:@"BackgroundVideoUnreadable"

--- a/sources/Settings/ProfilesWindowPreferencesViewController.m
+++ b/sources/Settings/ProfilesWindowPreferencesViewController.m
@@ -949,6 +949,9 @@ typedef NS_ENUM(NSUInteger, iTermWindowUnitsTag) {
     NSString *path = usesFolderRotation ? nil : [self stringForKey:KEY_BACKGROUND_IMAGE_LOCATION];
     const BOOL isVideo = path.length > 0 && [iTermImageWrapper pathIsVideo:path];
     NSPopUpButton *modePopup = [NSPopUpButton castFrom:_backgroundImageMode];
+    // Menu validation runs when the popup opens and would re-enable the item
+    // out from under us, leaving Tile selectable but drawn as though disabled.
+    modePopup.autoenablesItems = NO;
     [modePopup.menu itemWithTag:iTermBackgroundImageModeTile].enabled = !isVideo;
 }
 

--- a/sources/TerminalView/iTermImageView.m
+++ b/sources/TerminalView/iTermImageView.m
@@ -11,7 +11,9 @@
 #import "iTermMalloc.h"
 #import "NSArray+iTerm.h"
 #import "NSImage+iTerm.h"
+#import "NSObject+iTerm.h"
 
+#import <AVFoundation/AVFoundation.h>
 #import <QuartzCore/QuartzCore.h>
 
 @interface CALayer (CALayerAdditions)
@@ -138,6 +140,16 @@
 
 @implementation iTermInternalImageView {
     CGFloat _lastTilingScale;
+
+    // Set only while showing a video background. The player layer sits on top
+    // of self.layer and inherits the superview's alpha, so blend and
+    // transparency work the same as for still images. The player itself is
+    // owned by the image wrapper and shared with other consumers; we hold a
+    // playback interest on _playbackInterestImage while visible. That may
+    // lag _image briefly during an image change, which is why it's tracked
+    // separately: the release must go to the wrapper that was retained.
+    AVPlayerLayer *_playerLayer;
+    iTermImageWrapper *_playbackInterestImage;
 }
 
 - (instancetype)initWithFrame:(NSRect)frameRect {
@@ -164,6 +176,10 @@
                                                    object:nil];
     }
     return self;
+}
+
+- (void)dealloc {
+    [_playbackInterestImage releaseVideoPlaybackInterest];
 }
 
 - (void)setBlend:(CGFloat)blend {
@@ -214,6 +230,7 @@
     [super setHidden:hidden];
 
     [CATransaction commit];
+    [self updateVideoPlaybackState];
 }
 
 - (void)update {
@@ -226,6 +243,11 @@
 }
 
 - (void)reallyUpdate {
+    if (_image.isVideo) {
+        [self loadVideo];
+        return;
+    }
+    [self destroyVideoPlayer];
     switch (_contentMode) {
         case iTermBackgroundImageModeTile:
             [self loadTiledImage];
@@ -257,6 +279,89 @@
     _lastTilingScale = -1;
 }
 
+#pragma mark - Video
+
+- (AVLayerVideoGravity)desiredVideoGravity {
+    switch (_contentMode) {
+        case iTermBackgroundImageModeStretch:
+            return AVLayerVideoGravityResize;
+        case iTermBackgroundImageModeScaleAspectFit:
+            return AVLayerVideoGravityResizeAspect;
+        case iTermBackgroundImageModeScaleAspectFill:
+        case iTermBackgroundImageModeTile:
+            // Tiling a video isn't supported; fill is the least surprising stand-in.
+            return AVLayerVideoGravityResizeAspectFill;
+    }
+    return AVLayerVideoGravityResizeAspectFill;
+}
+
+- (void)loadVideo {
+    self.layer.contents = nil;
+    self.layer.backgroundColor = nil;
+    _lastTilingScale = -1;
+
+    if (_playerLayer && _playerLayer.player == _image.videoPlayer) {
+        _playerLayer.videoGravity = [self desiredVideoGravity];
+        return;
+    }
+    [self destroyVideoPlayer];
+
+    _playerLayer = [AVPlayerLayer playerLayerWithPlayer:_image.videoPlayer];
+    _playerLayer.videoGravity = [self desiredVideoGravity];
+    _playerLayer.actions = @{ @"bounds": [NSNull null],
+                              @"position": [NSNull null] };
+    _playerLayer.frame = self.layer.bounds;
+    [self.layer addSublayer:_playerLayer];
+
+    [self updateVideoPlaybackState];
+}
+
+- (void)destroyVideoPlayer {
+    [self setPlaybackInterestImage:nil];
+    [_playerLayer removeFromSuperlayer];
+    _playerLayer = nil;
+}
+
+- (void)setPlaybackInterestImage:(iTermImageWrapper *)image {
+    if (image == _playbackInterestImage) {
+        return;
+    }
+    [_playbackInterestImage releaseVideoPlaybackInterest];
+    _playbackInterestImage = image;
+    [_playbackInterestImage retainVideoPlaybackInterest];
+}
+
+// Decoding a video that nobody can see wastes power, so track visibility.
+// SessionView toggles hidden on an ancestor, hence the OrHasHiddenAncestor
+// check and the viewDidHide/viewDidUnhide overrides.
+- (void)updateVideoPlaybackState {
+    if (!_playerLayer) {
+        return;
+    }
+    const BOOL visible = !self.isHiddenOrHasHiddenAncestor && self.window != nil;
+    [self setPlaybackInterestImage:visible ? _image : nil];
+}
+
+- (void)viewDidHide {
+    [super viewDidHide];
+    [self updateVideoPlaybackState];
+}
+
+- (void)viewDidUnhide {
+    [super viewDidUnhide];
+    [self updateVideoPlaybackState];
+}
+
+- (void)layout {
+    [super layout];
+    if (_playerLayer) {
+        [CATransaction begin];
+        [CATransaction setDisableActions:YES];
+        _playerLayer.frame = self.layer.bounds;
+        [CATransaction commit];
+    }
+}
+
 - (CGFloat)scale {
     if (!self.window) {
         return 2;
@@ -267,6 +372,7 @@
 - (void)viewDidMoveToWindow {
     // The scale may have changed which affects tiled images.
     [self update];
+    [self updateVideoPlaybackState];
 }
 
 - (void)windowDidChangeScreen:(NSNotification *)notification {

--- a/sources/TerminalView/iTermImageView.m
+++ b/sources/TerminalView/iTermImageView.m
@@ -174,6 +174,10 @@
                                                  selector:@selector(windowDidChangeScreen:)
                                                      name:NSWindowDidChangeScreenNotification
                                                    object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(windowOcclusionDidChange:)
+                                                     name:NSWindowDidChangeOcclusionStateNotification
+                                                   object:nil];
     }
     return self;
 }
@@ -333,13 +337,22 @@
 
 // Decoding a video that nobody can see wastes power, so track visibility.
 // SessionView toggles hidden on an ancestor, hence the OrHasHiddenAncestor
-// check and the viewDidHide/viewDidUnhide overrides.
+// check and the viewDidHide/viewDidUnhide overrides. The view hierarchy says
+// nothing about the window being buried under other windows, miniaturized, or
+// on another Space; occlusionState covers all three.
 - (void)updateVideoPlaybackState {
     if (!_playerLayer) {
         return;
     }
-    const BOOL visible = !self.isHiddenOrHasHiddenAncestor && self.window != nil;
+    NSWindow *window = self.window;
+    const BOOL windowIsVisible =
+        window != nil && (window.occlusionState & NSWindowOcclusionStateVisible) != 0;
+    const BOOL visible = !self.isHiddenOrHasHiddenAncestor && windowIsVisible;
     [self setPlaybackInterestImage:visible ? _image : nil];
+}
+
+- (void)windowOcclusionDidChange:(NSNotification *)notification {
+    [self updateVideoPlaybackState];
 }
 
 - (void)viewDidHide {


### PR DESCRIPTION
## Summary

Adds support for using short videos (mp4/mov) as terminal background images, addressing the long-standing request for animated backgrounds (GitLab issue #7920).

- The Settings &gt; Profiles &gt; Window file picker accepts videos alongside images, validates that the file is playable and has a video track, previews the first frame, and shows a permanently-silenceable notice about the energy cost of high-resolution / high-frame-rate files.
- Videos play muted in a seamless loop (AVPlayerLooper) and respect blend, transparency, and the scaling modes. Tile is not offered for videos, since neither renderer can tile one.
- Works with **both renderers**:
  - **GPU renderer:** `iTermImageWrapper` owns the frame pull — it dequeues from the shared `AVPlayerItemVideoOutput` at most once per display refresh and wraps that frame as a BGRA Metal texture (zero-copy, via `CVMetalTextureCache`) once per GPU. Every pane showing the video samples that same texture for a given refresh. The update cadence treats a playing video like an inline animated GIF so frames draw at display rate.
  - **Legacy renderer:** an `AVPlayerLayer` in `iTermImageView` plays the video; playback position carries over seamlessly when the renderer switches because both paths share one player.
- `iTermImageWrapper` owns a single shared muted `AVQueuePlayer` + `AVPlayerItemVideoOutput` per video and loads a poster frame for image-only consumers (blending, snapshots). Consumers hold playback interests, so decoding stops when no window can show the video and split panes showing the same video share a single decoder.

## Test plan

Manually verified on macOS 26 (Apple Silicon), Xcode 26.6:
- Picking mp4/mov via the picker; picker still accepts images and folders; corrupt-file warning still works
- Playback under the GPU renderer (confirmed active) and under the legacy renderer (transparency enabled)
- Split panes: shared decoder, synchronized playback with no seam at the dividers; per-pane and whole-window background modes
- Blend slider and scaling modes live-update
- Six panes under sustained heavy output (~100% CPU for 75s) with no crash and memory returning to baseline
- Removing the video restores normal behavior

Not yet re-verified in the UI after the review fixes: the occlusion/miniaturize pause, the idle-session first frame, and the three settings changes (source-mode refresh, energy-notice suppression, Tile disabled).

## Known limitations

- Drag-and-drop of a video onto the settings image well is not supported (picker only) since NSImageView filters non-image drags
- The Metal path samples raw BGRA without color-space conversion, so colors can differ very slightly from the legacy path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
