### PR TITLE
Avoid redundant key reporting refreshes on screen switches

### DIFF
--- a/ModernTests/VT100ScreenTests.swift
+++ b/ModernTests/VT100ScreenTests.swift
@@ -83,20 +83,34 @@ class VT100ScreenTests: XCTestCase {
         XCTAssertEqual(range, VT100GridCoordRangeMake(1, 1, 3, 1))
     }
 
-    func testSwitchingScreenBuffersRefreshesKeyReportingFlags() {
+    func testSwitchingScreenBuffersRefreshesChangedKeyReportingFlags() {
         let screen = screen(width: 80, height: 24)
 
-        session.keyReportingFlagsDidChangeCount = 0
-        screen.performBlock(joinedThreads: { _, mutableState, _ in
-            mutableState.terminalShowAltBuffer()
-        })
-        XCTAssertEqual(session.keyReportingFlagsDidChangeCount, 1)
+        feed(screen, "\u{1b}[>1u")
+        feed(screen, "\u{1b}[?1049h")
+        feed(screen, "\u{1b}[>2u")
 
-        session.keyReportingFlagsDidChangeCount = 0
-        screen.performBlock(joinedThreads: { _, mutableState, _ in
-            mutableState.terminalShowPrimaryBuffer()
-        })
-        XCTAssertEqual(session.keyReportingFlagsDidChangeCount, 1)
+        session.keyReportingFlagsAtChange.removeAll()
+        feed(screen, "\u{1b}[?1049l")
+        XCTAssertEqual(session.keyReportingFlagsAtChange, [.disambiguateEscape])
+
+        session.keyReportingFlagsAtChange.removeAll()
+        feed(screen, "\u{1b}[?1049h")
+        XCTAssertEqual(session.keyReportingFlagsAtChange, [.reportAllEventTypes])
+    }
+
+    func testSwitchingScreenBuffersDoesNotRefreshUnchangedKeyReportingFlags() {
+        let screen = screen(width: 80, height: 24)
+
+        feed(screen, "\u{1b}[?1049h")
+        feed(screen, "\u{1b}[?1049l")
+        XCTAssertTrue(session.keyReportingFlagsAtChange.isEmpty)
+
+        feed(screen, "\u{1b}[=1;1u")
+        session.keyReportingFlagsAtChange.removeAll()
+        feed(screen, "\u{1b}[?1049h")
+        feed(screen, "\u{1b}[?1049l")
+        XCTAssertTrue(session.keyReportingFlagsAtChange.isEmpty)
     }
 
     private func screen(width: Int32, height: Int32) -> VT100Screen {
@@ -130,6 +144,11 @@ class VT100ScreenTests: XCTestCase {
                 }
             }
         })
+    }
+
+    private func feed(_ screen: VT100Screen, _ string: String) {
+        screen.inject(string.data(using: .utf8)!)
+        screen.performBlock(joinedThreads: { _, _, _ in })
     }
 
     // The per-row cache's combined screenCharArrayForLine:contentIdentity: must
@@ -1622,7 +1641,7 @@ struct SeededGenerator: RandomNumberGenerator {
 }
 
 class FakeSession: NSObject, VT100ScreenDelegate {
-    var keyReportingFlagsDidChangeCount = 0
+    var keyReportingFlagsAtChange = [VT100TerminalKeyReportingFlags]()
     var screen: VT100Screen?
     var configuration = VT100MutableScreenConfiguration()
     var selection = iTermSelection()
@@ -1922,7 +1941,7 @@ class FakeSession: NSObject, VT100ScreenDelegate {
     }
     
     func screenKeyReportingFlagsDidChange() {
-        keyReportingFlagsDidChangeCount += 1
+        keyReportingFlagsAtChange.append(screen!.terminalKeyReportingFlags)
     }
     
     func screenReportVariableNamed(_ name: String) {

--- a/sources/VT100/VT100Terminal.m
+++ b/sources/VT100/VT100Terminal.m
@@ -668,6 +668,8 @@ static const int kMaxScreenRows = 4096;
 }
 
 - (NSMutableArray<NSNumber *> *)currentKeyReportingModeStack {
+    // The active screen buffer selects its independent key-reporting mode stack, so changing
+    // buffers can change keyReportingFlags without mutating either stack.
     if ([self.delegate terminalIsInAlternateScreenMode]) {
         return _alternateKeyReportingModeStack;
     }

--- a/sources/VT100Screen/VT100ScreenMutableState.m
+++ b/sources/VT100Screen/VT100ScreenMutableState.m
@@ -2256,6 +2256,7 @@ void VT100ScreenEraseCell(screen_char_t *sct,
     if (self.currentGrid == self.altGrid) {
         return;
     }
+    const VT100TerminalKeyReportingFlags oldKeyReportingFlags = self.terminalKeyReportingFlags;
     if (!self.altGrid) {
         self.altGrid = [[VT100Grid alloc] initWithSize:self.primaryGrid.size delegate:self];
         self.altGrid.defaultChar = self.terminal.defaultChar;
@@ -2274,7 +2275,10 @@ void VT100ScreenEraseCell(screen_char_t *sct,
 
     [self.currentGrid markAllCharsDirty:YES updateTimestamps:NO];
     [self invalidateCommandStartCoordWithoutSideEffects];
-    [self terminalKeyReportingFlagsDidChange];
+    // currentGrid selects which key-reporting stack contributes the effective flags.
+    if (oldKeyReportingFlags != self.terminalKeyReportingFlags) {
+        [self terminalKeyReportingFlagsDidChange];
+    }
     [self addPausedSideEffect:^(id<VT100ScreenDelegate> delegate, iTermTokenExecutorUnpauser *unpauser) {
         [delegate screenRemoveSelection];
         [delegate screenScheduleRedrawSoon];
@@ -2286,6 +2290,7 @@ void VT100ScreenEraseCell(screen_char_t *sct,
     if (self.currentGrid != self.altGrid) {
         return;
     }
+    const VT100TerminalKeyReportingFlags oldKeyReportingFlags = self.terminalKeyReportingFlags;
     [self.temporaryDoubleBuffer reset];
     [self hideOnScreenNotesAndTruncateSpanners];
     self.currentGrid = self.primaryGrid;
@@ -2296,7 +2301,9 @@ void VT100ScreenEraseCell(screen_char_t *sct,
     [self reloadMarkCache];
 
     [self.currentGrid markAllCharsDirty:YES updateTimestamps:NO];
-    [self terminalKeyReportingFlagsDidChange];
+    if (oldKeyReportingFlags != self.terminalKeyReportingFlags) {
+        [self terminalKeyReportingFlagsDidChange];
+    }
     [self addPausedSideEffect:^(id<VT100ScreenDelegate> delegate, iTermTokenExecutorUnpauser *unpauser) {
         [delegate screenRemoveSelection];
         [delegate screenScheduleRedrawSoon];


### PR DESCRIPTION
## Summary

- Refresh key reporting after a screen-buffer switch only when the effective reporting flags actually change.
- Preserve the existing refresh behavior when the main and alternate buffers select different key-reporting mode stacks.
- Add parser-driven regression coverage for both changed and unchanged reporting flags.
- Document that the active screen buffer selects the active key-reporting mode stack.

## Problem Solved

The current screen-buffer transition path always reports that key reporting changed after switching between the main and alternate buffers.

That is necessary when the two buffers select different reporting flags, but it is incorrect when both buffers have the same effective flags. A redundant notification can reset session-level key handling even though the terminal's effective reporting state did not change.

For example:

```text
main buffer flags:      0
alternate buffer flags: 0

switch main -> alternate

before: emits "key reporting changed"
after:  emits nothing because the effective flags remain 0
```

Real reporting changes still notify normally:

```text
main buffer flags:      disambiguate escape
alternate buffer flags: report all event types

switch main -> alternate

after: emits "key reporting changed" with the alternate buffer's flags
```

## Implementation

Capture the effective key-reporting flags before changing `currentGrid`, then compare them with the effective flags after the switch. The existing `terminalKeyReportingFlagsDidChange` path now runs only when those values differ.

The terminal-side stack accessor also documents the invariant that the active screen buffer selects which independent key-reporting mode stack contributes the effective flags.

## Tests

Added parser-driven coverage in `ModernTests/VT100ScreenTests.swift`:

- `testSwitchingScreenBuffersRefreshesChangedKeyReportingFlags`
- `testSwitchingScreenBuffersDoesNotRefreshUnchangedKeyReportingFlags`

The unchanged-flags regression test fails on current `master` with two expected assertion failures and passes with this change.

```text
tools/run_tests.expect \
  ModernTests/VT100ScreenTests/testSwitchingScreenBuffersRefreshesChangedKeyReportingFlags \
  ModernTests/VT100ScreenTests/testSwitchingScreenBuffersDoesNotRefreshUnchangedKeyReportingFlags
```

## Relationship to #704

This is a follow-up to #704, which fixed stale key-reporting state by refreshing after main/alternate screen-buffer switches. The merged implementation refreshes on every real switch. This PR preserves that refresh when the switch selects different effective flags, and suppresses only equal-value notifications that can reset session-level key handling even though the terminal's reporting state did not change.
