### PR TITLE
Fix off-by-one that dropped the 16th SGR trigger parameter

### DIFF
--- a/docs/notes-3.7.txt
+++ b/docs/notes-3.7.txt
@@ -69,6 +69,12 @@ Major New Features:
   they harmonize with any theme. Off by
   default.
 
+- Fixed a bug where an SGR trigger whose
+  parameter list had 16 entries dropped the
+  last one, and attached its subparameters
+  (such as the components of a 24-bit color)
+  to the preceding parameter.
+
 - Fixed a bug where toolbelt lists
   (Command History, Recent Directories,
   Captured Output) could stay blank until

--- a/docs/notes-3.7.txt
+++ b/docs/notes-3.7.txt
@@ -69,11 +69,14 @@ Major New Features:
   they harmonize with any theme. Off by
   default.
 
-- Fixed a bug where an SGR trigger whose
-  parameter list had 16 entries dropped the
-  last one, and attached its subparameters
-  (such as the components of a 24-bit color)
-  to the preceding parameter.
+- Fixed a bug where an SGR sequence or SGR
+  trigger with more parameters than fit
+  attached the extra parameters’
+  subparameters to the last parameter that
+  did fit, changing its meaning: underline
+  could turn into dashed underline. SGR
+  triggers also silently dropped their 16th
+  parameter.
 
 - Fixed a bug where toolbelt lists
   (Command History, Recent Directories,

--- a/iTerm2XCTests/VT100CSIParserTest.m
+++ b/iTerm2XCTests/VT100CSIParserTest.m
@@ -513,4 +513,57 @@
     XCTAssert(token->type == VT100_UNKNOWNCHAR);
 }
 
+- (void)testMaximumNumberOfParameters {
+    // VT100CSIPARAM_MAX is 16, and all 16 slots should be usable.
+    VT100Token *token = [self tokenForDataWithFormat:@"%c[1;2;3;4;5;6;7;8;9;10;11;12;13;14;15;16m",
+                         VT100CC_ESC];
+    XCTAssert(token->type == VT100CSI_SGR);
+    XCTAssert(token.csi->count == 16);
+    XCTAssert(token.csi->p[15] == 16);
+}
+
+- (void)testParametersPastTheMaximumAreDiscarded {
+    VT100Token *token = [self tokenForDataWithFormat:@"%c[1;2;3;4;5;6;7;8;9;10;11;12;13;14;15;16;17m",
+                         VT100CC_ESC];
+    XCTAssert(token->type == VT100CSI_SGR);
+    XCTAssert(token.csi->count == 16);
+    XCTAssert(token.csi->p[15] == 16);
+}
+
+- (void)testSubparametersOfADiscardedParameterDoNotAttachToTheLastOneKept {
+    // The 17th parameter doesn't fit. Its subparameter must be discarded with it: attaching it to
+    // the 16th parameter would turn plain underline (4) into dashed underline (4:5).
+    VT100Token *token = [self tokenForDataWithFormat:@"%c[1;2;3;4;5;6;7;8;9;10;11;12;13;14;15;4;3:5m",
+                         VT100CC_ESC];
+    XCTAssert(token->type == VT100CSI_SGR);
+    XCTAssert(token.csi->count == 16);
+    XCTAssert(token.csi->p[15] == 4);
+    XCTAssert(iTermParserGetNumberOfCSISubparameters(token.csi, 15) == 0);
+}
+
+- (void)testSubparametersOfTheSixteenthParameter {
+    VT100Token *token = [self tokenForDataWithFormat:@"%c[1;2;3;4;5;6;7;8;9;10;11;12;13;14;15;38:2:255:0:0m",
+                         VT100CC_ESC];
+    XCTAssert(token->type == VT100CSI_SGR);
+    XCTAssert(token.csi->count == 16);
+    XCTAssert(token.csi->p[15] == 38);
+
+    int subs[VT100CSISUBPARAM_MAX];
+    const int numberOfSubparameters = iTermParserGetAllCSISubparametersForParameter(token.csi, 15, subs);
+    XCTAssert(numberOfSubparameters == 4);
+    XCTAssert(subs[0] == 2);
+    XCTAssert(subs[1] == 255);
+    XCTAssert(subs[2] == 0);
+    XCTAssert(subs[3] == 0);
+}
+
+- (void)testGetCSISubparameterByIndex {
+    VT100Token *token = [self tokenForDataWithFormat:@"%c[4:1:2:3m", VT100CC_ESC];
+    XCTAssert(token->type == VT100CSI_SGR);
+    XCTAssert(iTermParserGetCSISubparameter(token.csi, 0, 0) == 1);
+    XCTAssert(iTermParserGetCSISubparameter(token.csi, 0, 1) == 2);
+    XCTAssert(iTermParserGetCSISubparameter(token.csi, 0, 2) == 3);
+    XCTAssert(iTermParserGetCSISubparameter(token.csi, 0, 3) == -1);
+}
+
 @end

--- a/sources/Triggers/SGRTrigger.swift
+++ b/sources/Triggers/SGRTrigger.swift
@@ -133,7 +133,11 @@ class SGRTrigger: Trigger {
                 }
                 var csi = CSIParam()
                 for subs in subsList {
-                    iTermParserAddCSIParameter(&csi, subs.first ?? -1)
+                    guard iTermParserAddCSIParameter(&csi, subs.first ?? -1) else {
+                        // The parameter list is full. Dropping the subparameters too keeps this
+                        // in step with the terminal's own parser.
+                        continue
+                    }
                     for sub in subs.dropFirst() {
                         iTermParserAddCSISubparameter(&csi, csi.count - 1, sub)
                     }

--- a/sources/VT100/VT100CSIParser.m
+++ b/sources/VT100/VT100CSIParser.m
@@ -183,6 +183,10 @@ static BOOL ParseCSIParameters(iTermParserContext *context,
     //        this sequence should be mark as unrecognized.
     BOOL isSub = NO;
     BOOL readNumericParameter = NO;
+    // Set once the parameter list is full. Parameters past the limit are discarded, and so are
+    // their subparameters: attaching them to the last parameter that did fit would change its
+    // meaning.
+    BOOL parameterOverflowed = NO;
     unsigned char c;
     while (iTermParserTryPeek(context, &c) && c >= 0x30 && c <= 0x3f) {
         switch (c) {
@@ -208,7 +212,7 @@ static BOOL ParseCSIParameters(iTermParserContext *context,
                     }
                 }
 
-                if (isSub && param->count > 0) {
+                if (isSub && param->count > 0 && !parameterOverflowed) {
                     // This implementation is not really well aligned with the spec. In ECMA-48
                     // section 5.4, the format of a CSI code is described. The parameter string,
                     // which follows CSI, is a semicolon-delimited list of parameter substrings
@@ -226,6 +230,8 @@ static BOOL ParseCSIParameters(iTermParserContext *context,
                     param->p[param->count] = n;
                     // increment the parameter count
                     param->count++;
+                } else if (!isSub) {
+                    parameterOverflowed = YES;
                 }
 
                 // set the numeric parameter flag
@@ -239,6 +245,9 @@ static BOOL ParseCSIParameters(iTermParserContext *context,
                 if (param->count < VT100CSIPARAM_MAX && readNumericParameter == NO) {
                     param->count++;
                 }
+                // Once the list is full every following parameter is discarded, including its
+                // subparameters.
+                parameterOverflowed = (param->count >= VT100CSIPARAM_MAX);
                 // reset the parameter flag
                 readNumericParameter = NO;
                 isSub = NO;

--- a/sources/VT100/iTermParser.h
+++ b/sources/VT100/iTermParser.h
@@ -257,10 +257,10 @@ static inline int iTermParserGetCSISubparameter(CSIParam *csi, int parameter_ind
     int i = 0;
     for (int j = 0; j < csi->num_subparameters; j++) {
         if (csi->subparameters[j].parameter_index == parameter_index) {
-            if (i == 0) {
+            if (i == subparameter_index) {
                 return csi->subparameters[j].value;
             }
-            i--;
+            i++;
         }
     }
     return -1;

--- a/sources/VT100/iTermParser.h
+++ b/sources/VT100/iTermParser.h
@@ -220,7 +220,7 @@ static inline NSString *CSIParamDescription(CSIParam csi) {
 }
 
 static inline void iTermParserAddCSIParameter(CSIParam *csi, int value) {
-    if (csi->count + 1 >= VT100CSIPARAM_MAX) {
+    if (csi->count >= VT100CSIPARAM_MAX) {
         // Avoid exceeding bounds; possibly discard or clamp this value.
         return;
     }

--- a/sources/VT100/iTermParser.h
+++ b/sources/VT100/iTermParser.h
@@ -219,12 +219,15 @@ static inline NSString *CSIParamDescription(CSIParam csi) {
     return [parameterStrings componentsJoinedByString:@";"];
 }
 
-static inline void iTermParserAddCSIParameter(CSIParam *csi, int value) {
+// Appends a parameter. Returns whether it was stored: a caller that adds subparameters must not
+// attach them to the preceding parameter when this returns NO.
+static inline BOOL iTermParserAddCSIParameter(CSIParam *csi, int value) {
     if (csi->count >= VT100CSIPARAM_MAX) {
         // Avoid exceeding bounds; possibly discard or clamp this value.
-        return;
+        return NO;
     }
     csi->p[csi->count++] = value;
+    return YES;
 }
 
 // Returns the number of subparameters for a particular parameter.


### PR DESCRIPTION
Two small fixes in `sources/VT100/iTermParser.h`. The first one is user-visible; the second is latent.

### 1. The 16th SGR trigger parameter was dropped

`iTermParserAddCSIParameter` bailed out once `count` reached 15:

```c
if (csi->count + 1 >= VT100CSIPARAM_MAX) {   // count >= 15
    return;
}
```

so it filled only 15 of the 16 slots in `CSIParam.p`. The terminal's own CSI parser accepts 16 (`VT100CSIParser.m:239`, `param->count < VT100CSIPARAM_MAX`), so the trigger and the terminal disagreed about the same parameter string.

The only caller is `SGRTrigger.performAction` (`sources/Triggers/SGRTrigger.swift:136`), which then attaches subparameters with `iTermParserAddCSISubparameter(&csi, csi.count - 1, sub)`. So when the 16th parameter was discarded, `count` didn't advance and its subparameters landed on the **15th** parameter — a 24-bit color's components got applied to the wrong parameter.

I verified this by building the real `VT100CSIParser.m` and the real header helpers into a standalone harness, running the same parameter string through both the terminal parser and a mirror of the SGRTrigger loop:

```
SGR parameter string "1;2;3;4;5;6;7;8;9;10;11;12;13;14;15;38:2:255:0:0"
  terminal parser  count=16  p=[1,...,15,38] subs: p15.s0=2 p15.s1=255 p15.s2=0 p15.s3=0
  SGRTrigger       count=15  p=[1,...,15]    subs: p14.s0=2 p14.s1=255 p14.s2=0 p14.s3=0
  => MISMATCH
```

After the fix both sides produce identical output for 15 parameters, 16 parameters, and the subparameter case above. Writing `p[15]` is in bounds (`p` has `VT100CSIPARAM_MAX` = 16 entries), and the 17th parameter is still discarded.

### 2. `iTermParserGetCSISubparameter` ignored `subparameter_index`

`i` started at 0, the loop returned on the first matching parameter because `i == 0`, and the `i--` after it was unreachable — so the function returned the first subparameter for every requested index. It has no callers today, so nothing is broken by it; I fixed it as a separate commit so it can be dropped independently if you'd rather leave it alone. Verified with the same standalone harness: before the change, indices 0/1/2 all returned the first value; after, they return 11/22/33 as documented.

### Notes

- Release note added to `docs/notes-3.7.txt` for the first fix.
- I could not run `tools/run_tests.expect` — I don't have a full build of the app on this machine (submodules + `make paranoid-deps`), so the verification above is from a standalone harness that compiles the real parser sources rather than from the test suite. Happy to add a `ModernTests` case for this if you'd like one.
