### PR TITLE
Fix typos for word punctuation

### DIFF
--- a/api/library/python/iterm2/gen_binding.py
+++ b/api/library/python/iterm2/gen_binding.py
@@ -841,12 +841,12 @@ class PasteConfiguration:
 
     @property
     def convert_unicode_punctuation(self) -> bool:
-        "Returns whether to convert non-ASCII puncutation to ASCII equivalents when pasting."
+        "Returns whether to convert non-ASCII punctuation to ASCII equivalents when pasting."
         return self.__convert_unicode_punctuation
 
     @convert_unicode_punctuation.setter
     def convert_unicode_punctuation(self, value: bool):
-        "Sets whether to convert non-ASCII puncutation to ASCII equivalents when pasting."
+        "Sets whether to convert non-ASCII punctuation to ASCII equivalents when pasting."
         self.__convert_unicode_punctuation = value
 
     @property

--- a/api/library/python/iterm2/iterm2/binding.py
+++ b/api/library/python/iterm2/iterm2/binding.py
@@ -217,12 +217,12 @@ class PasteConfiguration:
 
     @property
     def convert_unicode_punctuation(self) -> bool:
-        "Returns whether to convert non-ASCII puncutation to ASCII equivalents when pasting."
+        "Returns whether to convert non-ASCII punctuation to ASCII equivalents when pasting."
         return self.__convert_unicode_punctuation
 
     @convert_unicode_punctuation.setter
     def convert_unicode_punctuation(self, value: bool):
-        "Sets whether to convert non-ASCII puncutation to ASCII equivalents when pasting."
+        "Sets whether to convert non-ASCII punctuation to ASCII equivalents when pasting."
         self.__convert_unicode_punctuation = value
 
     @property


### PR DESCRIPTION
Fix multiple occurrences of typo `puncutation` to `punctuation`

* Two corrections in: api/library/iterm2/gen_binding.py
* Two corrections in: api/library/iterm2/iterm2/binding.py

Ironically, no actual punctuation corrected.