### PR TITLE
fix(it2check): Set timeout so read does not hang

### DIFF
--- a/OtherResources/Utilities/it2check
+++ b/OtherResources/Utilities/it2check
@@ -47,7 +47,7 @@ function clean_up() {
 stty -echo -icanon raw min 0 time 0
 
 # Consume all pending input.
-while read none; do :; done
+while read -t 0.1 -n 10000 none; do :; done
 
 # Reset the TTY, so it behaves as expected for the rest of the it2check script.
 clean_up 


### PR DESCRIPTION
**See GitLab Issue: gnachman/iterm2#12934**

Utility it2check hangs when run as root in bash 5.2.21


* iTerm2 version: 3.6.11
* OS version: macOS 26.5 (Tahoe)

Running `it2check` as `root` under `bash` 5.2.21 hangs.  Regular users can run this without a problem.  

I discovered this issue after upgrading a server from `Ubuntu 22.04` (running `bash 5.1.16(1)-release`) to `Ubuntu 24.04` (running `bash 5.2.21(1)-release`).  In my `.bash_profile` I run `it2check` to decide how to set some `ENV` vars.  Logging into the upgraded server, sessions hang.  I traced the problem to:

It gets stuck at line 50  
`while read none; do :; done`

It seems that there is issue with this in bash.

The fix for the issue is to set a timeout on the read. I also set max chars.

`while read -t 0.1 -n 10000 none; do :; done`

I am sending a pull request on GitHub with my changes.

My solution was inspired by: [clear-stdin-before-reading](https://superuser.com/questions/276531/clear-stdin-before-reading)


Detailed steps to reproduce the problem:
1. login as root
2. run it2check

What happened:
the session hangs with no way out as `ctrl-c` and other remidies are captured and ignored.


What should have happened:
It returns after assessing if you are running iTerm2.

