### PR TITLE
Refresh key reporting after screen buffer switches

### DIFF
--- a/ModernTests/VT100ScreenTests.swift
+++ b/ModernTests/VT100ScreenTests.swift
@@ -83,6 +83,22 @@ class VT100ScreenTests: XCTestCase {
         XCTAssertEqual(range, VT100GridCoordRangeMake(1, 1, 3, 1))
     }
 
+    func testSwitchingScreenBuffersRefreshesKeyReportingFlags() {
+        let screen = screen(width: 80, height: 24)
+
+        session.keyReportingFlagsDidChangeCount = 0
+        screen.performBlock(joinedThreads: { _, mutableState, _ in
+            mutableState.terminalShowAltBuffer()
+        })
+        XCTAssertEqual(session.keyReportingFlagsDidChangeCount, 1)
+
+        session.keyReportingFlagsDidChangeCount = 0
+        screen.performBlock(joinedThreads: { _, mutableState, _ in
+            mutableState.terminalShowPrimaryBuffer()
+        })
+        XCTAssertEqual(session.keyReportingFlagsDidChangeCount, 1)
+    }
+
     private func screen(width: Int32, height: Int32) -> VT100Screen {
         let screen = VT100Screen()
         session.screen = screen
@@ -1606,6 +1622,7 @@ struct SeededGenerator: RandomNumberGenerator {
 }
 
 class FakeSession: NSObject, VT100ScreenDelegate {
+    var keyReportingFlagsDidChangeCount = 0
     var screen: VT100Screen?
     var configuration = VT100MutableScreenConfiguration()
     var selection = iTermSelection()
@@ -1905,7 +1922,7 @@ class FakeSession: NSObject, VT100ScreenDelegate {
     }
     
     func screenKeyReportingFlagsDidChange() {
-
+        keyReportingFlagsDidChangeCount += 1
     }
     
     func screenReportVariableNamed(_ name: String) {

--- a/sources/VT100Screen/VT100ScreenMutableState.m
+++ b/sources/VT100Screen/VT100ScreenMutableState.m
@@ -2274,6 +2274,7 @@ void VT100ScreenEraseCell(screen_char_t *sct,
 
     [self.currentGrid markAllCharsDirty:YES updateTimestamps:NO];
     [self invalidateCommandStartCoordWithoutSideEffects];
+    [self terminalKeyReportingFlagsDidChange];
     [self addPausedSideEffect:^(id<VT100ScreenDelegate> delegate, iTermTokenExecutorUnpauser *unpauser) {
         [delegate screenRemoveSelection];
         [delegate screenScheduleRedrawSoon];
@@ -2295,6 +2296,7 @@ void VT100ScreenEraseCell(screen_char_t *sct,
     [self reloadMarkCache];
 
     [self.currentGrid markAllCharsDirty:YES updateTimestamps:NO];
+    [self terminalKeyReportingFlagsDidChange];
     [self addPausedSideEffect:^(id<VT100ScreenDelegate> delegate, iTermTokenExecutorUnpauser *unpauser) {
         [delegate screenRemoveSelection];
         [delegate screenScheduleRedrawSoon];
@@ -8050,4 +8052,3 @@ launchCoprocessWithCommand:(NSString *)command
 }
 
 @end
-


### PR DESCRIPTION
## Summary

- Refresh key-reporting state when iTerm2 switches between the primary and alternate screen buffers.
- Prevent the session's key encoder from remaining in stale legacy mode after returning from an alternate-screen program.
- Add regression coverage for both primary-to-alternate and alternate-to-primary transitions.

## Problem Solved

iTerm2 keeps independent Kitty keyboard-mode stacks for the primary and alternate screen buffers. `VT100Terminal` selects the current stack from the active screen, and push/pop operations notify the session so it can recompute its key-mapping mode.

The Kitty protocol requires independent main and alternate screen keyboard-mode stacks so an alternate-screen program can change its mode without affecting the main screen. [Kitty keyboard protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol/)

The missing case was the screen-buffer transition itself. `showAltBuffer` and `showPrimaryBuffer` changed the active grid, which also changes the effective keyboard-mode stack, but did not notify the session.

An application can expose the bug with a balanced sequence:

1. Enable Kitty flags on the primary screen.
2. Enter the alternate screen and push flags there.
3. Pop the alternate-screen flags.
4. Return to the primary screen.

After step 3, iTerm2 correctly updates the session for the now-empty alternate stack. After step 4, the primary stack is active again and still contains its original flags, but the session is not refreshed. The key encoder therefore remains in legacy mode even though the terminal's effective primary-screen flags are nonzero.

For example, after a full-screen application enters and leaves the alternate screen:

- Control+Enter can be emitted as `0d` instead of CSI-u Control+Enter.
- Control+Backspace can be emitted as `08` / Control+H instead of CSI-u Control+Backspace.
- Control+Left and Control+Right can still work because their legacy modified-arrow CSI forms remain available.

## Fix

Call the existing `terminalKeyReportingFlagsDidChange` path after each actual primary/alternate buffer switch, after `currentGrid` has changed.

The existing early returns remain the no-op guard, so repeated requests for the already-active buffer do not emit extra notifications. The session then rereads the effective terminal flags and recomputes its key-mapping mode from the correct active stack.

This preserves the existing independent-stack semantics and fixes the missing state propagation rather than adding an application-specific workaround.

## Validation

- `tools/run_tests.expect ModernTests/VT100ScreenTests/testSwitchingScreenBuffersRefreshesKeyReportingFlags`
- `tools/run_tests.expect ModernTests/VT100ScreenTests`
- Manual reproduction with the balanced primary/alternate-screen keyboard-stack sequence above: Control+Enter and Control+Backspace remain CSI-u keys after returning to the primary screen.
