### PR TITLE
Fix settings search field focus ring corner artifacts on macOS 26

### DIFF
--- a/docs/notes-3.7.txt
+++ b/docs/notes-3.7.txt
@@ -2163,3 +2163,6 @@ Bug Fixes:
   user name and password when a site returns
   an HTTP authentication challenge (Basic,
   Digest, or NTLM) instead of failing to load.
+- Settings search field no longer draws a
+  custom focus ring on macOS 26+ that left
+  corner artifacts under the capsule.

--- a/sources/Settings/PreferencePanel.m
+++ b/sources/Settings/PreferencePanel.m
@@ -260,6 +260,13 @@ static PreferencePanel *gSessionsPreferencePanel;
 - (void)drawWithFrame:(NSRect)cellFrame inView:(NSView *)controlView {
     [super drawWithFrame:cellFrame inView:controlView];
 
+    // On macOS 26+ (Tahoe), the system draws its own accent ring around the
+    // search field when it is first responder. A second custom ring would
+    // extend below the capsule and leave corner artifacts — skip it.
+    if (@available(macOS 26, *)) {
+        return;
+    }
+
     // Draw custom focus ring that extends beyond cell bounds
     if ([controlView respondsToSelector:@selector(currentEditor)] &&
         [(NSControl *)controlView currentEditor] != nil) {


### PR DESCRIPTION
On macOS 26 (Tahoe), the system automatically draws an accent ring around the search field capsule when it is first responder. The custom focus ring in iTermPrefsSearchFieldCell.drawWithFrame: extends 4pt below the cell frame (NSInsetRect(cellFrame, -0.5, -4)) to work around a missing or broken focus ring in earlier Tahoe builds.

This extra ring is no longer needed on current Tahoe — it leaves thin angled line fragments protruding below the bottom corners of the capsule fill.

The fix skips the custom ring on macOS 26+, letting the system provide the focus indicator naturally.