### PR TITLE
Fix two format string bugs in logging calls

### DIFF
--- a/sources/API/iTermAPIHelper.h
+++ b/sources/API/iTermAPIHelper.h
@@ -122,7 +122,7 @@ typedef NS_ENUM(NSUInteger, iTermNoAuthStatus) {
                            fullParameters:(out NSDictionary<NSString *, id> **)fullParameters;
 
 - (void)logToConnectionHostingFunctionWithSignature:(NSString *)signatureString
-                                             format:(NSString *)format, ...;
+                                             format:(NSString *)format, ... NS_FORMAT_FUNCTION(2,3);
 - (void)logToConnectionHostingFunctionWithSignature:(NSString *)signatureString
                                              string:(NSString *)string;
 - (iTermScriptHistoryEntry *)scriptHistoryEntryForConnectionKey:(NSString *)connectionKey;

--- a/sources/Hotkey/iTermProfileHotKey.m
+++ b/sources/Hotkey/iTermProfileHotKey.m
@@ -605,6 +605,7 @@ static NSString *const kArrangement = @"Arrangement";
     self.windowController.window.animator.alphaValue = 0;
 #if BETA
     SetPinnedDebugLogMessage([NSString stringWithFormat:@"Fade out hotkey window %p", self],
+                             @"%@",
                              [[NSThread callStackSymbols] componentsJoinedByString:@"\n"]);
 #endif
     [NSAnimationContext endGrouping];

--- a/sources/Logging/DebugLogging.h
+++ b/sources/Logging/DebugLogging.h
@@ -248,7 +248,7 @@ void TurnOnDebugLoggingSilently(void);
 BOOL TurnOffDebugLoggingSilently(void);
 void TurnOnDebugLoggingAutomatically(void);
 
-void SetPinnedDebugLogMessage(NSString *key, NSString *value, ...);
+void SetPinnedDebugLogMessage(NSString *key, NSString *value, ...) NS_FORMAT_FUNCTION(2,3);
 void AppendPinnedDebugLogMessage(NSString *key, NSString *value, ...);
 
 _Noreturn NS_INLINE void iTermCrashWithMessage(const char *file,

--- a/sources/PTYSession/iTermSessionNameController.m
+++ b/sources/PTYSession/iTermSessionNameController.m
@@ -229,7 +229,7 @@ NSString *const iTermSessionNameControllerSystemTitleUniqueIdentifier = @"com.it
                                                                               string:message];
     } else {
         [[iTermAPIHelper sharedInstance] logToConnectionHostingFunctionWithSignature:nil
-                                                                              format:@"Malformed invocation in session name controller. The invocation is:\n%@\nIt doesn't look like a function call! The parser said:\n",
+                                                                              format:@"Malformed invocation in session name controller. The invocation is:\n%@\nIt doesn't look like a function call! The parser said:\n%@",
          invocation,
          invocationError.localizedDescription];
     }

--- a/sources/Swipe/iTermSwipeTracker.m
+++ b/sources/Swipe/iTermSwipeTracker.m
@@ -98,7 +98,7 @@ NSString *const iTermSwipeHandlerCancelSwipe = @"iTermSwipeHandlerCancelSwipe";
             } else {
                 if ([NSDate it_timeSinceBoot] - lastEvent > 5) {
                     [self abort];
-                    SetPinnedDebugLogMessage(@"SwipeTracker", [log componentsJoinedByString:@"\n"]);
+                    SetPinnedDebugLogMessage(@"SwipeTracker", @"%@", [log componentsJoinedByString:@"\n"]);
                     break;
                 }
             }


### PR DESCRIPTION
Caught one actual bug and two places where it was probably not causing any real problems but deserved cleanup.

I can also do a full scan over the repo and add the `NS_FORMAT_FUNCTION` macro everywhere, but let me know if you want that before I go off and drop a ~50LOC PR on you for that.