### PR TITLE
feat: add Profiles menu search

### DIFF
--- a/ModernTests/iTermProfilesMenuOpenActionTests.m
+++ b/ModernTests/iTermProfilesMenuOpenActionTests.m
@@ -1,0 +1,84 @@
+//
+//  iTermProfilesMenuOpenActionTests.m
+//  ModernTests
+//
+//  Created by OpenAI on 7/23/26.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "iTermController.h"
+
+@interface iTermController (iTermProfilesMenuOpenActionTests)
+- (void)openProfileFromProfilesMenuWithGuid:(NSString *)guid action:(SEL)action;
+@end
+
+@interface iTermProfilesMenuOpenActionTestController : iTermController
+@property(nonatomic, copy) NSString *openedGuid;
+@property(nonatomic, assign) SEL openedAction;
+@end
+
+@implementation iTermProfilesMenuOpenActionTestController
+
+- (void)newSessionInTabAtIndex:(id)sender {
+    self.openedAction = _cmd;
+    self.openedGuid = [sender representedObject];
+}
+
+- (void)newSessionInWindowAtIndex:(id)sender {
+    self.openedAction = _cmd;
+    self.openedGuid = [sender representedObject];
+}
+
+@end
+
+@interface iTermProfilesMenuOpenActionTests : XCTestCase
+@end
+
+@implementation iTermProfilesMenuOpenActionTests
+
+- (void)testProfilesMenuOpensTabByDefault {
+    SEL action = [iTermController profilesMenuActionForOpenProfilesInNewWindow:NO
+                                                                 modifierFlags:0];
+    XCTAssertEqual(action, @selector(newSessionInTabAtIndex:));
+}
+
+- (void)testProfilesMenuOpensWindowWhenOptionIsPressed {
+    SEL action = [iTermController profilesMenuActionForOpenProfilesInNewWindow:NO
+                                                                 modifierFlags:NSEventModifierFlagOption];
+    XCTAssertEqual(action, @selector(newSessionInWindowAtIndex:));
+}
+
+- (void)testProfilesMenuOpensWindowByDefaultWhenConfigured {
+    SEL action = [iTermController profilesMenuActionForOpenProfilesInNewWindow:YES
+                                                                 modifierFlags:0];
+    XCTAssertEqual(action, @selector(newSessionInWindowAtIndex:));
+}
+
+- (void)testProfilesMenuOpensTabWhenConfiguredForWindowAndOptionIsPressed {
+    SEL action = [iTermController profilesMenuActionForOpenProfilesInNewWindow:YES
+                                                                 modifierFlags:NSEventModifierFlagOption];
+    XCTAssertEqual(action, @selector(newSessionInTabAtIndex:));
+}
+
+- (void)testOpeningProfilePassesGuidToExistingTabAction {
+    NSString *guid = @"profile-guid";
+    iTermProfilesMenuOpenActionTestController *controller =
+        [[iTermProfilesMenuOpenActionTestController alloc] init];
+    [controller openProfileFromProfilesMenuWithGuid:guid
+                                            action:@selector(newSessionInTabAtIndex:)];
+    XCTAssertEqualObjects(controller.openedGuid, guid);
+    XCTAssertEqual(controller.openedAction, @selector(newSessionInTabAtIndex:));
+}
+
+- (void)testOpeningProfilePassesGuidToExistingWindowAction {
+    NSString *guid = @"profile-guid";
+    iTermProfilesMenuOpenActionTestController *controller =
+        [[iTermProfilesMenuOpenActionTestController alloc] init];
+    [controller openProfileFromProfilesMenuWithGuid:guid
+                                            action:@selector(newSessionInWindowAtIndex:)];
+    XCTAssertEqualObjects(controller.openedGuid, guid);
+    XCTAssertEqual(controller.openedAction, @selector(newSessionInWindowAtIndex:));
+}
+
+@end

--- a/docs/notes-3.7.txt
+++ b/docs/notes-3.7.txt
@@ -2350,3 +2350,5 @@ Bug Fixes:
   reprocessed to build each request, so the
   per-message work stays small no matter how
   long the conversation gets.
+- The Profiles menu now has Search Profiles…
+  for quickly opening a profile by name or tag.

--- a/iTerm2.xcodeproj/project.pbxproj
+++ b/iTerm2.xcodeproj/project.pbxproj
@@ -2735,6 +2735,7 @@
 		A671D6D62E1E372E0087348B /* dev.html in Resources */ = {isa = PBXBuildFile; fileRef = A671D6D32E1E37200087348B /* dev.html */; };
 		A6725AD223D639C2001CA48A /* iTermProfilesMenuController.h in Headers */ = {isa = PBXBuildFile; fileRef = A6725AD023D639C2001CA48A /* iTermProfilesMenuController.h */; };
 		A6725AD323D639C2001CA48A /* iTermProfilesMenuController.m in Sources */ = {isa = PBXBuildFile; fileRef = A6725AD123D639C2001CA48A /* iTermProfilesMenuController.m */; };
+		C0D3A00437B0000000000001 /* iTermProfileSearchWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = C0D3A00337B0000000000001 /* iTermProfileSearchWindowController.m */; };
 		A6725AD623D63B7A001CA48A /* iTermProfileModelJournal.h in Headers */ = {isa = PBXBuildFile; fileRef = A6725AD423D63B7A001CA48A /* iTermProfileModelJournal.h */; };
 		A6725AD723D63B7A001CA48A /* iTermProfileModelJournal.m in Sources */ = {isa = PBXBuildFile; fileRef = A6725AD523D63B7A001CA48A /* iTermProfileModelJournal.m */; };
 		A672CC8D2F9849A000EAC0FB /* iTermColorVectorCache.h in Headers */ = {isa = PBXBuildFile; fileRef = A672CC8C2F9849A000EAC0FB /* iTermColorVectorCache.h */; };
@@ -8047,6 +8048,8 @@
 		A671AC5F26D95C0400B23C95 /* HTMLEncoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTMLEncoding.swift; sourceTree = "<group>"; };
 		A671D6D32E1E37200087348B /* dev.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = dev.html; sourceTree = "<group>"; };
 		A67238B72E3EDC8E003227C3 /* iTermBrowserTriggerHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iTermBrowserTriggerHandler.swift; sourceTree = "<group>"; };
+		C0D3A00237B0000000000001 /* iTermProfileSearchWindowController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = iTermProfileSearchWindowController.h; sourceTree = "<group>"; };
+		C0D3A00337B0000000000001 /* iTermProfileSearchWindowController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = iTermProfileSearchWindowController.m; sourceTree = "<group>"; };
 		A6725AD023D639C2001CA48A /* iTermProfilesMenuController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = iTermProfilesMenuController.h; sourceTree = "<group>"; };
 		A6725AD123D639C2001CA48A /* iTermProfilesMenuController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = iTermProfilesMenuController.m; sourceTree = "<group>"; };
 		A6725AD423D63B7A001CA48A /* iTermProfileModelJournal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = iTermProfileModelJournal.h; sourceTree = "<group>"; };
@@ -14128,6 +14131,8 @@
 				A6725AD523D63B7A001CA48A /* iTermProfileModelJournal.m */,
 				1D468BBE1B056CD600226083 /* iTermProfileSearchToken.h */,
 				1D468BBF1B056CD600226083 /* iTermProfileSearchToken.m */,
+				C0D3A00237B0000000000001 /* iTermProfileSearchWindowController.h */,
+				C0D3A00337B0000000000001 /* iTermProfileSearchWindowController.m */,
 				A6725AD023D639C2001CA48A /* iTermProfilesMenuController.h */,
 				A6725AD123D639C2001CA48A /* iTermProfilesMenuController.m */,
 				1DE5EBE7122B892900C736B0 /* iTermProfilesWindowController.m */,
@@ -21597,6 +21602,7 @@
 				A6A4867720B67C3600493302 /* ProfilesAdvancedPreferencesViewController.m in Sources */,
 				A6FE7AA22E0E738900BEBCE4 /* iTermBrowserAutofillContactSource.swift in Sources */,
 				A6725AD323D639C2001CA48A /* iTermProfilesMenuController.m in Sources */,
+				C0D3A00437B0000000000001 /* iTermProfileSearchWindowController.m in Sources */,
 				A6E312D52E3C26AF008222DE /* iTermBrowserCopyModeHandler.swift in Sources */,
 				A6EC937C24E8568D00EEADEF /* iTermBuriedSessions.m in Sources */,
 				A6822748280786A5005DF0B4 /* Porthole.swift in Sources */,

--- a/sources/AppKit/iTermApplicationDelegate.m
+++ b/sources/AppKit/iTermApplicationDelegate.m
@@ -101,6 +101,7 @@
 #import "iTermPreferences.h"
 #import "iTermProfileModelJournal.h"
 #import "iTermProfilePreferences.h"
+#import "iTermProfileSearchWindowController.h"
 #import "iTermProfilesMenuController.h"
 #import "iTermProfilesWindowController.h"
 #import "iTermPromptOnCloseReason.h"
@@ -186,6 +187,7 @@ static BOOL hasBecomeActive = NO;
 
 @implementation iTermApplicationDelegate {
     iTermPasswordManagerWindowController *_passwordManagerWindowController;
+    iTermProfileSearchWindowController *_profileSearchWindowController;
 
     // Menu items
     IBOutlet NSMenu *bookmarkMenu;
@@ -359,6 +361,7 @@ static NSModalResponse iTermCompareRenderingRunModal(id self, SEL _cmd) {
     [_appNapStoppingActivity release];
     [_focusFollowsMouseController release];
     [_globalScopeController release];
+    [_profileSearchWindowController release];
     [_untitledWindowStateMachine release];
 
     [super dealloc];
@@ -2268,13 +2271,13 @@ static iTermKeyEventReplayer *gReplayer;
     if ([iTermAdvancedSettingsModel openProfilesInNewWindow]) {
         params.selector = @selector(newSessionInWindowAtIndex:);
         params.alternateSelector = @selector(newSessionInTabAtIndex:);
-        [bookmarkMenu itemAtIndex:2].title = [[bookmarkMenu itemAtIndex:2].title stringByReplacingOccurrencesOfString:@"Window" withString:@"Tab"];
         [bookmarkMenu itemAtIndex:3].title = [[bookmarkMenu itemAtIndex:3].title stringByReplacingOccurrencesOfString:@"Window" withString:@"Tab"];
+        [bookmarkMenu itemAtIndex:4].title = [[bookmarkMenu itemAtIndex:4].title stringByReplacingOccurrencesOfString:@"Window" withString:@"Tab"];
     } else {
         params.selector = @selector(newSessionInTabAtIndex:);
         params.alternateSelector = @selector(newSessionInWindowAtIndex:);
-        [bookmarkMenu itemAtIndex:2].title = [[bookmarkMenu itemAtIndex:2].title stringByReplacingOccurrencesOfString:@"Tab" withString:@"Window"];
         [bookmarkMenu itemAtIndex:3].title = [[bookmarkMenu itemAtIndex:3].title stringByReplacingOccurrencesOfString:@"Tab" withString:@"Window"];
+        [bookmarkMenu itemAtIndex:4].title = [[bookmarkMenu itemAtIndex:4].title stringByReplacingOccurrencesOfString:@"Tab" withString:@"Window"];
     }
     params.openAllSelector = @selector(newSessionsInWindow:);
     params.alternateOpenAllSelector = @selector(newSessionsInWindow:);
@@ -2283,7 +2286,7 @@ static iTermKeyEventReplayer *gReplayer;
     NSDictionary<NSString *, NSNumber *> *shortcutsChanged =
     [iTermProfilesMenuController applyJournal:[aNotification userInfo]
                                        toMenu:bookmarkMenu
-                               startingAtItem:5
+                               startingAtItem:6
                                        params:params];
     // See issue 6254.
     NSNumber *fShortcut = shortcutsChanged[@"F"];
@@ -2903,6 +2906,16 @@ static iTermKeyEventReplayer *gReplayer;
 - (IBAction)showBookmarkWindow:(id)sender {
     [NSApp activateIgnoringOtherApps:YES];
     [[iTermProfilesWindowController sharedInstance] showWindow:sender];
+}
+
+- (IBAction)showProfileSearchWindow:(id)sender {
+    if (!_profileSearchWindowController) {
+        _profileSearchWindowController = [[iTermProfileSearchWindowController alloc] init];
+        _profileSearchWindowController.profileSelected = ^(NSString *guid) {
+            [[iTermController sharedInstance] openProfileFromProfilesMenuWithGuid:guid];
+        };
+    }
+    [_profileSearchWindowController showSearchWindow:sender];
 }
 
 - (IBAction)pasteFaster:(id)sender

--- a/sources/MainMenu/MainMenu.xib
+++ b/sources/MainMenu/MainMenu.xib
@@ -1607,6 +1607,11 @@ CQ
                                     <action selector="showBookmarkWindow:" target="201" id="953"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Search Profiles…" identifier="Search Profiles…" id="cX7-Sr-Pfs">
+                                <connections>
+                                    <action selector="showProfileSearchWindow:" target="201" id="cX7-Sr-Pfa"/>
+                                </connections>
+                            </menuItem>
                             <menuItem isSeparatorItem="YES" id="868">
                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                             </menuItem>

--- a/sources/MainMenu/MainMenuMangler.swift
+++ b/sources/MainMenu/MainMenuMangler.swift
@@ -260,6 +260,7 @@ class MainMenuMangler: NSObject {
 
         // Profiles menu
         "Open Profiles…": "person",
+        "Search Profiles…": "magnifyingglass",
         // Press Option to Show Alternate Profiles removed - no identifier in XIB
         "Open In New Window": "macwindow",
         "Change Profile in Arrangement…": "person.crop.rectangle",

--- a/sources/Settings/Profiles/iTermProfileSearchWindowController.h
+++ b/sources/Settings/Profiles/iTermProfileSearchWindowController.h
@@ -1,0 +1,20 @@
+//
+//  iTermProfileSearchWindowController.h
+//  iTerm2SharedARC
+//
+//  Created by OpenAI on 7/23/26.
+//
+
+#import <Cocoa/Cocoa.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface iTermProfileSearchWindowController : NSWindowController
+
+@property(nonatomic, copy, nullable) void (^profileSelected)(NSString *guid);
+
+- (void)showSearchWindow:(id _Nullable)sender;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/sources/Settings/Profiles/iTermProfileSearchWindowController.m
+++ b/sources/Settings/Profiles/iTermProfileSearchWindowController.m
@@ -1,0 +1,104 @@
+//
+//  iTermProfileSearchWindowController.m
+//  iTerm2SharedARC
+//
+//  Created by OpenAI on 7/23/26.
+//
+
+#import "iTermProfileSearchWindowController.h"
+
+#import "ProfileListView.h"
+#import "ProfileModel.h"
+
+@interface iTermProfileSearchPanel : NSPanel
+@end
+
+@implementation iTermProfileSearchPanel
+
+- (void)sendEvent:(NSEvent *)event {
+    if (event.type == NSEventTypeKeyDown && event.keyCode == 53) {
+        [self close];
+        return;
+    }
+    [super sendEvent:event];
+}
+
+@end
+
+@interface iTermProfileSearchWindowController ()<ProfileListViewDelegate, NSWindowDelegate>
+@end
+
+@implementation iTermProfileSearchWindowController {
+    ProfileListView *_profileListView;
+}
+
+- (instancetype)init {
+    NSRect frame = NSMakeRect(0, 0, 520, 420);
+    iTermProfileSearchPanel *panel =
+        [[iTermProfileSearchPanel alloc] initWithContentRect:frame
+                                                   styleMask:(NSWindowStyleMaskTitled |
+                                                              NSWindowStyleMaskClosable |
+                                                              NSWindowStyleMaskUtilityWindow)
+                                                     backing:NSBackingStoreBuffered
+                                                       defer:NO];
+    panel.title = @"Search Profiles";
+    panel.releasedWhenClosed = NO;
+    panel.hidesOnDeactivate = NO;
+    panel.minSize = NSMakeSize(360, 260);
+    if (@available(macOS 10.16, *)) {
+        panel.toolbarStyle = NSWindowToolbarStyleUnifiedCompact;
+    }
+
+    self = [super initWithWindow:panel];
+    if (self) {
+        panel.delegate = self;
+
+        _profileListView =
+            [[ProfileListView alloc] initWithFrame:panel.contentView.bounds
+                                            model:[ProfileModel sharedInstance]
+                                            font:nil
+                                     profileTypes:ProfileTypeAll];
+        _profileListView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+        _profileListView.delegate = self;
+        [_profileListView forceOverlayScroller];
+        [panel.contentView addSubview:_profileListView];
+    }
+    return self;
+}
+
+- (void)dealloc {
+    if (self.window.delegate == self) {
+        self.window.delegate = nil;
+    }
+    _profileListView.delegate = nil;
+}
+
+- (void)showSearchWindow:(id)sender {
+    [_profileListView clearSearchField];
+    [_profileListView reloadData];
+    if (_profileListView.numberOfRows > 0) {
+        [_profileListView selectRowIndex:0];
+    }
+    [NSApp activateIgnoringOtherApps:YES];
+    [self showWindow:sender];
+    [self.window center];
+    [self.window makeKeyAndOrderFront:sender];
+    [_profileListView focusSearchField];
+}
+
+- (void)profileTableRowSelected:(ProfileListView *)sender {
+    NSString *guid = sender.selectedGuid;
+    if (!guid) {
+        return;
+    }
+    if (self.profileSelected) {
+        self.profileSelected(guid);
+    }
+    [self close];
+}
+
+- (void)windowWillClose:(NSNotification *)notification {
+    [_profileListView clearSearchField];
+}
+
+@end

--- a/sources/iTermController/iTermController.h
+++ b/sources/iTermController/iTermController.h
@@ -89,6 +89,9 @@ extern NSString *const iTermSnippetsTagsDidChange;
 - (void)arrangeHorizontally;
 - (void)newSessionInTabAtIndex:(id)sender;
 - (void)newSessionInWindowAtIndex:(id)sender;
++ (SEL)profilesMenuActionForOpenProfilesInNewWindow:(BOOL)openProfilesInNewWindow
+                                      modifierFlags:(NSEventModifierFlags)modifierFlags;
+- (void)openProfileFromProfilesMenuWithGuid:(NSString *)guid;
 - (PseudoTerminal*)keyTerminalWindow;
 - (PTYSession *)anyTmuxSession;
 
@@ -317,4 +320,3 @@ typedef NS_OPTIONS(NSUInteger, iTermSingleUseWindowOptions) {
 - (NSArray<NSString *> *)currentSnippetsFilter;
 
 @end
-

--- a/sources/iTermController/iTermController.m
+++ b/sources/iTermController/iTermController.m
@@ -88,6 +88,7 @@ extern NSString *const iTermProcessTypeDidChangeNotification;
 static iTermController *gSharedInstance;
 
 @interface iTermController()<iTermSetCurrentTerminalHelperDelegate, iTermPresentationControllerDelegate>
+- (void)openProfileFromProfilesMenuWithGuid:(NSString *)guid action:(SEL)action;
 @end
 
 @implementation iTermController {
@@ -322,6 +323,44 @@ static iTermController *gSharedInstance;
                                   inTerminal:nil
                           respectTabbingMode:NO
                                   completion:nil];
+    }
+}
+
++ (SEL)profilesMenuActionForOpenProfilesInNewWindow:(BOOL)openProfilesInNewWindow
+                                      modifierFlags:(NSEventModifierFlags)modifierFlags {
+    const BOOL optionPressed = (modifierFlags & NSEventModifierFlagOption) != 0;
+    const BOOL openInWindow = optionPressed ? !openProfilesInNewWindow : openProfilesInNewWindow;
+    return openInWindow ? @selector(newSessionInWindowAtIndex:) : @selector(newSessionInTabAtIndex:);
+}
+
+- (void)openProfileFromProfilesMenuWithGuid:(NSString *)guid {
+    if (!guid) {
+        return;
+    }
+
+    SEL action = [self.class profilesMenuActionForOpenProfilesInNewWindow:[iTermAdvancedSettingsModel openProfilesInNewWindow]
+                                                            modifierFlags:[NSEvent modifierFlags]];
+    [self openProfileFromProfilesMenuWithGuid:guid action:action];
+}
+
+- (void)openProfileFromProfilesMenuWithGuid:(NSString *)guid action:(SEL)action {
+    if (!guid) {
+        return;
+    }
+
+    NSMenuItem *sender = [[NSMenuItem alloc] initWithTitle:@""
+                                                    action:action
+                                             keyEquivalent:@""];
+    sender.representedObject = guid;
+    id validator = [NSApp delegate];
+    if ([validator respondsToSelector:@selector(validateMenuItem:)] &&
+        ![validator validateMenuItem:sender]) {
+        return;
+    }
+    if (action == @selector(newSessionInWindowAtIndex:)) {
+        [self newSessionInWindowAtIndex:sender];
+    } else {
+        [self newSessionInTabAtIndex:sender];
     }
 }
 
@@ -2239,4 +2278,3 @@ replaceInitialDirectoryForSessionWithGUID:(NSString *)guid
 }
 
 @end
-


### PR DESCRIPTION
Adds Search Profiles… to the Profiles menu with a lightweight ProfileListView-based search panel. Reuses the existing Profiles menu open path and includes ModernTests for GUID/open-action behavior.