### PR TITLE
Add an option to make the left-side tab bar scrollable

### DIFF
--- a/ThirdParty/PSMTabBarControl/source/PSMTabBarControl.m
+++ b/ThirdParty/PSMTabBarControl/source/PSMTabBarControl.m
@@ -10,6 +10,7 @@
 
 #import "DebugLogging.h"
 #import "iTerm2SharedARC-Swift.h"
+#import "iTermAdvancedSettingsModel.h"
 #import "NSBezierPath+iTerm.h"
 #import "PSMTabBarCell.h"
 #import "PSMOverflowPopUpButton.h"
@@ -158,6 +159,11 @@ PSMTabBarControlOptionKey PSMTabBarControlOptionPUAFontProvider = @"PSMTabBarCon
 
     // vertical tab resizing
     BOOL _resizing;
+
+    // How far the vertical (left-side) tab bar is scrolled, in points. 0 means the first tab is at
+    // the top. Only meaningful when the scrollable vertical tab bar is enabled; otherwise tabs that
+    // don't fit go into the overflow menu and this stays 0.
+    CGFloat _verticalScrollOffset;
 
     // animation for hide/show
     int _currentStep;
@@ -1214,6 +1220,104 @@ static NSString *PSMSmartTruncationPrefix(NSString *title, NSInteger length) {
     [self syncTabProgressBars];
 }
 
+#pragma mark - Scrollable vertical tab bar
+
+// The left-side tab bar normally drops tabs that don't fit into the overflow menu. When this is on
+// they stay in the bar and the scroll wheel moves through them instead.
+- (BOOL)verticalTabBarIsScrollable {
+    return (_orientation == PSMTabBarVerticalOrientation &&
+            [iTermAdvancedSettingsModel scrollableVerticalTabBar]);
+}
+
+// Height of one vertical cell. Every cell in a vertical bar is the same height.
+- (CGFloat)verticalCellHeight {
+    return [self genericCellRectWithOverflow:(NO || _showAddTabButton)].size.height;
+}
+
+// How far you can scroll before the last tab sits at the bottom of the bar. 0 when everything fits.
+- (CGFloat)maximumVerticalScrollOffsetForCellHeight:(CGFloat)cellHeight cellCount:(NSInteger)cellCount {
+    const CGFloat contentHeight = ([[self style] topMarginForTabBarControl] +
+                                   (cellHeight * (CGFloat)cellCount));
+    return MAX(0, contentHeight - [self frame].size.height);
+}
+
+- (void)clampVerticalScrollOffsetForCellHeight:(CGFloat)cellHeight cellCount:(NSInteger)cellCount {
+    const CGFloat maximum = [self maximumVerticalScrollOffsetForCellHeight:cellHeight cellCount:cellCount];
+    _verticalScrollOffset = MAX(0, MIN(maximum, _verticalScrollOffset));
+}
+
+- (void)scrollWheel:(NSEvent *)event {
+    if (![self verticalTabBarIsScrollable]) {
+        [super scrollWheel:event];
+        return;
+    }
+    const CGFloat cellHeight = [self verticalCellHeight];
+    if (cellHeight <= 0) {
+        [super scrollWheel:event];
+        return;
+    }
+    const CGFloat maximum = [self maximumVerticalScrollOffsetForCellHeight:cellHeight
+                                                                 cellCount:(NSInteger)_cells.count];
+    if (maximum <= 0) {
+        // Everything fits; let the event go on to whatever is behind us.
+        [super scrollWheel:event];
+        return;
+    }
+    // Precise deltas (trackpad, Magic Mouse) are already in points. Line-based deltas (a notched
+    // wheel) are in lines, so scale them to one tab per line.
+    CGFloat delta = event.scrollingDeltaY;
+    if (!event.hasPreciseScrollingDeltas) {
+        delta *= cellHeight;
+    }
+    // The view is flipped, so scrolling content down means decreasing the offset.
+    const CGFloat proposed = _verticalScrollOffset - delta;
+    const CGFloat clamped = MAX(0, MIN(maximum, proposed));
+    if (clamped == _verticalScrollOffset) {
+        return;
+    }
+    _verticalScrollOffset = clamped;
+    [self update:NO];
+}
+
+// Keeps the selected tab on screen -- e.g. after cmd-shift-[ walks past the top edge, or when a tab
+// is selected from somewhere other than the bar.
+- (void)scrollSelectedTabIntoView {
+    if (![self verticalTabBarIsScrollable]) {
+        return;
+    }
+    const NSInteger index = [_cells indexOfObjectPassingTest:^BOOL(PSMTabBarCell *cell, NSUInteger i, BOOL *stop) {
+        return [[cell representedObject] isEqualTo:[self->_tabView selectedTabViewItem]];
+    }];
+    if (index == NSNotFound) {
+        return;
+    }
+    const CGFloat cellHeight = [self verticalCellHeight];
+    if (cellHeight <= 0) {
+        return;
+    }
+    const CGFloat topMargin = [[self style] topMarginForTabBarControl];
+    const CGFloat cellTop = topMargin + (cellHeight * (CGFloat)index);
+    const CGFloat cellBottom = cellTop + cellHeight;
+    const CGFloat viewportHeight = [self frame].size.height;
+
+    CGFloat offset = _verticalScrollOffset;
+    if (cellTop < offset) {
+        offset = cellTop;
+    } else if (cellBottom > offset + viewportHeight) {
+        offset = cellBottom - viewportHeight;
+    } else {
+        return;
+    }
+    const CGFloat maximum = [self maximumVerticalScrollOffsetForCellHeight:cellHeight
+                                                                 cellCount:(NSInteger)_cells.count];
+    offset = MAX(0, MIN(maximum, offset));
+    if (offset == _verticalScrollOffset) {
+        return;
+    }
+    _verticalScrollOffset = offset;
+    [self update:NO];
+}
+
 - (void)update:(BOOL)animate {
     // This method handles all of the cell layout, and is called when something changes to require
     // the refresh.  This method is not called during drag and drop. See the PSMTabDragAssistant's
@@ -1331,16 +1435,31 @@ static NSString *PSMSmartTruncationPrefix(NSString *title, NSInteger length) {
         NSRect cellRect = [self genericCellRectWithOverflow:(NO || _showAddTabButton)];
         NSMutableArray *newOrigins = [NSMutableArray arrayWithCapacity:cellCount];
 
-        for (int i = 0; i < cellCount; ++i) {
-            if (currentOrigin + cellRect.size.height <= [self frame].size.height) {
+        if ([self verticalTabBarIsScrollable]) {
+            // Give every cell an origin, shifted up by the scroll offset. Cells above or below the
+            // visible rect just get off-screen frames and are clipped when drawn, so nothing lands
+            // in the overflow menu -- the scroll wheel reaches them instead.
+            // NSView.clipsToBounds defaults to NO on macOS 14+, so ask for clipping explicitly or
+            // the scrolled-away tabs paint over the window's chrome.
+            self.clipsToBounds = YES;
+            [self clampVerticalScrollOffsetForCellHeight:cellRect.size.height cellCount:cellCount];
+            currentOrigin -= _verticalScrollOffset;
+            for (int i = 0; i < cellCount; ++i) {
                 [newOrigins addObject:[NSNumber numberWithFloat:currentOrigin]];
                 currentOrigin += cellRect.size.height;
-            } else {
-                // Out of room, the remaining unpinned tabs go into overflow.
-                if ([newOrigins count] > 0 && [self frame].size.height - currentOrigin < cellRect.size.height) {
-                    [newOrigins removeLastObject];
+            }
+        } else {
+            for (int i = 0; i < cellCount; ++i) {
+                if (currentOrigin + cellRect.size.height <= [self frame].size.height) {
+                    [newOrigins addObject:[NSNumber numberWithFloat:currentOrigin]];
+                    currentOrigin += cellRect.size.height;
+                } else {
+                    // Out of room, the remaining unpinned tabs go into overflow.
+                    if ([newOrigins count] > 0 && [self frame].size.height - currentOrigin < cellRect.size.height) {
+                        [newOrigins removeLastObject];
+                    }
+                    break;
                 }
-                break;
             }
         }
         [self finishUpdateWithRegularWidths:newOrigins widthsWithOverflow:newOrigins];
@@ -1640,8 +1759,13 @@ static NSString *PSMSmartTruncationPrefix(NSString *title, NSInteger length) {
 
     [_overflowPopUpButton setHidden:(overflowMenu == nil)];
 
-    // Set up add tab button.
-    if (!overflowMenu && _showAddTabButton) {
+    // Set up add tab button. A scrollable vertical bar has no overflow menu, so check directly
+    // whether the tabs run past the bottom -- the button would otherwise be placed off-screen.
+    const BOOL addTabButtonWouldBeOffscreen =
+        ([self verticalTabBarIsScrollable] &&
+         [self maximumVerticalScrollOffsetForCellHeight:[self verticalCellHeight]
+                                              cellCount:(NSInteger)_cells.count] > 0);
+    if (!overflowMenu && _showAddTabButton && !addTabButtonWouldBeOffscreen) {
         NSRect cellRect = [self genericCellRectWithOverflow:YES];
         cellRect.size = [_addTabButton frame].size;
 
@@ -2532,6 +2656,7 @@ static CFAbsoluteTime gDragMoveFirstTime = 0;
     // message, thus I can end up updating when there are no cells, if no tabs were (yet) present
     if ([_cells count] > 0) {
         [self update];
+        [self scrollSelectedTabIntoView];
     }
     if ([[self delegate] respondsToSelector:@selector(tabView:didSelectTabViewItem:)]) {
         [[self delegate] tabView:aTabView didSelectTabViewItem:tabViewItem];

--- a/sources/Settings/iTermAdvancedSettingsModel.h
+++ b/sources/Settings/iTermAdvancedSettingsModel.h
@@ -194,6 +194,7 @@ extern NSString *const iTermAdvancedSettingsDidChange;
 + (BOOL)doNotSetCtype;
 + (BOOL)doubleClickTabToEdit;
 + (BOOL)doubleReportScrollWheel;
++ (BOOL)scrollableVerticalTabBar;
 + (NSString *)downloadsDirectory;
 + (double)noSyncDownloadPrefsTimeout;
 + (BOOL)noSyncOpenLinksInApp;

--- a/sources/Settings/iTermAdvancedSettingsModel.m
+++ b/sources/Settings/iTermAdvancedSettingsModel.m
@@ -345,6 +345,7 @@ DEFINE_BOOL(convertTabDragToWindowDragForSolitaryTabInCompactOrMinimalTheme, YES
 DEFINE_BOOL(highVisibility, YES, SECTION_TABS @"High Contrast modes maximize visibility.\nWhen enabled, the dark high-contrast theme emphasizes visibility over beauty.");
 DEFINE_BOOL(drawBottomLineForHorizontalTabBar, YES, SECTION_TABS @"Draw bottom line for horizontal tabbar in Regular, Dark and Light theme?");
 DEFINE_BOOL(disableTabBarTooltips, NO, SECTION_TABS @"Disable tab bar tooltips?");
+DEFINE_BOOL(scrollableVerticalTabBar, NO, SECTION_TABS @"Make the left-side tab bar scrollable?\nWhen the tab bar is on the left and there are more tabs than fit, the extras normally go into the “More tabs” overflow menu. When this is enabled they stay in the bar and you scroll to reach them.");
 DEFINE_BOOL(useCustomTabBarFontSize, NO, SECTION_TABS @"Use custom font size for tab labels?\nSee also advanced setting “Custom tab label font size”.");
 DEFINE_FLOAT(customTabBarFontSize, 11.0, SECTION_TABS @"Custom tab label font size\nFor this to take effect, turn on “Use custom font size for tab labels?”.");
 DEFINE_FLOAT(minimalSelectedTabUnderlineProminence, 1, SECTION_TABS @"Prominence of selected tab underline indicator in the Minimal theme when there is at least one colored tab.");


### PR DESCRIPTION
## Problem

iTerm2 has a vertical tab bar (Appearance > General > Tab Bar Location > Left), but it cannot be scrolled. Tabs that do not fit are moved into the "More tabs" overflow menu, so once you have a lot of tabs open most of them are only reachable through that menu.

The layout in `PSMTabBarControl.m` `reallyUpdate:` walks down from a fixed top margin and breaks at the bottom edge:

```objc
for (int i = 0; i < cellCount; ++i) {
    if (currentOrigin + cellRect.size.height <= [self frame].size.height) {
        [newOrigins addObject:[NSNumber numberWithFloat:currentOrigin]];
        currentOrigin += cellRect.size.height;
    } else {
        // Out of room, the remaining unpinned tabs go into overflow.
        ...
        break;
    }
}
```

There is no scroll offset anywhere in that file, and `scrollWheel:` / `NSScrollView` / `scrollOffset` have no hits in it.

Existing request for this: https://gitlab.com/gnachman/iterm2/-/issues/10944

## What this does

Adds an advanced setting, "Make the left-side tab bar scrollable?" (`scrollableVerticalTabBar`, default off). When it is on and the tab bar is on the left:

* Every cell gets an origin shifted by a scroll offset, instead of the layout stopping at the bottom edge. Nothing goes into the overflow menu, so the scroll wheel can reach every tab.
* `scrollWheel:` moves the offset, clamped at both ends. Precise deltas (trackpad, Magic Mouse) are used as-is; line deltas from a notched wheel are scaled to one tab per line. When everything already fits, the event is passed through to `super` unchanged.
* Selecting a tab that is off-screen scrolls it into view, for example when cmd-shift-[ walks past the top, or when the selection comes from outside the bar.
* `clipsToBounds` is set explicitly, because `NSView` defaults it to `NO` on macOS 14 and later and the scrolled-away cells would otherwise paint over the window chrome.
* The add-tab button is hidden when the tabs run past the bottom, since there is no overflow menu for it to sit against and it would land off-screen.

Default is off, so behaviour is unchanged unless it is turned on.

Files touched: `ThirdParty/PSMTabBarControl/source/PSMTabBarControl.m`, `sources/Settings/iTermAdvancedSettingsModel.{h,m}`.

## Testing

Built Deployment on macOS 26.5, Xcode 26.2, arm64. Tested with 18 tabs in a 420pt tall window:

* Setting off: unchanged, tabs overflow into the menu exactly as before.
* Setting on: the overflow button disappears, the trackpad and scroll wheel reach every tab, cells clip cleanly at the top and bottom edges, and selecting tab 1 scrolls the bar back to the top.

I run with roughly 200 tabs in a left sidebar day to day, which is what prompted this.

## One thing worth flagging

With the setting on, layout gives an origin to every cell rather than only the ones that fit, so `_setupCells:` sets a frame and a close-button tracking rect for all of them, and `scrollWheel:` triggers a relayout per event. At high tab counts that is more work per update than the overflow path does. I have not profiled that difference.

If you would rather have it only lay out the cells in the visible range plus a small buffer, I am happy to rework it that way before this is merged.
