### PR TITLE
Fix Kitty keyboard protocol SET behavior

### DIFF
--- a/sources/VT100/VT100Terminal.m
+++ b/sources/VT100/VT100Terminal.m
@@ -2511,17 +2511,30 @@ static BOOL VT100TokenIsTmux(VT100Token *token) {
 
         case VT100CSI_SET_KEY_REPORTING_MODE:
             self.dirty = YES;
-            [self.currentKeyReportingModeStack removeAllObjects];
-            switch (token.csi->p[1]) {
-                case 1:  // all set bits are set and all unset bits are reset
-                    _keyReportingFlags = token.csi->p[0];
-                    break;
-                case 2:  // all set bits are set, unset bits are left unchanged
-                    _keyReportingFlags |= token.csi->p[0];
-                    break;
-                case 3:  // all set bits are reset, unset bits are left unchanged
-                    _keyReportingFlags &= ~token.csi->p[0];
-                    break;
+            {
+                VT100TerminalKeyReportingFlags effective;
+                if (self.currentKeyReportingModeStack.count) {
+                    effective = self.currentKeyReportingModeStack.lastObject.intValue;
+                } else {
+                    effective = _keyReportingFlags;
+                }
+                switch (token.csi->p[1]) {
+                    case 1:  // all set bits are set and all unset bits are reset
+                        effective = token.csi->p[0];
+                        break;
+                    case 2:  // all set bits are set, unset bits are left unchanged
+                        effective |= token.csi->p[0];
+                        break;
+                    case 3:  // all set bits are reset, unset bits are left unchanged
+                        effective &= ~token.csi->p[0];
+                        break;
+                }
+                if (self.currentKeyReportingModeStack.count) {
+                    [self.currentKeyReportingModeStack removeLastObject];
+                    [self.currentKeyReportingModeStack addObject:@(effective)];
+                } else {
+                    _keyReportingFlags = effective;
+                }
             }
             [self.delegate terminalKeyReportingFlagsDidChange];
             break;


### PR DESCRIPTION
The SET form should modify the flags on the current stack frame, not destroy the entire stack. Compare the Ghostty [implementation](https://github.com/ghostty-org/ghostty/blob/4d605bf0d819df901a0332bbb320dc849fdd82e4/src/terminal/kitty/key.zig#L27):

```zig
    /// Perform the "set" operation as described in the spec for
    /// the CSI = u sequence.
    pub fn set(
        self: *FlagStack,
        mode: SetMode,
        v: Flags,
    ) void {
        switch (mode) {
            .set => self.flags[self.idx] = v,
            .@"or" => self.flags[self.idx] = @bitCast(
                self.flags[self.idx].int() | v.int(),
            ),
            .not => self.flags[self.idx] = @bitCast(
                self.flags[self.idx].int() & ~v.int(),
            ),
        }
    }
```