### PR TITLE
Honor OSC 9;4;4 (paused) when the percentage is omitted

### DIFF
--- a/ModernTests/VT100ScreenTests.swift
+++ b/ModernTests/VT100ScreenTests.swift
@@ -1616,6 +1616,116 @@ class VT100ScreenTests: XCTestCase {
                        ".....!")
     }
 
+    // MARK: - ConEmu progress protocol (OSC 9;4)
+
+    private func screenProgress(_ screen: VT100Screen) -> Int {
+        var result = 0
+        screen.performBlock(joinedThreads: { _, mutableState, _ in
+            result = mutableState.progress.rawValue
+        })
+        return result
+    }
+
+    // Mirrors kMinimumVisibleProgressPercentage in
+    // VT100ScreenMutableState+TerminalDelegate.m.
+    private let minimumVisibleProgressPercentage = 10
+
+    // The percentage is optional for the paused state, so pausing without one keeps
+    // the percentage that is already showing and only changes its color.
+    func testProgressPauseWithoutPercentageKeepsCurrentPercentage() {
+        let screen = screen(width: 80, height: 24)
+        feed(screen, "\u{1b}]9;4;1;60\u{07}")
+        XCTAssertEqual(screenProgress(screen), VT100ScreenProgress.successBase.rawValue + 60)
+
+        feed(screen, "\u{1b}]9;4;4\u{07}")
+        XCTAssertEqual(screenProgress(screen), VT100ScreenProgress.warningBase.rawValue + 60)
+    }
+
+    // The percentage is preserved no matter which base it was in.
+    func testProgressPauseWithoutPercentageKeepsErrorPercentage() {
+        let screen = screen(width: 80, height: 24)
+        feed(screen, "\u{1b}]9;4;2;25\u{07}")
+        XCTAssertEqual(screenProgress(screen), VT100ScreenProgress.errorBase.rawValue + 25)
+
+        feed(screen, "\u{1b}]9;4;4\u{07}")
+        XCTAssertEqual(screenProgress(screen), VT100ScreenProgress.warningBase.rawValue + 25)
+    }
+
+    // With no percentage to keep, show the minimum visible one rather than 0, which
+    // would draw a zero-width bar.
+    func testProgressPauseWithoutPercentageAndNothingShowingUsesMinimum() {
+        let screen = screen(width: 80, height: 24)
+        XCTAssertEqual(screenProgress(screen), VT100ScreenProgress.stopped.rawValue)
+
+        feed(screen, "\u{1b}]9;4;4\u{07}")
+        XCTAssertEqual(screenProgress(screen),
+                       VT100ScreenProgress.warningBase.rawValue + minimumVisibleProgressPercentage)
+    }
+
+    // A percentage of 0 is showing but would be invisible, so it gets the minimum too.
+    func testProgressPauseWithoutPercentageFromZeroUsesMinimum() {
+        let screen = screen(width: 80, height: 24)
+        feed(screen, "\u{1b}]9;4;1;0\u{07}")
+        XCTAssertEqual(screenProgress(screen), VT100ScreenProgress.successBase.rawValue)
+
+        feed(screen, "\u{1b}]9;4;4\u{07}")
+        XCTAssertEqual(screenProgress(screen),
+                       VT100ScreenProgress.warningBase.rawValue + minimumVisibleProgressPercentage)
+    }
+
+    // An explicitly invalid percentage is ignored: an out-of-range value must not
+    // change the state the way an absent one does.
+    func testProgressPauseWithInvalidPercentageIsIgnored() {
+        let screen = screen(width: 80, height: 24)
+        feed(screen, "\u{1b}]9;4;1;60\u{07}")
+
+        feed(screen, "\u{1b}]9;4;4;101\u{07}")
+        XCTAssertEqual(screenProgress(screen), VT100ScreenProgress.successBase.rawValue + 60)
+
+        feed(screen, "\u{1b}]9;4;4;-1\u{07}")
+        XCTAssertEqual(screenProgress(screen), VT100ScreenProgress.successBase.rawValue + 60)
+    }
+
+    // An explicit percentage is always honored, including 0.
+    func testProgressPauseWithExplicitPercentage() {
+        let screen = screen(width: 80, height: 24)
+        feed(screen, "\u{1b}]9;4;1;60\u{07}")
+
+        feed(screen, "\u{1b}]9;4;4;30\u{07}")
+        XCTAssertEqual(screenProgress(screen), VT100ScreenProgress.warningBase.rawValue + 30)
+
+        feed(screen, "\u{1b}]9;4;4;0\u{07}")
+        XCTAssertEqual(screenProgress(screen), VT100ScreenProgress.warningBase.rawValue)
+
+        feed(screen, "\u{1b}]9;4;4;100\u{07}")
+        XCTAssertEqual(screenProgress(screen), VT100ScreenProgress.warningBase.rawValue + 100)
+    }
+
+    // The other states are unaffected by how the paused state treats a missing
+    // percentage.
+    func testProgressOtherStatesAreUnchanged() {
+        let screen = screen(width: 80, height: 24)
+
+        feed(screen, "\u{1b}]9;4;1;40\u{07}")
+        XCTAssertEqual(screenProgress(screen), VT100ScreenProgress.successBase.rawValue + 40)
+
+        // st=1 requires a percentage and ignores an invalid one.
+        feed(screen, "\u{1b}]9;4;1;101\u{07}")
+        XCTAssertEqual(screenProgress(screen), VT100ScreenProgress.successBase.rawValue + 40)
+        feed(screen, "\u{1b}]9;4;1\u{07}")
+        XCTAssertEqual(screenProgress(screen), VT100ScreenProgress.successBase.rawValue + 40)
+
+        // st=2 without a percentage falls back to its own sentinel.
+        feed(screen, "\u{1b}]9;4;2\u{07}")
+        XCTAssertEqual(screenProgress(screen), VT100ScreenProgress.error.rawValue)
+
+        feed(screen, "\u{1b}]9;4;3\u{07}")
+        XCTAssertEqual(screenProgress(screen), VT100ScreenProgress.indeterminate.rawValue)
+
+        feed(screen, "\u{1b}]9;4;0\u{07}")
+        XCTAssertEqual(screenProgress(screen), VT100ScreenProgress.stopped.rawValue)
+    }
+
 }
 
 // a very simple LCG-based RNG

--- a/docs/notes-3.7.txt
+++ b/docs/notes-3.7.txt
@@ -2579,3 +2579,10 @@ Bug Fixes:
   wrong width, which corrupted cursor
   movement. Conjoining jamo now compose
   into a single syllable cell.
+- OSC 9;4;4, the ConEmu progress protocol’s
+  paused state, now works when the percentage
+  is left out, which the protocol allows. The
+  bar keeps the percentage it was showing and
+  changes color instead of doing nothing. If
+  there was none, it shows a small one so the
+  paused state is visible.

--- a/sources/VT100Screen/VT100ScreenMutableState+TerminalDelegate.m
+++ b/sources/VT100Screen/VT100ScreenMutableState+TerminalDelegate.m
@@ -23,6 +23,12 @@
 #import "iTermAdvancedSettingsModel.h"
 #import "iTermHistogram.h"
 
+// When the ConEmu progress protocol pauses without giving a percentage and there is none to
+// keep, show this much. The bar's width comes from the percentage, so 0 would be invisible.
+// Windows Terminal substitutes the same value in Terminal::SetTaskbarProgress, where it is
+// called TaskbarMinProgress.
+static const int kMinimumVisibleProgressPercentage = 10;
+
 @implementation VT100ScreenMutableState (TerminalDelegate)
 
 - (BOOL)enteringCommand {
@@ -1525,7 +1531,11 @@ typedef struct {
         if ([params[0] intValue] == 4) {
             if (params.count >= 2 && [params[1] isNumeric]) {
                 const int st = [params[1] intValue];
-                const int pr = params.count >= 3 ? [params[2] intValue] : -1;
+                // A missing pr is not the same as an invalid one: st=4 preserves the current
+                // percentage when pr is absent but ignores an explicit out-of-range value.
+                // An empty field (as in 9;4;4;) counts as present and parses as 0.
+                const BOOL havePR = params.count >= 3;
+                const int pr = havePR ? [params[2] intValue] : -1;
                 switch (st) {
                     case 0:
                         [self setProgress:VT100ScreenProgressStopped];
@@ -1545,11 +1555,22 @@ typedef struct {
                     case 3:  // set indeterminate state
                         [self setProgress:VT100ScreenProgressIndeterminate];
                         break;
-                    case 4:  // set error state in progress. pr is optional
+                    case 4: {  // set paused state in progress. pr is optional
                         if (pr >= 0 && pr <= 100) {
                             [self setProgress:VT100ScreenProgressWarningBase + pr];
+                        } else if (!havePR) {
+                            // Keep the percentage that is already showing and just recolor it,
+                            // as Ghostty does: its docs say the value is used when specified and
+                            // the current one is left unchanged otherwise. There is no encoding
+                            // for a paused state without a percentage, so when there is nothing
+                            // to keep, show the minimum visible amount.
+                            const int currentPercentage = VT100ScreenProgressPercentage(self.progress);
+                            const int percentage = currentPercentage > 0 ? currentPercentage : kMinimumVisibleProgressPercentage;
+                            [self setProgress:VT100ScreenProgressWarningBase + percentage];
                         }
+                        // A pr that is present but out of range is ignored, as in case 1.
                         break;
+                    }
                 }
             } else if (params.count == 1) {
                 [self setProgress:VT100ScreenProgressStopped];

--- a/sources/VT100Screen/VT100ScreenProgress.h
+++ b/sources/VT100Screen/VT100ScreenProgress.h
@@ -17,12 +17,25 @@ typedef NS_ENUM(NSInteger, VT100ScreenProgress) {
     VT100ScreenProgressWarningBase = 3000  // same as .successBase
 };
 
+// Returns the percentage encoded in progress, whichever base it uses, or -1 if it doesn't
+// encode a percentage (i.e., it's stopped or one of the sentinel states).
+NS_INLINE int VT100ScreenProgressPercentage(VT100ScreenProgress progress) {
+    if (progress >= VT100ScreenProgressSuccessBase && progress <= VT100ScreenProgressSuccessBase + 100) {
+        return (int)(progress - VT100ScreenProgressSuccessBase);
+    }
+    if (progress >= VT100ScreenProgressErrorBase && progress <= VT100ScreenProgressErrorBase + 100) {
+        return (int)(progress - VT100ScreenProgressErrorBase);
+    }
+    if (progress >= VT100ScreenProgressWarningBase && progress <= VT100ScreenProgressWarningBase + 100) {
+        return (int)(progress - VT100ScreenProgressWarningBase);
+    }
+    return -1;
+}
+
 NS_INLINE BOOL VT100ScreenProgressIsVisible(VT100ScreenProgress progress) {
     if (progress == VT100ScreenProgressError || progress == VT100ScreenProgressIndeterminate) {
         return YES;
     }
-    return ((progress >= VT100ScreenProgressSuccessBase && progress <= VT100ScreenProgressSuccessBase + 100) ||
-            (progress >= VT100ScreenProgressErrorBase && progress <= VT100ScreenProgressErrorBase + 100) ||
-            (progress >= VT100ScreenProgressWarningBase && progress <= VT100ScreenProgressWarningBase + 100));
+    return VT100ScreenProgressPercentage(progress) >= 0;
 }
 

--- a/tests/progress-bar-paused.sh
+++ b/tests/progress-bar-paused.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Ramp up, then pause without giving a percentage. The percentage is optional
+# for the paused state, so the bar should hold at 60% and turn orange.
+for i in $(seq 0 60); do
+    printf '\e]9;4;1;%d\a' "$i"
+    sleep 0.02
+done
+sleep 1
+printf '\e]9;4;4\a'
+sleep 3
+
+# An explicitly invalid percentage is ignored, so nothing should change here.
+printf '\e]9;4;4;101\a'
+sleep 2
+printf '\e]9;4;0\a'
+sleep 1
+
+# Pausing with nothing showing gives a small bar instead of an invisible one.
+printf '\e]9;4;4\a'
+sleep 3
+printf '\e]9;4;0\a'


### PR DESCRIPTION
`ESC ]9;4;4 ST` — the ConEmu protocol's "paused" state without a percentage — currently does nothing.

The `pr` value is optional for `st=4` per the [ConEmu spec](https://conemu.github.io/en/AnsiEscapeCodes.html), and the comment on that branch in `-terminalPostUserNotification:` already said so, but the code only acted when `pr` was in 0…100. `st=2` (error) handles the same situation by falling back to the `VT100ScreenProgressError` sentinel. The `case 4` comment was also a copy of `case 2`'s and wrongly said "set error state".

### What this does

When `pr` is absent, keep the percentage that is already showing and just switch it to the warning encoding, so a paused 60% download stays at 60% and only changes color. That is what [Ghostty](https://ghostty.org/docs/vt/osc/conemu) does ("v when specified, otherwise unchanged"), and what Windows Terminal does in `Terminal::SetTaskbarProgress`. When there is no percentage to keep, it falls back to 10% — the progress bar's width is derived from the percentage, so 0 would draw an invisible indicator; Windows Terminal substitutes the same value under the name `TaskbarMinProgress`.

An explicitly out-of-range `pr` is still ignored, exactly as before and as `st=1` does — this distinguishes "the parameter is absent" from "the parameter is present but invalid", so `ESC ]9;4;4;101 ST` remains a no-op rather than changing state.

`VT100ScreenProgressPercentage()` is a new `NS_INLINE` helper in `VT100ScreenProgress.h` that extracts the percentage from whichever base is in use; `VT100ScreenProgressIsVisible` now uses it instead of repeating the three range checks. No enum values were added, so `PSMProgress` needs no corresponding change.

### Testing

Six tests added to `ModernTests/VT100ScreenTests.swift` (no new file, so no project change), driving the real parser through the existing `screen(...)`/`feed(...)` helpers:

- 60% then `9;4;4` → warning encoding at 60%; likewise from an error percentage
- `9;4;4` with nothing showing, and from an explicit 0% → the minimum visible value
- `9;4;4;101` and `9;4;4;-1` → state untouched
- explicit 0, 30, 100 → honored exactly
- st=0/1/2/3 unchanged, including the ignored `9;4;1;101`

`tests/progress-bar-paused.sh` is a manual demonstration in the style of the existing `progress-bar-*.sh` scripts.

Manual check:

```sh
printf '\033]9;4;1;60\a'   # bar at 60%
printf '\033]9;4;4\a'      # stays at 60%, turns orange
printf '\033]9;4;4;101\a'  # ignored
printf '\033]9;4;0\a'      # clear
```

### Verification

`make Development` succeeds on this branch — `** BUILD SUCCEEDED **`, no errors and no new warnings in the touched files. The seven tests above run and pass:

```
xcodebuild test -scheme ModernTests -only-testing:ModernTests/VT100ScreenTests
** TEST SUCCEEDED **
```
