### PR TITLE
Linkify long URLs past the ⌘-click capture window

### DIFF
--- a/ModernTests/ExtendURLSearchResultsTests.swift
+++ b/ModernTests/ExtendURLSearchResultsTests.swift
@@ -220,3 +220,69 @@ class ExtendURLSearchResultsTests: XCTestCase {
                       "Should detect pipe character as divider")
     }
 }
+
+// MARK: - Forward-walk URL extension
+
+/// Tests for -[iTermTextExtractor locatedStringByWalkingForwardFrom:characterSet:maxChars:],
+/// which extends a URL match past the fixed capture window so long URLs get fully linkified.
+/// Reuses MockDataSourceWithDividers above (plain strings, no dividers).
+class URLForwardWalkTests: XCTestCase {
+    // iTermTextExtractor holds its data source weakly, so keep the mocks alive for the test.
+    private var retainedSources: [MockDataSourceWithDividers] = []
+
+    private func urlLikeCharacterSet() -> CharacterSet {
+        var set = CharacterSet.alphanumerics
+        set.insert(charactersIn: "/:._-")
+        return set
+    }
+
+    private func extractor(_ lines: [String], width: Int32) -> iTermTextExtractor {
+        let source = MockDataSourceWithDividers(strings: lines, width: width)
+        retainedSources.append(source)
+        return iTermTextExtractor(dataSource: source)
+    }
+
+    // Walks from the end of a full (soft-wrapped) line onto the next line, stopping at a separator.
+    func testWalkAcrossSoftWrapStopsAtSeparator() {
+        let ex = extractor(["abcdefghij", "klmno pqr "], width: 10)
+        let result = ex.locatedStringByWalkingForward(from: VT100GridCoord(x: 9, y: 0),
+                                                      characterSet: urlLikeCharacterSet(),
+                                                      maxChars: 10000)
+        XCTAssertEqual(result.string, "klmno")
+    }
+
+    // The collected coordinates are 1:1 with the characters and land on the continuation line.
+    func testWalkRecordsCoordinates() {
+        let ex = extractor(["abcdefghij", "klmno pqr "], width: 10)
+        let result = ex.locatedStringByWalkingForward(from: VT100GridCoord(x: 9, y: 0),
+                                                      characterSet: urlLikeCharacterSet(),
+                                                      maxChars: 10000)
+        XCTAssertEqual(result.gridCoords.count, 5)
+        guard result.gridCoords.count == 5 else { return }
+        XCTAssertEqual(result.gridCoords.coord(at: 0).x, 0)
+        XCTAssertEqual(result.gridCoords.coord(at: 0).y, 1)
+        XCTAssertEqual(result.gridCoords.coord(at: 4).x, 4)
+    }
+
+    // maxChars caps the walk.
+    func testWalkStopsAtMaxChars() {
+        let ex = extractor(["abcdefghij", "klmnopqrst"], width: 10)
+        let result = ex.locatedStringByWalkingForward(from: VT100GridCoord(x: 9, y: 0),
+                                                      characterSet: urlLikeCharacterSet(),
+                                                      maxChars: 3)
+        XCTAssertEqual(result.string, "klm")
+    }
+
+    // An immediate separator, and running off the end of the buffer, both yield empty results.
+    func testWalkEmptyCases() {
+        let atSeparator = extractor(["abcdefghij", " klmnopqr "], width: 10)
+            .locatedStringByWalkingForward(from: VT100GridCoord(x: 9, y: 0),
+                                           characterSet: urlLikeCharacterSet(), maxChars: 10000)
+        XCTAssertEqual(atSeparator.length, 0)
+
+        let atBufferEnd = extractor(["abcdefghij"], width: 10)
+            .locatedStringByWalkingForward(from: VT100GridCoord(x: 9, y: 0),
+                                           characterSet: urlLikeCharacterSet(), maxChars: 10000)
+        XCTAssertEqual(atBufferEnd.length, 0)
+    }
+}

--- a/docs/notes-3.7.txt
+++ b/docs/notes-3.7.txt
@@ -117,6 +117,11 @@ Major New Features:
   tokens, or AI chat content. These could
   previously accumulate in memory with debug
   logging off.
+- ⌘-click now linkifies very long URLs in
+  full. Previously only the first couple
+  thousand characters were clickable; the
+  linkifier now scans onward to the next
+  separator so the whole URL is detected.
 - In AI chat orchestration mode, references
   to a session or workgroup now appear as a
   clickable link, marked with a terminal

--- a/sources/ContentAnalysis/iTermTextExtractor.h
+++ b/sources/ContentAnalysis/iTermTextExtractor.h
@@ -213,6 +213,15 @@ extern const NSInteger kLongMaximumWordLength;
                              continuationChars:(NSMutableIndexSet * _Nullable)continuationChars
                            convertNullsToSpace:(BOOL)convertNullsToSpace;
 
+// Walks forward from `coord` (starting at its successor), collecting successive characters that are
+// members of `characterSet` into a located string with one grid coordinate per character. Stops at
+// the first character that is not a member, a null, a complex (non-simple) character, the end of the
+// buffer, or once `maxChars` characters have been collected. Used to extend a URL match past the
+// fixed capture window so very long URLs get fully linkified.
+- (iTermLocatedString *)locatedStringByWalkingForwardFrom:(VT100GridCoord)coord
+                                             characterSet:(NSCharacterSet *)characterSet
+                                                 maxChars:(int)maxChars;
+
 - (ScreenCharArray *)combinedLinesInRange:(NSRange)range;
 
 - (screen_char_t)characterAtVisualCoord:(VT100GridCoord)coord;

--- a/sources/ContentAnalysis/iTermTextExtractor.m
+++ b/sources/ContentAnalysis/iTermTextExtractor.m
@@ -1881,6 +1881,25 @@ trimTrailingWhitespace:(BOOL)trimSelectionTrailingSpaces
     return locatedString;
 }
 
+- (iTermLocatedString *)locatedStringByWalkingForwardFrom:(VT100GridCoord)coord
+                                             characterSet:(NSCharacterSet *)characterSet
+                                                 maxChars:(int)maxChars {
+    iTermLocatedString *result = [[iTermLocatedString alloc] init];
+    VT100GridCoord previousCoord = coord;
+    VT100GridCoord next = [self successorOfCoord:coord];
+    while (result.length < maxChars && !VT100GridCoordEquals(next, previousCoord)) {
+        const screen_char_t c = [self characterAt:next];
+        const unichar ch = c.code;
+        if (c.code == 0 || c.complexChar || ![characterSet characterIsMember:ch]) {
+            break;
+        }
+        [result appendString:[NSString stringWithCharacters:&ch length:1] at:next];
+        previousCoord = next;
+        next = [self successorOfCoord:next];
+    }
+    return result;
+}
+
 // Convenience: callers that don't need metadata get a wrapper that ignores it.
 - (void)enumerateCharsInRange:(VT100GridWindowedRange)range
                   supportBidi:(BOOL)supportBidi

--- a/sources/SemanticHistory/iTermURLActionFactory.m
+++ b/sources/SemanticHistory/iTermURLActionFactory.m
@@ -625,7 +625,39 @@ static NSMutableArray<iTermURLActionFactory *> *sFactories;
     return [possibleUrl substringWithRange:range];
 }
 
+// If the run of URL-legal characters around the click reaches the end of the captured suffix
+// window, the URL may have been cut off (the window is bounded by maxSemanticHistoryPrefixOrSuffix
+// and a ±10-line clamp). Rather than re-run matching on an ever-larger window, walk the grid
+// forward from the last captured character, consuming URL-legal characters until a separator (or the
+// 100 KB backstop), and append them to the located suffix so extraction below sees the whole URL.
+- (void)extendLocatedSuffixIfURLRunReachesWindowEnd {
+    NSCharacterSet *const urlCharacterSet = [NSCharacterSet urlCharacterSet];
+    NSString *joined = [self.locatedPrefix.string stringByAppendingString:self.locatedSuffix.string];
+    int prefixChars = 0;
+    NSString *possibleUrl = [joined substringIncludingOffset:self.locatedPrefix.string.length
+                                            fromCharacterSet:urlCharacterSet
+                                        charsTakenFromPrefix:&prefixChars];
+    const NSInteger suffixChars = (NSInteger)possibleUrl.length - prefixChars;
+    if (suffixChars <= 0 ||
+        suffixChars < (NSInteger)self.locatedSuffix.string.length ||
+        self.locatedSuffix.gridCoords.count == 0) {
+        return;
+    }
+    const int maxURLLength = 100 * 1024;
+    const VT100GridCoord lastCoord =
+        [self.locatedSuffix.gridCoords coordAt:self.locatedSuffix.gridCoords.count - 1];
+    iTermLocatedString *extension =
+        [self.extractor locatedStringByWalkingForwardFrom:lastCoord
+                                             characterSet:urlCharacterSet
+                                                 maxChars:maxURLLength];
+    if (extension.length > 0) {
+        DLog(@"URL ran to end of suffix window; extended by %@ chars", @(extension.length));
+        [self.locatedSuffix appendLocatedString:extension];
+    }
+}
+
 - (URLAction *)urlActionForURLLike {
+    [self extendLocatedSuffixIfURLRunReachesWindowEnd];
     NSString *joined = [self.locatedPrefix.string stringByAppendingString:self.locatedSuffix.string];
     DLog(@"Smart selection found nothing. Look for URL-like things in %@ around offset %d",
          joined, (int)[self.locatedPrefix.string length]);


### PR DESCRIPTION
### Problem

⌘-clicking a very long URL (7–8k chars) only linkifies its first ~1–2k characters — on hover you can see only a prefix of the URL turn blue. `iTermURLActionFactory` matches within a bounded window around the click (`maxSemanticHistoryPrefixOrSuffix`, 2000 chars per side, further clamped to ±10 lines), so the URL-legal run reaches the edge of the captured suffix and stops.

### Fix

When the run reaches the end of the captured suffix, walk the grid forward one cell at a time, consuming URL-legal characters until a separator (or null, complex char, or buffer end), capped at 100 KB — rather than re-running the matcher on ever-larger windows. The walked characters and their grid coords are appended to the located suffix, so the existing punctuation trimming, validation, and coordinate mapping all operate on the widened window unchanged, including the underline drawn on hover.

Adds `-[iTermTextExtractor locatedStringByWalkingForwardFrom:characterSet:maxChars:]`.

### Testing

`tools/run_tests.expect ModernTests/URLForwardWalkTests` — 4 new cases (soft-wrap crossing, coordinate mapping, `maxChars` cap, empty/boundary cases). Existing `ExtendURLSearchResults`, extractor, word-extractor, and URL-string suites still pass.