### PR TITLE
Move rtlFound with row content in scrollRect (fixes RTL scrambling in TUIs)

### DIFF
--- a/ModernTests/BidiTUIRepaintTests.swift
+++ b/ModernTests/BidiTUIRepaintTests.swift
@@ -1,0 +1,338 @@
+//
+//  BidiTUIRepaintTests.swift
+//  ModernTests
+//
+//  A TUI (like an AI agent CLI) repaints its output in place: cursor up,
+//  erase line, rewrite, then eventually the rows scroll into history. Rows
+//  written this way must get the same bidi treatment as rows printed once
+//  and never touched. These tests replay that write pattern at the
+//  VT100ScreenMutableState level, running populateRTLStateIfNeeded between
+//  cycles the way the per-frame sync does, and assert that the per-row
+//  BidiDisplayInfo survives each cycle.
+//
+
+import XCTest
+@testable import iTerm2SharedARC
+
+// FakeSession leaves screenRestore(_:) and screenUpdateDisplay(_:)
+// unimplemented. Without the former, the screen's shared-state count never
+// returns to zero after a joined block and every synchronizeWithConfig
+// short-circuits; without the latter, the end-of-joined-block sync that
+// PTYSession performs in production never happens. These tests exercise the
+// real sync cadence, so implement both the way PTYSession does.
+private class SyncingFakeSession: FakeSession {
+    private let syncConfig: VT100MutableScreenConfiguration = {
+        let config = VT100MutableScreenConfiguration()
+        config.sessionGuid = "BidiTUIRepaintTests"
+        return config
+    }()
+
+    override func screenRestore(_ state: VT100ScreenState) {
+        screen?.restore(state)
+    }
+
+    override func screenUpdateDisplay(_ redraw: Bool) {
+        guard let screen else { return }
+        _ = screen.synchronize(withConfig: syncConfig,
+                               expect: nil,
+                               checkTriggers: .none,
+                               resetOverflow: false,
+                               mutableState: screen.mutableState)
+    }
+}
+
+class BidiTUIRepaintTests: XCTestCase {
+    private var session = SyncingFakeSession()
+
+    private let persian = "جشنواره فیلم کوتاه تا یکشنبه ادامه دارد"
+    private let mixed = "فستیوال Hikari Japan Festival فقط شنبه است"
+
+    // [iTermPreferences bidiEnabled] is a fast-path cache updated via async
+    // KVO dispatched to the main queue; pump the runloop until it lands.
+    private func setBidiPreference(_ enabled: Bool) {
+        iTermPreferences.setBool(enabled, forKey: kPreferenceKeyBidi)
+        let deadline = Date().addingTimeInterval(0.5)
+        while iTermPreferences.bidiEnabled() != enabled && Date() < deadline {
+            RunLoop.main.run(mode: .default, before: Date(timeIntervalSinceNow: 0.005))
+        }
+    }
+
+    private func makeScreen(width: Int32 = 60, height: Int32 = 6) -> VT100Screen {
+        let screen = VT100Screen()
+        session.screen = screen
+        screen.delegate = session
+        screen.performBlock(joinedThreads: { _, mutableState, _ in
+            mutableState.terminalEnabled = true
+            mutableState.terminal!.termType = "xterm"
+            screen.destructivelySetScreenWidth(width, height: height, mutableState: mutableState)
+        })
+        return screen
+    }
+
+    override func setUp() {
+        super.setUp()
+        setBidiPreference(true)
+    }
+
+    override func tearDown() {
+        setBidiPreference(false)
+        super.tearDown()
+    }
+
+    // Runs one "frame": performs the writes, then populates RTL state the way
+    // the cross-thread sync does before every draw, and returns the bidi info
+    // for the requested grid row.
+    @discardableResult
+    private func frame(_ screen: VT100Screen,
+                       row: Int32 = 0,
+                       writes: @escaping (VT100ScreenMutableState) -> Void) -> BidiDisplayInfoObjc? {
+        var info: BidiDisplayInfoObjc?
+        screen.performBlock(joinedThreads: { _, mutableState, _ in
+            writes(mutableState)
+            mutableState.populateRTLStateIfNeeded()
+            info = mutableState.currentGrid.bidiInfo(forLine: row)
+        })
+        return info
+    }
+
+    private func assertHasRTLRuns(_ info: BidiDisplayInfoObjc?,
+                                  _ message: String,
+                                  file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertNotNil(info, message, file: file, line: line)
+        if let info {
+            XCTAssertFalse(info.rtlIndexes.isEmpty,
+                           "bidi info exists but has no RTL runs — \(message)",
+                           file: file, line: line)
+        }
+    }
+
+    // Baseline: a Persian row printed once, like `cat`, gets bidi info.
+    func testPlainAppendGetsBidiInfo() {
+        let screen = makeScreen()
+        let info = frame(screen) { mutableState in
+            mutableState.appendString(atCursor: self.persian)
+            mutableState.appendCarriageReturnLineFeed()
+        }
+        assertHasRTLRuns(info, "plain append must produce bidi info")
+    }
+
+    // One repaint cycle: draw, then cursor-up + erase + rewrite, draw again.
+    func testRepaintedRowKeepsBidiInfo() {
+        let screen = makeScreen()
+        let before = frame(screen) { mutableState in
+            mutableState.appendString(atCursor: self.persian)
+            mutableState.appendCarriageReturnLineFeed()
+        }
+        assertHasRTLRuns(before, "before repaint")
+
+        let after = frame(screen) { mutableState in
+            mutableState.cursorUp(1, andToStartOfLine: true)
+            mutableState.eraseLine(beforeCursor: true, afterCursor: true, decProtect: false)
+            mutableState.appendString(atCursor: self.persian)
+            mutableState.appendCarriageReturnLineFeed()
+        }
+        assertHasRTLRuns(after, "after one repaint cycle")
+    }
+
+    // Streaming: several repaint cycles with a populate (≈ a drawn frame)
+    // between each, mixed Persian/English like real agent output.
+    func testStreamingRepaintCyclesKeepBidiInfo() {
+        let screen = makeScreen()
+        frame(screen) { mutableState in
+            mutableState.appendString(atCursor: self.mixed)
+            mutableState.appendCarriageReturnLineFeed()
+        }
+        for cycle in 1...5 {
+            let info = frame(screen) { mutableState in
+                mutableState.cursorUp(1, andToStartOfLine: true)
+                mutableState.eraseLine(beforeCursor: true, afterCursor: true, decProtect: false)
+                mutableState.appendString(atCursor: self.mixed)
+                mutableState.appendCarriageReturnLineFeed()
+            }
+            assertHasRTLRuns(info, "after repaint cycle \(cycle)")
+        }
+    }
+
+    // A repaint that is interrupted mid-frame: erase happens, populate runs
+    // (blank row), then the rewrite lands in the next frame. The final frame
+    // must still produce bidi info.
+    func testEraseThenRewriteAcrossFrames() {
+        let screen = makeScreen()
+        frame(screen) { mutableState in
+            mutableState.appendString(atCursor: self.persian)
+            mutableState.appendCarriageReturnLineFeed()
+        }
+        frame(screen) { mutableState in
+            mutableState.cursorUp(1, andToStartOfLine: true)
+            mutableState.eraseLine(beforeCursor: true, afterCursor: true, decProtect: false)
+        }
+        let info = frame(screen) { mutableState in
+            mutableState.appendString(atCursor: self.persian)
+            mutableState.appendCarriageReturnLineFeed()
+        }
+        assertHasRTLRuns(info, "rewrite one frame after erase")
+    }
+
+    // Region scrolls (DECSTBM, IND at the bottom margin, IL/DL) move row
+    // content with scrollRect:downBy:softBreak:. The rtlFound annotation must
+    // travel with the content: bidi analysis is gated on it, so leaving it
+    // behind makes the next populate pass null out the moved row's bidi info
+    // and the row renders in raw logical order.
+    func testScrollRectMovesRTLFoundWithContent() {
+        let grid = VT100Grid(size: VT100GridSize(width: 20, height: 4), delegate: nil)!
+        let lineBuffer = LineBuffer(blockSize: 1000)
+
+        func appendRow(_ text: String, rtl: Bool) {
+            let sca = screenCharArrayWithDefaultStyle(text, eol: EOL_HARD)
+            grid.appendChars(atCursor: sca.line,
+                             length: sca.length,
+                             scrollingInto: lineBuffer,
+                             unlimitedScrollback: true,
+                             useScrollbackWithRegion: false,
+                             wraparound: true,
+                             ansi: false,
+                             insert: false,
+                             externalAttributeIndex: nil,
+                             rtlFound: rtl,
+                             dwcFree: false)
+            grid.cursorX = 0
+            grid.cursorY += 1
+        }
+        appendRow("hello", rtl: false)
+        appendRow(persian, rtl: true)
+        XCTAssertFalse(grid.metadata(atLineNumber: 0).rtlFound.boolValue, "precondition")
+        XCTAssertTrue(grid.metadata(atLineNumber: 1).rtlFound.boolValue, "precondition")
+
+        // Scroll the whole grid up one row: the Persian row moves from 1 to 0.
+        grid.scroll(VT100GridRectMake(0, 0, 20, 4), downBy: -1, softBreak: false)
+
+        XCTAssertTrue(grid.metadata(atLineNumber: 0).rtlFound.boolValue,
+                      "rtlFound must move with the Persian row's content")
+    }
+
+    // End to end: after a region scroll, the moved Persian row must still get
+    // bidi info from the next populate pass.
+    func testRegionScrollKeepsBidiInfo() {
+        let screen = makeScreen(width: 40, height: 4)
+        let before = frame(screen, row: 1) { mutableState in
+            mutableState.appendString(atCursor: "hello")
+            mutableState.appendCarriageReturnLineFeed()
+            mutableState.appendString(atCursor: self.persian)
+            mutableState.appendCarriageReturnLineFeed()
+        }
+        assertHasRTLRuns(before, "before region scroll")
+
+        var after: BidiDisplayInfoObjc?
+        screen.performBlock(joinedThreads: { _, mutableState, _ in
+            // Emulate a TUI scrolling its viewport: the grid rows shift up by
+            // one without going through the line buffer.
+            mutableState.currentGrid.scroll(VT100GridRectMake(0, 0, 40, 4),
+                                            downBy: -1,
+                                            softBreak: false)
+            mutableState.populateRTLStateIfNeeded()
+            after = mutableState.currentGrid.bidiInfo(forLine: 0)
+        })
+        XCTAssertNotNil(after, "Persian row scrolled up a row must keep bidi info")
+        if let after {
+            XCTAssertFalse(after.rtlIndexes.isEmpty, "moved row must still have RTL runs")
+        }
+    }
+
+    // Streaming within a row: agents append a sentence to the same row in
+    // several chunks, and a bidi pass (≈ a drawn frame) can run between any
+    // two chunks. The final row's reordering table must be identical to the
+    // one produced by writing the whole sentence at once — a stale mid-write
+    // table shifts every subsequent letter by a cell.
+    func testChunkedAppendMatchesOneShotBidiInfo() {
+        // ZWNJ-heavy, like real Persian prose.
+        let sentence = "میرم پیش‌بینی هوای برلین رو از سرویس هواشناسی بگیرم و بعد دنبال برنامه‌های آخر هفته بگردم."
+
+        let oneShot = makeScreen(width: 100, height: 6)
+        let expected = frame(oneShot) { mutableState in
+            mutableState.appendString(atCursor: sentence)
+        }
+        assertHasRTLRuns(expected, "one-shot append must produce bidi info")
+
+        let chunked = makeScreen(width: 100, height: 6)
+        // Split mid-word and next to ZWNJs, the worst places to pause.
+        let chunks = ["میرم پیش", "‌بینی هوا", "ی برلین رو از سروی", "س هواشناسی بگیرم و بع", "د دنبال برنامه‌", "های آخر هفته بگردم."]
+        XCTAssertEqual(chunks.joined(), sentence, "chunks must reassemble the sentence")
+        var actual: BidiDisplayInfoObjc?
+        for chunk in chunks {
+            actual = frame(chunked) { mutableState in
+                mutableState.appendString(atCursor: chunk)
+            }
+        }
+        XCTAssertNotNil(actual, "chunked append must produce bidi info")
+        XCTAssertEqual(actual, expected,
+                       "chunked and one-shot appends must yield the same reordering")
+    }
+
+    // The renderer draws from the immutable state's grid, refreshed from the
+    // mutable grid on every frame sync. After each sync the renderer's copy
+    // must be self-consistent: its stored bidi info must match info computed
+    // fresh from its own row content. A stale copy shifts every letter drawn
+    // after the staleness point.
+    func testRendererCopyStaysConsistentAcrossStreamingFrames() {
+        let width: Int32 = 100
+        let screen = makeScreen(width: width, height: 6)
+
+        let chunks = ["میرم پیش", "‌بینی هوا", "ی برلین رو از سروی", "س هواشناسی بگیرم و بع", "د دنبال برنامه‌", "های آخر هفته بگردم."]
+        for (i, chunk) in chunks.enumerated() {
+            var mayRTL = false
+            // The sync happens automatically at the end of the joined block via
+            // SyncingFakeSession.screenUpdateDisplay, as in production.
+            screen.performBlock(joinedThreads: { _, mutableState, _ in
+                mutableState.appendString(atCursor: chunk)
+                mayRTL = mutableState.currentGrid.mayContainRTL
+            })
+            XCTAssertTrue(mayRTL, "probe: grid must know it may contain RTL after chunk \(i)")
+            XCTAssertTrue(iTermPreferences.bidiEnabled(), "probe: pref cache on at sync time, chunk \(i)")
+
+            // What the renderer actually consumes: the SCA from the
+            // main-thread state, with its attached bidi info.
+            let sca = screen.screenCharArray(forLine: 0)
+            let stored = sca.bidiInfo
+            let fresh = BidiDisplayInfoObjc(sca, paddedTo: width)
+            // Triangulation probes: which hop loses the bidi info?
+            var mutableGridInfo: BidiDisplayInfoObjc?
+            screen.performBlock(joinedThreads: { _, mutableState, _ in
+                mutableGridInfo = mutableState.currentGrid.bidiInfo(forLine: 0)
+            })
+            let drawingAccessor = screen.bidiInfo(forLine: 0)
+            XCTAssertNotNil(mutableGridInfo, "probe: mutable grid after chunk \(i)")
+            XCTAssertNotNil(drawingAccessor, "probe: screen.bidiInfoForLine after chunk \(i)")
+            XCTAssertEqual(stored, fresh,
+                           "renderer bidi info stale after streaming chunk \(i)")
+        }
+    }
+
+    // The rewritten row scrolls into history; its bidi info must survive in
+    // the line buffer, which is what the renderer consults for history rows.
+    func testRepaintedRowScrolledIntoHistoryKeepsBidiInfo() {
+        let screen = makeScreen(width: 60, height: 4)
+        frame(screen) { mutableState in
+            mutableState.maxScrollbackLines = 100
+            mutableState.appendString(atCursor: self.persian)
+            mutableState.appendCarriageReturnLineFeed()
+        }
+        let before = frame(screen) { mutableState in
+            mutableState.cursorUp(1, andToStartOfLine: true)
+            mutableState.eraseLine(beforeCursor: true, afterCursor: true, decProtect: false)
+            mutableState.appendString(atCursor: self.persian)
+            mutableState.appendCarriageReturnLineFeed()
+        }
+        assertHasRTLRuns(before, "before scrolling out")
+
+        var historyInfo: BidiDisplayInfoObjc?
+        screen.performBlock(joinedThreads: { _, mutableState, _ in
+            for _ in 0..<8 {
+                mutableState.appendCarriageReturnLineFeed()
+            }
+            mutableState.populateRTLStateIfNeeded()
+            let width = mutableState.currentGrid.size.width
+            historyInfo = mutableState.linebuffer.bidiInfo(forLine: 0, width: width)
+        })
+        assertHasRTLRuns(historyInfo, "after scrolling into history")
+    }
+}

--- a/docs/notes-3.7.txt
+++ b/docs/notes-3.7.txt
@@ -2562,3 +2562,11 @@ Bug Fixes:
   because your input method changed the
   character a key produces, iTerm2 now offers
   to interpret key bindings by physical key.
+- Fixed right-to-left text getting scrambled in
+  full-screen programs and AI agent CLIs that
+  scroll or repaint their output region: the
+  per-line right-to-left annotation now moves
+  with the content when a scroll region shifts
+  rows, so Persian, Arabic, and Hebrew lines
+  keep their correct display order instead of
+  falling back to logical order.

--- a/sources/VT100/VT100Grid.m
+++ b/sources/VT100/VT100Grid.m
@@ -1892,6 +1892,17 @@ externalAttributeIndex:(iTermExternalAttributeIndex *)ea {
             [self copyExternalAttributesFrom:VT100GridCoordMake(rect.origin.x, sourceIndex)
                                           to:VT100GridCoordMake(rect.origin.x, destIndex)
                                       length:length];
+            // Bidi analysis is gated on rtlFound, so it must travel with the
+            // content. A full-width move replaces the whole row; a partial move
+            // mixes moved and existing content, where a stale YES only costs a
+            // wasted analysis but a stale NO would leave RTL text drawn in
+            // logical order.
+            const BOOL sourceRTL = [self lineInfoAtLineNumber:sourceIndex].metadata.rtlFound;
+            if (rect.origin.x == 0 && rect.size.width == size_.width) {
+                [[self lineInfoAtLineNumber:destIndex] setRTLFound:sourceRTL];
+            } else if (sourceRTL) {
+                [[self lineInfoAtLineNumber:destIndex] setRTLFound:YES];
+            }
 
             sourceIndex -= direction;
             destIndex -= direction;

--- a/tests/rtl-tui-repro.sh
+++ b/tests/rtl-tui-repro.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Emulates how a TUI (like Claude Code) writes streaming RTL output:
+# print a Persian paragraph, then repeatedly repaint it in place
+# (cursor up + erase line + rewrite, with styled segments), then let
+# it scroll into history. With bidi enabled, all four copies below
+# must render identically (right-justified, correct RTL order). If
+# the repainted copies render in logical order (visually reversed)
+# while the plain-printed ones are correct, the bug reproduces.
+#
+# Usage: run in an iTerm2 window with RTL support enabled and watch
+# the output. The window should be at least 60 columns wide.
+
+L1='داشتیم به فارسی درباره آبوهوا و برنامه آخر هفته برلین صحبت می‌کردیم.'
+L2='جشنواره British Shorts Summer Edition تا یکشنبه ادامه دارد و هوا حدود ۲۵ درجه است.'
+L3='فستیوال فرهنگ و غذای ژاپنی Hikari Japan Festival فقط شنبه است.'
+
+echo "=== PLAIN (control): printed once, never repainted ==="
+printf '%s\n%s\n%s\n' "$L1" "$L2" "$L3"
+echo
+
+echo "=== REPAINTED: rewritten in place 5 times ==="
+printf '%s\n%s\n%s\n' "$L1" "$L2" "$L3"
+for i in 1 2 3 4 5; do
+    sleep 0.1
+    # Cursor up 3 rows, then erase and rewrite each row.
+    printf '\033[3A'
+    printf '\r\033[2K%s\n' "$L1"
+    printf '\r\033[2K%s\n' "$L2"
+    printf '\r\033[2K%s\n' "$L3"
+done
+echo
+
+echo "=== SEGMENTED: each row written as styled pieces ==="
+printf '\033[1m%s\033[0m %s \033[2m%s\033[0m\n' 'جشنواره' 'British Shorts Summer Edition' 'تا یکشنبه ادامه دارد.'
+printf '\033[33m%s\033[0m %s\n' 'فستیوال ژاپنی' 'Hikari Japan Festival فقط شنبه است.'
+echo
+
+echo "=== SCROLLED: repainted rows pushed into scrollback ==="
+printf '%s\n%s\n' "$L1" "$L2"
+sleep 0.1
+printf '\033[2A\r\033[2K%s\n\r\033[2K%s\n' "$L1" "$L2"
+for i in $(seq 1 3); do echo; done
+echo "(scroll up: the two rows above must still read correctly)"


### PR DESCRIPTION
## Problem

With right-to-left support enabled, RTL text printed by full-screen programs and AI agent CLIs comes out scrambled (drawn in raw logical order), while the same text printed by `cat` renders correctly. Persian/Arabic/Hebrew users chatting with terminal AI agents see most long paragraphs reversed.

## Cause

`scrollRect:downBy:softBreak:` moves characters (memmove) and external attributes between rows, but not the per-line `rtlFound` metadata. Bidi analysis is gated on that flag: `populateRTLState` skips paragraphs whose lines lack it and actively nulls their display info. So any RTL row moved by a region scroll (DECSTBM margin scrolling, IND at the bottom margin, IL/DL) is left with a stale `rtlFound=NO`, loses its BidiDisplayInfo on the next populate pass, and renders in logical order. TUIs scroll and repaint their regions constantly; `cat` never does, which is why plain output was unaffected.

## Fix

Carry `rtlFound` with the content in the move loop: copied exactly for a full-width move, ORed in for a partial-width move (a stale YES only costs a wasted bidi analysis; a stale NO renders RTL text backwards).

## Testing

- New `ModernTests/BidiTUIRepaintTests.swift` replays TUI write patterns end to end: repaint cycles (cursor up + EL + rewrite), chunked mid-row streaming, erase-and-rewrite split across frames, region scrolls (grid-level metadata check plus screen-level populate check — both red before the fix), scrollback commits, and a renderer-consistency test that runs the real `synchronizeWithConfig` cadence and asserts the SCA handed to the renderer carries bidi info matching its own content.
- Note: the shared test `FakeSession` never implemented `screenRestore(_:)` (so `_sharedStateCount` never returned to zero and all syncs short-circuited) or `screenUpdateDisplay(_:)`. The new tests use a subclass implementing both the way PTYSession does; the existing fixture is unchanged.
- `tests/rtl-tui-repro.sh` reproduces the bug visually with plain escape sequences (repainted and scrolled Persian paragraphs vs. plain-printed controls).
- Full VT100GridTests suite (158 tests) passes with the change.