### PR TITLE
RTL selection, highlight, and copy in the terminal

### DIFF
--- a/ModernTests/BidiCopyLogicalRangeTests.swift
+++ b/ModernTests/BidiCopyLogicalRangeTests.swift
@@ -99,4 +99,28 @@ class BidiCopyLogicalRangeTests: XCTestCase {
         XCTAssertTrue(text.contains("ر") || text.contains("ز"),
                       "line 1 (روز خوش دوست) dropped from multi-line copy; got >>>\(text)<<<")
     }
+
+    // A partial selection covering an English word embedded in RTL must copy the
+    // whole word contiguously — «Berlin» must not come out as «B … شهری» (the
+    // visually-adjacent-but-logically-split result the user hit).
+    func testPartialCopyKeepsEnglishWordWhole() {
+        let width = 40
+        // Persian first -> RTL paragraph; «Berlin» is an English island in the middle.
+        let content = "متن Berlin شهری بزرگ"
+        let s = content + String(repeating: " ", count: width - content.count)
+        let base = screenCharArrayWithDefaultStyle(s, eol: EOL_HARD)
+        guard let bidi = BidiDisplayInfoObjc(base) else { return XCTFail("no bidi") }
+        XCTAssertNotEqual(bidi.visualForLogical(0), 0, "mixed line not reordered; test is meaningless")
+        let sca = ScreenCharArray(copyOfLine: base.line, length: base.length,
+                                  continuation: base.continuation, bidiInfo: bidi)
+        let ds = BidiLinesDataSource([sca], width: Int32(width))
+        let extractor = iTermTextExtractor(dataSource: ds)
+        extractor.supportBidi = true
+
+        // Select logical [0, 12): «متن Berlin ش» — covers متن plus the whole Berlin island.
+        let range = VT100GridWindowedRangeMake(VT100GridCoordRangeMake(0, 0, 12, 0), 0, 0)
+        let text = extractor.content(in: range, excludingSubranges: nil) ?? ""
+        XCTAssertTrue(text.contains("Berlin"),
+                      "English island was split by the copy; expected whole 'Berlin', got >>>\(text)<<<")
+    }
 }

--- a/ModernTests/BidiCopyLogicalRangeTests.swift
+++ b/ModernTests/BidiCopyLogicalRangeTests.swift
@@ -1,0 +1,102 @@
+//
+//  BidiCopyLogicalRangeTests.swift
+//  ModernTests
+//
+//  The selection is stored in LOGICAL coordinates. Copying it must return the
+//  text of that LOGICAL range in reading order. On a reordered right-to-left
+//  line the extractor's bidi branch used to treat the range as VISUAL, so a
+//  partial selection (and the last line of a multi-line selection) extracted
+//  the empty left margin instead of the words — the copy came back empty even
+//  though the highlight (which correctly uses the logical range) showed text.
+//
+
+import XCTest
+@testable import iTerm2SharedARC
+
+private final class BidiLinesDataSource: NSObject, iTermTextDataSource {
+    private let scas: [ScreenCharArray]
+    private let gridWidth: Int32
+    init(_ scas: [ScreenCharArray], width: Int32) { self.scas = scas; self.gridWidth = width; super.init() }
+    func width() -> Int32 { gridWidth }
+    func numberOfLines() -> Int32 { Int32(scas.count) }
+    func totalScrollbackOverflow() -> Int64 { 0 }
+    func screenCharArray(forLine line: Int32) -> ScreenCharArray {
+        (line >= 0 && line < Int32(scas.count)) ? scas[Int(line)] : ScreenCharArray.emptyLine(ofLength: gridWidth)
+    }
+    func screenCharArray(atScreenIndex index: Int32) -> ScreenCharArray { screenCharArray(forLine: index) }
+    func externalAttributeIndex(forLine y: Int32) -> (any iTermExternalAttributeIndexReading)? { nil }
+    func fetchLine(_ line: Int32, block: (ScreenCharArray) -> Any?) -> Any? { block(screenCharArray(forLine: line)) }
+    func date(forLine line: Int32) -> Date? { nil }
+    func commandMark(at coord: VT100GridCoord, mustHaveCommand: Bool, range: UnsafeMutablePointer<VT100GridWindowedRange>?) -> (any VT100ScreenMarkReading)? { nil }
+    func metadata(onLine lineNumber: Int32) -> iTermImmutableMetadata { iTermImmutableMetadataDefault() }
+    func isFirstLine(ofBlock lineNumber: Int32) -> Bool { false }
+}
+
+class BidiCopyLogicalRangeTests: XCTestCase {
+    private var savedDetect: Any?
+    override func setUp() {
+        super.setUp()
+        iTermPreferences.setBool(true, forKey: kPreferenceKeyBidi)
+        savedDetect = iTermUserDefaults.userDefaults().object(forKey: "DetectParagraphDirection")
+        iTermUserDefaults.userDefaults().set(true, forKey: "DetectParagraphDirection")
+        iTermAdvancedSettingsModel.loadAdvancedSettingsFromUserDefaults()
+    }
+    override func tearDown() {
+        if let v = savedDetect { iTermUserDefaults.userDefaults().set(v, forKey: "DetectParagraphDirection") }
+        else { iTermUserDefaults.userDefaults().removeObject(forKey: "DetectParagraphDirection") }
+        iTermAdvancedSettingsModel.loadAdvancedSettingsFromUserDefaults()
+        iTermPreferences.setBool(false, forKey: kPreferenceKeyBidi)
+        super.tearDown()
+    }
+
+    // Returns (sca, bidi). Asserts the line is actually reordered.
+    private func reorderedLine(_ content: String, width: Int, file: StaticString = #filePath, line: UInt = #line) -> (ScreenCharArray, BidiDisplayInfoObjc)? {
+        let s = content + String(repeating: " ", count: max(0, width - content.count))
+        let base = screenCharArrayWithDefaultStyle(s, eol: EOL_HARD)
+        guard let bidi = BidiDisplayInfoObjc(base) else { XCTFail("no bidi", file: file, line: line); return nil }
+        // Sanity: a right-to-left line must NOT be identity-mapped, or the test
+        // isn't exercising reordering at all.
+        XCTAssertNotEqual(bidi.visualForLogical(0), 0, "line not reordered; test is meaningless", file: file, line: line)
+        let sca = ScreenCharArray(copyOfLine: base.line, length: base.length,
+                                  continuation: base.continuation, bidiInfo: bidi)
+        return (sca, bidi)
+    }
+
+    // Partial selection on ONE reordered RTL line: logical [0, k). Copy must be
+    // the first k logical characters (reading order), not the empty left margin.
+    func testPartialSingleLineCopyIsLogical() {
+        let width = 30
+        let content = "سلام دنیا خوب"
+        guard let (sca, _) = reorderedLine(content, width: width) else { return }
+        let ds = BidiLinesDataSource([sca], width: Int32(width))
+        let extractor = iTermTextExtractor(dataSource: ds)
+        extractor.supportBidi = true
+
+        let k: Int32 = 4  // logical [0,4) == first 4 chars "سلام"
+        let range = VT100GridWindowedRangeMake(VT100GridCoordRangeMake(0, 0, k, 0), 0, 0)
+        let text = (extractor.content(in: range, excludingSubranges: nil) ?? "")
+            .trimmingCharacters(in: .whitespaces)
+        let expected = String(Array(content)[0..<Int(k)])
+        XCTAssertEqual(text, expected, "partial RTL copy should be the logical range \(expected), got >>>\(text)<<<")
+    }
+
+    // Multi-line: line 0 from logical 4 to end, line 1 from start to logical 6.
+    // Copy must include BOTH lines' logical text.
+    func testMultilineRTLCopyIncludesBothLines() {
+        let width = 30
+        let l0 = "سلام دنیا خوب"
+        let l1 = "روز خوش دوست"
+        guard let (s0, _) = reorderedLine(l0, width: width),
+              let (s1, _) = reorderedLine(l1, width: width) else { return }
+        let ds = BidiLinesDataSource([s0, s1], width: Int32(width))
+        let extractor = iTermTextExtractor(dataSource: ds)
+        extractor.supportBidi = true
+
+        let range = VT100GridWindowedRangeMake(VT100GridCoordRangeMake(4, 0, 6, 1), 0, 0)
+        let text = extractor.content(in: range, excludingSubranges: nil) ?? ""
+        // «ر»/«ز» appear only in line 1 (روز); their presence means line 1 wasn't dropped.
+        XCTAssertTrue(text.contains("ن") || text.contains("ا"), "line 0 missing; got >>>\(text)<<<")
+        XCTAssertTrue(text.contains("ر") || text.contains("ز"),
+                      "line 1 (روز خوش دوست) dropped from multi-line copy; got >>>\(text)<<<")
+    }
+}

--- a/ModernTests/BidiDragSelectionTests.swift
+++ b/ModernTests/BidiDragSelectionTests.swift
@@ -1,0 +1,195 @@
+//
+//  BidiDragSelectionTests.swift
+//  ModernTests
+//
+//  A drag selects VISUAL columns; the mouse handler converts each endpoint to a
+//  LOGICAL cell (logicalForVisual), stores the inclusive logical range, and the
+//  highlight draws each selected logical cell at its visual column. On a right-
+//  justified RTL line (content pushed right by trailing spaces that reorder to
+//  the visual left) the highlight must cover the same visual columns the user
+//  dragged over — not empty space on the far left.
+//
+
+import XCTest
+@testable import iTerm2SharedARC
+
+// One bidi line, exposed to iTermTextExtractor so its visual→logical conversion
+// (the exact call the mouse handler makes on mouse-down and drag) can be tested.
+private class OneBidiLineDataSource: NSObject, iTermTextDataSource {
+    private let sca: ScreenCharArray
+    private let gridWidth: Int32
+    init(_ sca: ScreenCharArray, width: Int32) { self.sca = sca; self.gridWidth = width; super.init() }
+    func width() -> Int32 { gridWidth }
+    func numberOfLines() -> Int32 { 1 }
+    func totalScrollbackOverflow() -> Int64 { 0 }
+    func screenCharArray(forLine line: Int32) -> ScreenCharArray { sca }
+    func screenCharArray(atScreenIndex index: Int32) -> ScreenCharArray { sca }
+    func externalAttributeIndex(forLine y: Int32) -> (any iTermExternalAttributeIndexReading)? { nil }
+    func fetchLine(_ line: Int32, block: (ScreenCharArray) -> Any?) -> Any? { block(sca) }
+    func date(forLine line: Int32) -> Date? { nil }
+    func commandMark(at coord: VT100GridCoord, mustHaveCommand: Bool, range: UnsafeMutablePointer<VT100GridWindowedRange>?) -> (any VT100ScreenMarkReading)? { nil }
+    func metadata(onLine lineNumber: Int32) -> iTermImmutableMetadata { iTermImmutableMetadataDefault() }
+    func isFirstLine(ofBlock lineNumber: Int32) -> Bool { false }
+}
+
+class BidiDragSelectionTests: XCTestCase {
+    private func setBidiPreference(_ enabled: Bool) {
+        iTermPreferences.setBool(enabled, forKey: kPreferenceKeyBidi)
+        let deadline = Date().addingTimeInterval(0.5)
+        while iTermPreferences.bidiEnabled() != enabled && Date() < deadline {
+            RunLoop.main.run(mode: .default, before: Date(timeIntervalSinceNow: 0.005))
+        }
+    }
+    private var savedDetect: Any?
+    override func setUp() {
+        super.setUp()
+        setBidiPreference(true)
+        // Match the real app: paragraph direction auto-detected, so a first-strong
+        // RTL line becomes an RTL paragraph and its content is pushed to the right
+        // while trailing spaces reorder to the visual left.
+        savedDetect = iTermUserDefaults.userDefaults().object(forKey: "DetectParagraphDirection")
+        savedIsolate = iTermUserDefaults.userDefaults().object(forKey: "IsolateLatinRunsInRTL")
+        iTermUserDefaults.userDefaults().set(true, forKey: "DetectParagraphDirection")
+        iTermUserDefaults.userDefaults().set(true, forKey: "IsolateLatinRunsInRTL")
+        iTermAdvancedSettingsModel.loadAdvancedSettingsFromUserDefaults()
+    }
+    private var savedIsolate: Any?
+    override func tearDown() {
+        if let v = savedDetect { iTermUserDefaults.userDefaults().set(v, forKey: "DetectParagraphDirection") }
+        else { iTermUserDefaults.userDefaults().removeObject(forKey: "DetectParagraphDirection") }
+        if let v = savedIsolate { iTermUserDefaults.userDefaults().set(v, forKey: "IsolateLatinRunsInRTL") }
+        else { iTermUserDefaults.userDefaults().removeObject(forKey: "IsolateLatinRunsInRTL") }
+        iTermAdvancedSettingsModel.loadAdvancedSettingsFromUserDefaults()
+        setBidiPreference(false)
+        super.tearDown()
+    }
+
+    // Simulate the mouse path: drag visual [v1,v2] -> logical endpoints via
+    // logicalForVisual -> inclusive logical range -> highlight -> visual cells lit.
+    private func highlightedVisualsForDrag(_ bidi: BidiDisplayInfoObjc,
+                                           sca: ScreenCharArray,
+                                           v1: Int, v2: Int) -> Set<Int> {
+        let l1 = Int(bidi.logicalForVisual(Int32(v1)))
+        let l2 = Int(bidi.logicalForVisual(Int32(v2)))
+        var selected = IndexSet()
+        selected.insert(integersIn: min(l1, l2)..<(max(l1, l2) + 1))
+        let width = Int(sca.length)
+        var anyBlink: ObjCBool = false
+        guard let runs = iTermBackgroundColorRunsInLine.backgroundRuns(
+            inLine: sca.line, lineLength: Int32(width), sourceLineNumber: 0, displayLineNumber: 0,
+            selectedIndexes: selected, within: NSRange(location: 0, length: width),
+            matches: nil, anyBlink: &anyBlink, y: 0, bidi: bidi, eaIndex: nil, darkMode: false) else {
+            return []
+        }
+        var highlighted = Set<Int>()
+        for boxed in runs.array where boxed.valuePointer.pointee.selected.boolValue {
+            let r = boxed.valuePointer.pointee.visualRange
+            for v in r.location..<(r.location + r.length) { highlighted.insert(v) }
+        }
+        return highlighted
+    }
+
+    private func dumpMapping(_ label: String, _ bidi: BidiDisplayInfoObjc, _ n: Int) {
+        var lines = ["=== \(label) (numberOfCells=\(bidi.numberOfCells), inverseCount=\(bidi.inverseLUTCount)) ==="]
+        for logical in 0..<n {
+            lines.append("logical \(logical) -> visual \(bidi.visualForLogical(Int32(logical)))")
+        }
+        print(lines.joined(separator: "\n"))
+    }
+
+    // Pure RTL with trailing spaces: content reorders to the right, spaces to the
+    // left. Dragging over the content's visual columns must highlight exactly
+    // those columns.
+    func testRightJustifiedDragHighlightsDraggedColumns() {
+        let content = "سلام دنیا"            // 9 cells, all RTL/neutral
+        let s = content + "           "       // pad to 20 with trailing spaces
+        let sca = screenCharArrayWithDefaultStyle(s, eol: EOL_HARD)
+        guard let bidi = BidiDisplayInfoObjc(sca) else { return XCTFail("no bidi info") }
+        let width = Int(sca.length)
+        dumpMapping("right-justified", bidi, width)
+
+        // Find the visual span the CONTENT occupies (logical 0..<9).
+        let contentVisuals = (0..<9).map { Int(bidi.visualForLogical(Int32($0))) }
+        let vMin = contentVisuals.min()!, vMax = contentVisuals.max()!
+        print("content occupies visual [\(vMin)...\(vMax)]; dragging that span")
+
+        // Drag over the full content visual span.
+        let lit = highlightedVisualsForDrag(bidi, sca: sca, v1: vMin, v2: vMax)
+        print("dragged visual [\(vMin)...\(vMax)] -> lit \(lit.sorted())")
+
+        // Every dragged visual column that holds content must be lit, and no
+        // far-left empty column outside the dragged span may be lit.
+        for v in vMin...vMax {
+            XCTAssertTrue(lit.contains(v), "content visual column \(v) was dragged but not highlighted")
+        }
+        for v in lit {
+            XCTAssertTrue(v >= vMin && v <= vMax, "column \(v) lit but is outside the dragged span [\(vMin)...\(vMax)]")
+        }
+    }
+
+    // Drag over only PART of the content (a couple of words), not the whole span.
+    func testPartialContentDragHighlightsOnlyDraggedColumns() {
+        let content = "سلام دنیا خوب"        // 12 cells
+        let s = content + "        "           // pad to 20
+        let sca = screenCharArrayWithDefaultStyle(s, eol: EOL_HARD)
+        guard let bidi = BidiDisplayInfoObjc(sca) else { return XCTFail("no bidi info") }
+        // Drag a visual sub-span in the middle of the content.
+        let contentVisuals = (0..<12).map { Int(bidi.visualForLogical(Int32($0))) }
+        let vMax = contentVisuals.max()!
+        let v1 = vMax - 5, v2 = vMax - 1        // five columns inside the content
+        let lit = highlightedVisualsForDrag(bidi, sca: sca, v1: v1, v2: v2)
+        print("partial drag visual [\(v1)...\(v2)] -> lit \(lit.sorted())")
+        XCTAssertEqual(lit, Set(min(v1, v2)...max(v1, v2)),
+                       "partial drag over [\(v1)...\(v2)] should light exactly those columns, got \(lit.sorted())")
+    }
+
+    // The user's screenshot line: an English island inside an RTL sentence. Drag
+    // over the visual columns and confirm the highlight covers exactly them, so a
+    // drag over the words never lands on empty space or mirror columns.
+    func testMixedIslandDragHighlightsDraggedColumns() {
+        let content = "Berlin شهری بزرگ در آلمان"
+        let s = content + "      "
+        let ns = content as NSString
+        let sca = screenCharArrayWithDefaultStyle(s, eol: EOL_HARD)
+        guard let bidi = BidiDisplayInfoObjc(sca) else { return XCTFail("no bidi info") }
+        let width = Int(sca.length)
+        dumpMapping("mixed island", bidi, width)
+
+        // Drag over the Persian tail «شهری بزرگ در آلمان» (everything after Berlin).
+        let faStart = ns.range(of: "شهری").location
+        let faVisuals = (faStart..<content.count).map { Int(bidi.visualForLogical(Int32($0))) }
+        let vMin = faVisuals.min()!, vMax = faVisuals.max()!
+        let lit = highlightedVisualsForDrag(bidi, sca: sca, v1: vMin, v2: vMax)
+        print("mixed drag visual [\(vMin)...\(vMax)] -> lit \(lit.sorted())")
+        // Contiguous visual drag must light a contiguous visual block == the drag.
+        XCTAssertEqual(lit, Set(vMin...vMax),
+                       "mixed-line drag over [\(vMin)...\(vMax)] should light exactly those columns, got \(lit.sorted())")
+    }
+
+    // Close the loop with the REAL conversion the mouse handler runs. The drag
+    // tests above simulate the endpoint conversion with bidi.logicalForVisual;
+    // this proves iTermTextExtractor.logicalCoordForVisualCoord: (what
+    // PTYMouseHandler/PTYTextView actually call) returns exactly that for every
+    // visual column of the mixed island line — so the simulation is faithful and
+    // the fetched line/coord are right (no off-by-one, no wrong line).
+    func testExtractorConversionMatchesBidiLogicalForVisual() {
+        let content = "Berlin شهری بزرگ در آلمان"
+        let s = content + "      "
+        let base = screenCharArrayWithDefaultStyle(s, eol: EOL_HARD)
+        guard let bidi = BidiDisplayInfoObjc(base) else { return XCTFail("no bidi info") }
+        // Rebuild the line carrying the bidi info, so the extractor's fetch sees it.
+        let sca = ScreenCharArray(copyOfLine: base.line, length: base.length,
+                                  continuation: base.continuation, bidiInfo: bidi)
+        let width = Int(sca.length)
+        let ds = OneBidiLineDataSource(sca, width: Int32(width))
+        let extractor = iTermTextExtractor(dataSource: ds)
+        extractor.supportBidi = true
+
+        for v in 0..<width {
+            let got = extractor.logicalCoord(forVisualCoord: VT100GridCoord(x: Int32(v), y: 0))
+            let want = bidi.logicalForVisual(Int32(v))
+            XCTAssertEqual(got.x, want, "extractor visual \(v) -> logical \(got.x), expected \(want)")
+            XCTAssertEqual(got.y, 0)
+        }
+    }
+}

--- a/ModernTests/BidiPaddedHighlightTests.swift
+++ b/ModernTests/BidiPaddedHighlightTests.swift
@@ -1,0 +1,77 @@
+//
+//  BidiPaddedHighlightTests.swift
+//  ModernTests
+//
+//  Alternate-screen (TUI) rows build a PADDED / right-justified BidiDisplayInfo
+//  (initWithScreenCharArray:paddedTo:width), unlike scrollback which is
+//  unpadded. The earlier selection-highlight tests only used the unpadded form.
+//  This drives the real backgroundRunsInLine path with the padded bidi and
+//  asserts the highlight lands on the visual columns the padded LUT maps the
+//  selected LOGICAL cells to (i.e. the words on the right), not empty padding.
+//
+
+import XCTest
+@testable import iTerm2SharedARC
+
+class BidiPaddedHighlightTests: XCTestCase {
+    private var savedDetect: Any?
+    private var savedRJ: Any?
+    override func setUp() {
+        super.setUp()
+        iTermPreferences.setBool(true, forKey: kPreferenceKeyBidi)
+        savedDetect = iTermUserDefaults.userDefaults().object(forKey: "DetectParagraphDirection")
+        savedRJ = iTermUserDefaults.userDefaults().object(forKey: "RightJustifyRTLLines")
+        iTermUserDefaults.userDefaults().set(true, forKey: "DetectParagraphDirection")
+        iTermUserDefaults.userDefaults().set(true, forKey: "RightJustifyRTLLines")
+        iTermAdvancedSettingsModel.loadAdvancedSettingsFromUserDefaults()
+    }
+    override func tearDown() {
+        restore("DetectParagraphDirection", savedDetect)
+        restore("RightJustifyRTLLines", savedRJ)
+        iTermAdvancedSettingsModel.loadAdvancedSettingsFromUserDefaults()
+        iTermPreferences.setBool(false, forKey: kPreferenceKeyBidi)
+        super.tearDown()
+    }
+    private func restore(_ k: String, _ v: Any?) {
+        if let v { iTermUserDefaults.userDefaults().set(v, forKey: k) }
+        else { iTermUserDefaults.userDefaults().removeObject(forKey: k) }
+    }
+
+    func testPaddedRightJustifiedHighlightFollowsLogicalCells() {
+        let width: Int32 = 24
+        let content = "سلام دنیا"                 // 9 cells of RTL content
+        // The TUI builds bidi from the paragraph content, padded to the grid width.
+        let contentSca = screenCharArrayWithDefaultStyle(content, eol: EOL_HARD)
+        guard let bidi = BidiDisplayInfoObjc(contentSca, paddedTo: width) else {
+            return XCTFail("no padded bidi (needs RTL + rightJustify)")
+        }
+        XCTAssertEqual(bidi.numberOfCells, width, "padded bidi should span the full width")
+        // Right-justified: logical 0 must map to a visual column on the RIGHT.
+        XCTAssertGreaterThan(bidi.visualForLogical(0), width / 2,
+                             "content should be right-justified; visualForLogical(0)=\(bidi.visualForLogical(0))")
+
+        // The actual grid row: content then trailing spaces, full width.
+        let full = content + String(repeating: " ", count: Int(width) - content.count)
+        let lineSca = screenCharArrayWithDefaultStyle(full, eol: EOL_HARD)
+
+        // Select the first three LOGICAL content cells.
+        var selected = IndexSet()
+        selected.insert(integersIn: 0..<3)
+
+        var anyBlink: ObjCBool = false
+        guard let runs = iTermBackgroundColorRunsInLine.backgroundRuns(
+            inLine: lineSca.line, lineLength: width, sourceLineNumber: 0, displayLineNumber: 0,
+            selectedIndexes: selected, within: NSRange(location: 0, length: Int(width)),
+            matches: nil, anyBlink: &anyBlink, y: 0, bidi: bidi, eaIndex: nil, darkMode: false) else {
+            return XCTFail("no runs")
+        }
+        var highlighted = Set<Int>()
+        for boxed in runs.array where boxed.valuePointer.pointee.selected.boolValue {
+            let r = boxed.valuePointer.pointee.visualRange
+            for v in r.location..<(r.location + r.length) { highlighted.insert(v) }
+        }
+        let expected = Set(selected.map { Int(bidi.visualForLogical(Int32($0))) })
+        XCTAssertEqual(highlighted, expected,
+                       "padded/right-justified highlight landed on \(highlighted.sorted()), expected \(expected.sorted())")
+    }
+}

--- a/ModernTests/BidiSelectionCrashGuardTests.swift
+++ b/ModernTests/BidiSelectionCrashGuardTests.swift
@@ -1,0 +1,81 @@
+//
+//  BidiSelectionCrashGuardTests.swift
+//  ModernTests
+//
+//  Selection auto-scroll passes a y below the top of the buffer (negative) and
+//  the mouse-overflow path can pass one past the end. Converting such a coord
+//  to logical must NOT fetch that line: in the real line buffer that asserts and
+//  aborts (the drag-to-scroll crash). This mock flags any out-of-range fetch, so
+//  the test fails if the guard in -logicalCoordForVisualCoord: is ever removed.
+//
+
+import XCTest
+@testable import iTerm2SharedARC
+
+private class GuardMockDataSource: NSObject, iTermTextDataSource {
+    private let lines: [ScreenCharArray]
+    private let gridWidth: Int32
+    var badLineFetched = false
+
+    init(strings: [String], width: Int32 = 80) {
+        self.gridWidth = width
+        var built = [ScreenCharArray]()
+        for string in strings {
+            var buffer = [screen_char_t](repeating: screen_char_t(), count: Int(width) + 1)
+            for (index, scalar) in string.unicodeScalars.enumerated() where index < Int(width) {
+                buffer[index].code = unichar(scalar.value)
+            }
+            var continuation = screen_char_t()
+            continuation.code = unichar(EOL_HARD)
+            built.append(ScreenCharArray(copyOfLine: buffer, length: width, continuation: continuation))
+        }
+        self.lines = built
+        super.init()
+    }
+
+    func width() -> Int32 { gridWidth }
+    func numberOfLines() -> Int32 { Int32(lines.count) }
+    func totalScrollbackOverflow() -> Int64 { 0 }
+
+    func screenCharArray(forLine line: Int32) -> ScreenCharArray {
+        if line < 0 || line >= Int32(lines.count) {
+            badLineFetched = true
+            return ScreenCharArray.emptyLine(ofLength: gridWidth)
+        }
+        return lines[Int(line)]
+    }
+    func screenCharArray(atScreenIndex index: Int32) -> ScreenCharArray {
+        screenCharArray(forLine: index)
+    }
+    func externalAttributeIndex(forLine y: Int32) -> (any iTermExternalAttributeIndexReading)? { nil }
+    func fetchLine(_ line: Int32, block: (ScreenCharArray) -> Any?) -> Any? {
+        block(screenCharArray(forLine: line))
+    }
+    func date(forLine line: Int32) -> Date? { nil }
+    func commandMark(at coord: VT100GridCoord, mustHaveCommand: Bool, range: UnsafeMutablePointer<VT100GridWindowedRange>?) -> (any VT100ScreenMarkReading)? { nil }
+    func metadata(onLine lineNumber: Int32) -> iTermImmutableMetadata { iTermImmutableMetadataDefault() }
+    func isFirstLine(ofBlock lineNumber: Int32) -> Bool { false }
+}
+
+class BidiSelectionCrashGuardTests: XCTestCase {
+    func testConversionDoesNotFetchOutOfRangeLine() {
+        let ds = GuardMockDataSource(strings: ["سلام دنیا"])  // one line, indices [0, 1)
+        let extractor = iTermTextExtractor(dataSource: ds)
+        extractor.supportBidi = true
+
+        // Below the top (auto-scroll up) and past the end (mouse overflow).
+        _ = extractor.logicalCoord(forVisualCoord: VT100GridCoord(x: 0, y: -1))
+        _ = extractor.logicalCoord(forVisualCoord: VT100GridCoord(x: 5, y: 100))
+        XCTAssertFalse(ds.badLineFetched,
+                       "conversion fetched an out-of-range line, which asserts in the real line buffer")
+
+        // Out-of-range lines convert to themselves (identity), so the selection
+        // model still gets a usable coordinate.
+        let below = extractor.logicalCoord(forVisualCoord: VT100GridCoord(x: 3, y: -1))
+        XCTAssertEqual(below.x, 3)
+        XCTAssertEqual(below.y, -1)
+        let past = extractor.logicalCoord(forVisualCoord: VT100GridCoord(x: 7, y: 100))
+        XCTAssertEqual(past.x, 7)
+        XCTAssertEqual(past.y, 100)
+    }
+}

--- a/ModernTests/BidiSelectionHighlightTests.swift
+++ b/ModernTests/BidiSelectionHighlightTests.swift
@@ -1,0 +1,120 @@
+//
+//  BidiSelectionHighlightTests.swift
+//  ModernTests
+//
+//  The selection is stored in LOGICAL coordinates. On a right-to-left line the
+//  background highlight must decide whether a cell is selected from its logical
+//  index and then draw it at its visual column, so the highlight lands on the
+//  cells the user actually selected instead of their mirror images (which showed
+//  up as highlighting the wrong words and empty space on the left).
+//
+//  This drives the real backgroundRunsInLine path, so it fails if the selected
+//  flag is ever taken from the visual column again.
+//
+
+import XCTest
+@testable import iTerm2SharedARC
+
+class BidiSelectionHighlightTests: XCTestCase {
+    private func setBidiPreference(_ enabled: Bool) {
+        iTermPreferences.setBool(enabled, forKey: kPreferenceKeyBidi)
+        let deadline = Date().addingTimeInterval(0.5)
+        while iTermPreferences.bidiEnabled() != enabled && Date() < deadline {
+            RunLoop.main.run(mode: .default, before: Date(timeIntervalSinceNow: 0.005))
+        }
+    }
+
+    override func setUp() { super.setUp(); setBidiPreference(true) }
+    override func tearDown() { setBidiPreference(false); super.tearDown() }
+
+    func testSelectionHighlightFollowsLogicalMembership() {
+        // Four right-to-left letters: visual order is the reverse of logical.
+        let s = "ابجد"
+        let sca = screenCharArrayWithDefaultStyle(s, eol: EOL_HARD)
+        guard let bidi = BidiDisplayInfoObjc(sca) else { return XCTFail("no bidi info") }
+        let width = Int(sca.length)
+        XCTAssertGreaterThanOrEqual(width, 4)
+
+        // Select the first two LOGICAL cells. This is asymmetric under the
+        // reversal, so testing the visual column (the old bug) and the logical
+        // index (the fix) give different answers — cell 0 lives at the far right.
+        var selected = IndexSet()
+        selected.insert(integersIn: 0..<2)
+
+        var anyBlink: ObjCBool = false
+        let runsInLine = iTermBackgroundColorRunsInLine.backgroundRuns(
+            inLine: sca.line,
+            lineLength: Int32(width),
+            sourceLineNumber: 0,
+            displayLineNumber: 0,
+            selectedIndexes: selected,
+            within: NSRange(location: 0, length: width),
+            matches: nil,
+            anyBlink: &anyBlink,
+            y: 0,
+            bidi: bidi,
+            eaIndex: nil,
+            darkMode: false)
+        guard let runsInLine else { return XCTFail("no background runs") }
+
+        var selectedRuns = 0
+        for boxed in runsInLine.array {
+            let run = boxed.valuePointer.pointee
+            let logical = Int(run.modelRange.location)
+            let expected = selected.contains(logical)
+            XCTAssertEqual(run.selected.boolValue, expected,
+                           "logical cell \(logical) drawn at visual \(run.visualRange.location): selected=\(run.selected.boolValue), expected \(expected)")
+            if run.selected.boolValue {
+                selectedRuns += 1
+                // A selected run must draw at the visual column of a selected
+                // logical cell, never at an unrelated (mirror-image) column.
+                XCTAssertTrue(selected.contains(logical),
+                              "selected run at visual \(run.visualRange.location) maps to unselected logical \(logical)")
+            }
+        }
+        XCTAssertEqual(selectedRuns, 2, "exactly the two selected logical cells should be highlighted")
+    }
+
+    // The user's screenshot case: an English island inside Persian, with the
+    // Latin-islands setting on. Selecting the English word's logical cells must
+    // highlight the visual cells where that word is drawn, not the mirror on the
+    // left. Uses a manual logical IndexSet (what the mouse path stores) so it
+    // isolates the highlight math from the selection model.
+    func testIslandLineHighlight() {
+        let saved = iTermUserDefaults.userDefaults().object(forKey: "IsolateLatinRunsInRTL")
+        let savedD = iTermUserDefaults.userDefaults().object(forKey: "DetectParagraphDirection")
+        iTermUserDefaults.userDefaults().set(true, forKey: "IsolateLatinRunsInRTL")
+        iTermUserDefaults.userDefaults().set(true, forKey: "DetectParagraphDirection")
+        iTermAdvancedSettingsModel.loadAdvancedSettingsFromUserDefaults()
+        defer {
+            if let v = saved { iTermUserDefaults.userDefaults().set(v, forKey: "IsolateLatinRunsInRTL") } else { iTermUserDefaults.userDefaults().removeObject(forKey: "IsolateLatinRunsInRTL") }
+            if let v = savedD { iTermUserDefaults.userDefaults().set(v, forKey: "DetectParagraphDirection") } else { iTermUserDefaults.userDefaults().removeObject(forKey: "DetectParagraphDirection") }
+            iTermAdvancedSettingsModel.loadAdvancedSettingsFromUserDefaults()
+        }
+        let s = "متن abc دیگر"                    // Persian, English island, Persian
+        let ns = s as NSString
+        let sca = screenCharArrayWithDefaultStyle(s, eol: EOL_HARD)
+        guard let bidi = BidiDisplayInfoObjc(sca) else { return XCTFail("no bidi info") }
+        let width = Int(sca.length)
+        let abcStart = ns.range(of: "abc").location   // logical index of the island
+
+        var selected = IndexSet()
+        selected.insert(integersIn: abcStart..<(abcStart + 3))  // select "abc"
+
+        var anyBlink: ObjCBool = false
+        guard let runs = iTermBackgroundColorRunsInLine.backgroundRuns(
+            inLine: sca.line, lineLength: Int32(width), sourceLineNumber: 0, displayLineNumber: 0,
+            selectedIndexes: selected, within: NSRange(location: 0, length: width),
+            matches: nil, anyBlink: &anyBlink, y: 0, bidi: bidi, eaIndex: nil, darkMode: false) else {
+            return XCTFail("no runs")
+        }
+        var highlighted = Set<Int>()
+        for boxed in runs.array where boxed.valuePointer.pointee.selected.boolValue {
+            let r = boxed.valuePointer.pointee.visualRange
+            for v in r.location..<(r.location + r.length) { highlighted.insert(v) }
+        }
+        let expected = Set(selected.map { Int(bidi.visualForLogical(Int32($0))) })
+        XCTAssertEqual(highlighted, expected,
+                       "island “abc” highlight landed on visual \(highlighted.sorted()), expected \(expected.sorted())")
+    }
+}

--- a/sources/ContentAnalysis/iTermTextExtractor.m
+++ b/sources/ContentAnalysis/iTermTextExtractor.m
@@ -294,15 +294,17 @@ const NSInteger kLongMaximumWordLength = 100000;
                                      big:(BOOL)big
                 additionalWordCharacters:(NSString *)additionalWordCharacters
                            regexPatterns:(NSArray<NSString *> *)regexPatterns {
+    // `visualLocation` is already a LOGICAL coordinate here: every caller (the
+    // mouse handler's begin-selection at PTYMouseHandler.m, autocomplete, and
+    // logical movement) has already converted the click from visual to logical
+    // before calling this. Converting again with logicalForVisual double-applies
+    // the bidi reorder map and lands on a different word — the "double-click a
+    // word and a different word gets selected" bug on right-to-left lines. Word
+    // boundaries are found in logical order, so operate on the logical location
+    // directly and return a logical range (the selection model is logical, and
+    // the highlight maps logical→visual via the LUT, exactly like a character
+    // selection).
     VT100GridCoord location = visualLocation;
-    iTermBidiDisplayInfo *bidi = nil;
-    if (_supportBidi) {
-        ScreenCharArray *sca = [_dataSource screenCharArrayForLine:visualLocation.y];
-        bidi = sca.bidiInfo;
-        if (bidi) {
-            location.x = [bidi logicalForVisual:visualLocation.x];
-        }
-    }
     iTermWordExtractor *wordExtractor = [[iTermWordExtractor alloc] initWithLocation:location
                                                                        maximumLength:maximumLength
                                                                                  big:big];
@@ -313,12 +315,7 @@ const NSInteger kLongMaximumWordLength = 100000;
         wordExtractor.regexPatterns = regexPatterns;
     }
     wordExtractor.dataSource = self;
-    VT100GridWindowedRange range = [wordExtractor windowedRange];
-    if (bidi) {
-        // TODO: This is wrong. When a word wraps, we need to select characters from the left side of the start line and the right side of the end line. Selections don't know how to do this currently.
-        return [self visualWindowedRangeForLogical:range];
-    }
-    return range;
+    return [wordExtractor windowedRange];
 }
 
 - (VT100GridCoordRange)visualRangeForLogical:(VT100GridCoordRange)logical {

--- a/sources/ContentAnalysis/iTermTextExtractor.m
+++ b/sources/ContentAnalysis/iTermTextExtractor.m
@@ -2293,6 +2293,12 @@ static NSRange NSMakeRangeFromHalfOpenInterval(NSUInteger lowerBound, NSUInteger
     if (!_supportBidi) {
         return visualCoord;
     }
+    // An off-screen line (selection auto-scroll passes a negative y; mouse
+    // overflow can pass one past the end) has nothing to reorder. Fetching it
+    // would assert in the line buffer, so treat it as an identity mapping.
+    if (visualCoord.y < 0 || visualCoord.y >= [_dataSource numberOfLines]) {
+        return visualCoord;
+    }
     iTermBidiDisplayInfo *bidi = nil;
     ScreenCharArray *sca = [_dataSource screenCharArrayForLine:visualCoord.y];
     bidi = sca.bidiInfo;

--- a/sources/ContentAnalysis/iTermTextExtractor.m
+++ b/sources/ContentAnalysis/iTermTextExtractor.m
@@ -2044,17 +2044,20 @@ trimTrailingWhitespace:(BOOL)trimSelectionTrailingSpaces
         iTermBidiDisplayInfo *bidi = _supportBidi ? sca.bidiInfo : nil;
         if (charBlock) {
             if (supportBidi && bidi) {
-                const NSRange visualRange = NSMakeRangeFromHalfOpenInterval(MIN(width - 1, MAX(range.columnWindow.location, startx)),
-                                                                            endx);
-                [bidi enumerateLogicalRangesIn:visualRange closure:^(NSRange logicalRange, int visualStart, BOOL *stop) {
-                    for (int i = 0; i < logicalRange.length; i++) {
-                        int x = logicalRange.location + i;
-                        if (charBlock(theLine, theLine[x], eaIndex[x], VT100GridCoordMake(x, y), VT100GridCoordMake(visualStart + i, y), &lineMetadata)) {
-                            *stop = YES;
-                            return;
-                        }
+                // The selection is stored in LOGICAL coordinates (the highlight uses
+                // them too), so emit the logical range in reading order rather than
+                // gathering the cells that happen to fall under a visual span. That
+                // keeps a partial selection on a mixed line a contiguous string — an
+                // English word embedded in right-to-left text (e.g. «Berlin») is
+                // copied whole instead of split into visually-adjacent pieces — while
+                // the bytes stay in the logical order that editors re-render correctly.
+                // Report each cell's visual column via the LUT for callers that use it.
+                const int lo = MIN(width - 1, MAX(range.columnWindow.location, startx));
+                for (int x = lo; x < endx; x++) {
+                    if (charBlock(theLine, theLine[x], eaIndex[x], VT100GridCoordMake(x, y), VT100GridCoordMake([bidi visualForLogical:x], y), &lineMetadata)) {
+                        return;
                     }
-                }];
+                }
             } else {
                 // Iterate over characters up to terminal nulls.
                 for (int x = MIN(width - 1, MAX(range.columnWindow.location, startx)); x < endx - numNulls; x++) {
@@ -2083,11 +2086,6 @@ trimTrailingWhitespace:(BOOL)trimSelectionTrailingSpaces
         }
         startx = left;
     }
-}
-
-static NSRange NSMakeRangeFromHalfOpenInterval(NSUInteger lowerBound, NSUInteger openUpperBound) {
-    assert(lowerBound <= openUpperBound);
-    return NSMakeRange(lowerBound, openUpperBound - lowerBound);
 }
 
 // NOTE: This enumerates in logical order. RTL characters will not actually be reversed.

--- a/sources/Drawing/iTermBackgroundColorRun.m
+++ b/sources/Drawing/iTermBackgroundColorRun.m
@@ -12,7 +12,6 @@
 static void iTermMakeBackgroundColorRun(iTermBackgroundColorRun *run,
                                         const screen_char_t *theLine,
                                         VT100GridCoord coord,
-                                        int visualColumn,
                                         NSIndexSet *selectedIndexes,
                                         NSData *matches,
                                         int width,
@@ -21,7 +20,13 @@ static void iTermMakeBackgroundColorRun(iTermBackgroundColorRun *run,
     if (ScreenCharIsDWC_SKIP(theLine[coord.x])) {
         run->selected = NO;
     } else {
-        run->selected = [selectedIndexes containsIndex:visualColumn];
+        // selectedIndexes is in LOGICAL (source-cell) coordinates, so test the
+        // cell's logical index. On a bidi-reordered line the visual column is a
+        // different cell, and testing it would highlight the mirror-image cells
+        // (and empty padding). The run is still positioned at its visual column
+        // via the LUT, so a contiguous logical selection paints the correct
+        // visual cells even when they are not contiguous on screen.
+        run->selected = [selectedIndexes containsIndex:coord.x];
     }
     if (matches) {
         // Test if this char is a highlighted match from a Find.
@@ -110,7 +115,6 @@ static NSRange NSMakeRangeFromEndpointsInclusive(NSUInteger start, NSUInteger in
     const int32_t bidiLUTLength = bidi.numberOfCells;
 
     int lastVisualColumn = -1;
-    int visualColumnForSelection = -1;  // visual column, but for DWC_RIGHT is the preceding cell. Used to make selection extend into DWC_RIGHT.
     int visualColumn = -1;
     for (j = charRange.location; j < charRange.location + charRange.length; j++) {
         lastVisualColumn = visualColumn;
@@ -126,11 +130,6 @@ static NSRange NSMakeRangeFromEndpointsInclusive(NSUInteger start, NSUInteger in
                 continue;
             }
         }
-        if (x < bidiLUTLength) {
-            visualColumnForSelection = bidiLUT[x];
-        } else {
-            visualColumnForSelection = x;
-        }
         if (j < bidiLUTLength) {
             visualColumn = bidiLUT[j];
         } else {
@@ -139,7 +138,6 @@ static NSRange NSMakeRangeFromEndpointsInclusive(NSUInteger start, NSUInteger in
         iTermMakeBackgroundColorRun(&current,
                                     theLine,
                                     VT100GridCoordMake(x, displayLineNumber),
-                                    visualColumnForSelection,
                                     selectedIndexes,
                                     matches,
                                     width,
@@ -207,7 +205,6 @@ static NSRange NSMakeRangeFromEndpointsInclusive(NSUInteger start, NSUInteger in
     iTermMakeBackgroundColorRun(&run,
                                 &defaultCharacter,
                                 VT100GridCoordMake(0, 0),
-                                0,
                                 nil,
                                 nil,
                                 width,

--- a/sources/MetalRenderer/Glue/iTermMetalPerFrameState.m
+++ b/sources/MetalRenderer/Glue/iTermMetalPerFrameState.m
@@ -1404,7 +1404,13 @@ int iTermGetMetalBackgroundColors(iTermMetalPerFrameState *self,
             }
             continue;
         }
-        const BOOL selected = [selectedIndexes containsIndex:visualX];
+        // selectedIndexes is in LOGICAL coordinates (the selection is stored and
+        // reported logically), so test the logical cell index. The run is still
+        // positioned at its visual column via the LUT above; testing visualX here
+        // lit the mirror-image cells on right-to-left lines (the highlight landed
+        // on empty trailing-space columns at the left). Matches the CoreGraphics
+        // path in iTermBackgroundColorRun.m.
+        const BOOL selected = [selectedIndexes containsIndex:logicalX];
         BOOL findMatch = NO;
         if (findMatches && !selected) {
             findMatch = CheckFindMatchAtIndex(findMatches, logicalX);

--- a/sources/TerminalView/PTYMouseHandler.h
+++ b/sources/TerminalView/PTYMouseHandler.h
@@ -55,6 +55,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)mouseHandlerIsScrolledToBottom:(PTYMouseHandler *)handler;
 - (VT100GridCoord)mouseHandlerCoordForPointInWindow:(NSPoint)point;
 - (VT100GridCoord)mouseHandlerCoordForPointInView:(NSPoint)point;
+// Converts a visual grid coordinate (where the mouse physically is) to the
+// logical coordinate the selection model uses. A no-op unless the line is
+// bidi-reordered, so left-to-right text is unaffected.
+- (VT100GridCoord)mouseHandler:(PTYMouseHandler *)handler
+        logicalCoordForVisualCoord:(VT100GridCoord)visualCoord;
 - (NSPoint)mouseHandlerReportablePointForPointInView:(NSPoint)point;
 - (void)mouseHandlerMoveCursorToCoord:(VT100GridCoord)coord
                              forEvent:(NSEvent *)event;

--- a/sources/TerminalView/PTYMouseHandler.m
+++ b/sources/TerminalView/PTYMouseHandler.m
@@ -283,10 +283,12 @@ static double EuclideanDistance(NSPoint p1, NSPoint p2) {
         return YES;
     }
 
-    const VT100GridCoord clickPointCoord = [self.mouseDelegate mouseHandler:self
-                                                                 clickPoint:event
-                                                              allowOverflow:YES
-                                                                 firstMouse:_mouseDownWasFirstMouse];
+    const VT100GridCoord clickPointCoord =
+        [self.mouseDelegate mouseHandler:self
+              logicalCoordForVisualCoord:[self.mouseDelegate mouseHandler:self
+                                                               clickPoint:event
+                                                            allowOverflow:YES
+                                                               firstMouse:_mouseDownWasFirstMouse]];
     const int x = clickPointCoord.x;
     const int y = clickPointCoord.y;
     if ([self.mouseDelegate mouseHandler:self coordIsMutable:VT100GridCoordMake(x, y)] &&

--- a/sources/TerminalView/PTYTextView+Private.h
+++ b/sources/TerminalView/PTYTextView+Private.h
@@ -112,5 +112,9 @@ NSPopoverDelegate> {
 // Interactive features (cursor, selection, marks) are disabled.
 - (iTermTextDrawingHelper *)newDrawingHelperForOffscreenRendering;
 
+// Converts a visual grid coordinate to the logical one the selection model
+// uses. A no-op unless the line is bidi-reordered.
+- (VT100GridCoord)logicalCoordForVisualCoord:(VT100GridCoord)visualCoord;
+
 @end
 

--- a/sources/TerminalView/PTYTextView.m
+++ b/sources/TerminalView/PTYTextView.m
@@ -3968,6 +3968,20 @@ static NSString *iTermStringForEventPhase(NSEventPhase eventPhase) {
 }
 
 // Returns YES if the selection changed.
+// The mouse reports the column it physically points at (visual). On a
+// bidi-reordered line that differs from the logical cell the selection model
+// stores, which is why a right-to-left selection used to highlight the wrong
+// cells. Returns the input unchanged when bidi is off or the line has no
+// reordering, so left-to-right text is untouched.
+- (VT100GridCoord)logicalCoordForVisualCoord:(VT100GridCoord)visualCoord {
+    if (![iTermPreferences bidiEnabled]) {
+        return visualCoord;
+    }
+    iTermTextExtractor *extractor = [iTermTextExtractor textExtractorWithDataSource:_dataSource];
+    extractor.supportBidi = YES;
+    return [extractor logicalCoordForVisualCoord:visualCoord];
+}
+
 - (BOOL)moveSelectionEndpointToX:(int)x Y:(int)y locationInTextView:(NSPoint)locationInTextView {
     if (!_selection.live) {
         return NO;
@@ -3983,8 +3997,18 @@ static NSString *iTermStringForEventPhase(NSEventPhase eventPhase) {
         x = width;
         y--;
     }
-    if (y >= [_dataSource numberOfLines]) {
-        y = [_dataSource numberOfLines] - 1;
+    const int numberOfLines = [_dataSource numberOfLines];
+    if (y >= numberOfLines) {
+        y = numberOfLines - 1;
+    }
+    // The x above is a visual column. On a bidi-reordered line convert it to the
+    // logical cell the selection stores; a no-op on left-to-right lines and for
+    // the past-the-end boundary values set just above. Only convert for an
+    // on-screen line: selection auto-scroll can pass a y below the top (negative)
+    // or an empty buffer can leave y = -1, and fetching that line to read its
+    // bidi info would assert.
+    if (x >= 0 && x < width && y >= 0 && y < numberOfLines) {
+        x = [self logicalCoordForVisualCoord:VT100GridCoordMake(x, y)].x;
     }
     const BOOL hasColumnWindow = (_selection.liveRange.columnWindow.location > 0 ||
                                   _selection.liveRange.columnWindow.length < width);
@@ -8008,6 +8032,11 @@ allowDragBeforeMouseDown:(BOOL)allowDragBeforeMouseDown
     return [self moveSelectionEndpointToX:coord.x
                                         Y:coord.y
                        locationInTextView:locationInTextView];
+}
+
+- (VT100GridCoord)mouseHandler:(PTYMouseHandler *)handler
+    logicalCoordForVisualCoord:(VT100GridCoord)visualCoord {
+    return [self logicalCoordForVisualCoord:visualCoord];
 }
 
 - (NSString *)mouseHandler:(PTYMouseHandler *)mouseHandler

--- a/sources/iTerm2SharedARC-Bridging-Header.h
+++ b/sources/iTerm2SharedARC-Bridging-Header.h
@@ -229,6 +229,7 @@
 #import "SCPPath.h"
 #import "ScreenChar.h"
 #import "ScreenCharArray.h"
+#import "iTermBackgroundColorRun.h"
 #import "SearchResult.h"
 #import "iTermDragHandleView.h"
 #import "iTermFindOnPageHelper.h"


### PR DESCRIPTION
**Draft — work in progress.**

Selection, highlight, and copy fixes for right-to-left (Persian/Arabic/Hebrew)
text in the terminal. Gated behind the existing **Bidi** preference: with it
off, per-line `BidiDisplayInfo` is nil, so `visualX == logicalX` for every cell
and each change below is a no-op. No behavior change for left-to-right-only
users.

## What it fixes

- **Mouse selection maps through the bidi reordering.** A click is converted
  from its visual column to the logical cell, so character drag, word/line/smart
  selection, the highlight, and copy all operate in the logical space the
  selection model already uses.
- **Selection highlight on the Metal (GPU) renderer** tested the visual column
  against a logically-stored selection, lighting the mirror-image cells (the
  empty trailing padding on the left of a right-to-left line). It now tests the
  logical cell index, matching the CoreGraphics path.
- **Copy extracts the logical selection range**, not the cells that happen to
  fall under a visual span. A partial selection on a mixed line stays a
  contiguous string — an English word embedded in Persian is copied whole
  instead of split into visually-adjacent pieces.
- **Word/double-click selection no longer double-converts the coordinate.** The
  click already arrives logical from the mouse handler, but `rangeForWordAt`
  converted again (and converted the result back to visual), landing on a
  different word on right-to-left lines — double-click «معلم» and «تومن» got
  selected. It now operates on the logical location directly and returns a
  logical range.

## Tests

New `ModernTests` suites: drag-selection highlight, padded (TUI/alt-screen)
highlight, and logical copy range.
