### PR TITLE
Stop hidden hotkey windows from redrawing at full cadence

### DIFF
--- a/docs/notes-3.7.txt
+++ b/docs/notes-3.7.txt
@@ -2691,3 +2691,12 @@ Bug Fixes:
   animates: the member tabs slide shut and open.
   Works on horizontal and vertical tab bars in
   every theme.
+- Hidden hotkey windows no longer redraw
+  at the full active cadence. Sessions
+  with continuous output (builds, tails,
+  agents) in a hidden hotkey window used
+  to burn CPU and GPU rendering frames
+  nobody could see, spinning fans on
+  laptops. Hidden windows now drop to
+  the background refresh rate and repaint
+  the instant they are revealed.

--- a/sources/PTYSession/PTYSession.m
+++ b/sources/PTYSession/PTYSession.m
@@ -1043,6 +1043,10 @@ typedef NS_ENUM(NSUInteger, PTYSessionTurdType) {
                                                      name:@"iTermWindowWillMiniaturize"
                                                    object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(windowOcclusionStateDidChange:)
+                                                     name:NSWindowDidChangeOcclusionStateNotification
+                                                   object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(autoComposerDidChange:)
                                                      name:iTermAutoComposerDidChangeNotification
                                                    object:nil];
@@ -7807,6 +7811,21 @@ static NSString *const PTYSessionComposerPrefixUserDataKeyDetectedByTrigger = @"
     DLog(@"windowDidMiniaturize for %@", self);
     if (_alertOnMarksinOffscreenSessions) {
         [self sync];
+    }
+}
+
+// Fires on orderOut/orderFront (e.g., a hotkey window being hidden or revealed), which do not go
+// through the miniaturize or tab-selection paths that normally poke the cadence controller.
+- (void)windowOcclusionStateDidChange:(NSNotification *)notification {
+    if (notification.object != self.view.window) {
+        return;
+    }
+    DLog(@"windowOcclusionStateDidChange for %@", self);
+    [_cadenceController changeCadenceIfNeeded];
+    if (self.view.window.occlusionState & NSWindowOcclusionStateVisible) {
+        // Ensure the content is fresh the moment the window is revealed rather than waiting for
+        // the next cadence tick.
+        [_textview requestDelegateRedraw];
     }
 }
 
@@ -21361,7 +21380,12 @@ static const NSTimeInterval PTYSessionFocusReportBellSquelchTimeIntervalThreshol
     iTermUpdateCadenceState state;
     state.active = _active;
     state.idle = self.isIdle;
-    state.visible = [_delegate sessionBelongsToVisibleTab] && !self.view.window.isMiniaturized;
+    // isVisible distinguishes windows that were ordered out (e.g., a hidden hotkey window) from
+    // on-screen windows. Without it, a hidden hotkey window with a non-idle session redraws at
+    // the full active cadence forever. See the offscreen predicate in -shouldAlert for precedent.
+    state.visible = ([_delegate sessionBelongsToVisibleTab] &&
+                     self.view.window.isVisible &&
+                     !self.view.window.isMiniaturized);
 
     if (self.useMetal) {
         if ([iTermPreferences maximizeThroughput] &&

--- a/sources/TerminalView/iTermMTKView.swift
+++ b/sources/TerminalView/iTermMTKView.swift
@@ -53,6 +53,12 @@ public class iTermMTKView: iTermMetalView {
             DLog("Not visible \(self)")
             return;
         }
+        if window?.occlusionState.contains(.visible) != true {
+            // The window was ordered out (e.g., a hidden hotkey window) or is fully occluded.
+            // Keeping the pipeline warm would burn CPU and GPU drawing pixels nobody can see.
+            DLog("Window not visible \(self)")
+            return;
+        }
         if (round(1000 * timer.timeInterval) != round(1000 * iTermAdvancedSettingsModel.metalRedrawPeriod()))  {
             DLog("Recreate timer");
             _timer?.invalidate()


### PR DESCRIPTION
An `orderOut`'d hotkey window is invisible to three separate subsystems, so a session with continuous output keeps rendering at the full active cadence — up to 120fps on ProMotion — for as long as it stays hidden.

### Causes

1. **`updateCadenceControllerState`** only checked `sessionBelongsToVisibleTab` and `isMiniaturized`, never whether the window is actually on screen. An `orderOut`'d window with a non-idle session therefore stayed on the active cadence indefinitely. This adds an `isVisible` check, matching the offscreen predicate already used in `-shouldAlert`.

2. **Nothing poked the cadence controller on `orderOut`/`orderFront`.** Hotkey show/hide does not go through the miniaturize or tab-selection paths that normally trigger a cadence change, so even a correct predicate would not have been re-evaluated. This observes `NSWindowDidChangeOcclusionStateNotification` to change cadence immediately, and requests one redraw on reveal so content is fresh rather than waiting for the next tick.

3. **`iTermMTKView`'s keep-warm timer** only bailed on `isHidden` / zero alpha / nil window — none of which apply to an `orderOut`'d window. Every split pane kept a 2fps Metal render loop alive. This bails when the window's `occlusionState` is not visible.

Hidden sessions still tick at the 1Hz background cadence, so tab colors and activity indicators keep working.

### Measurements

Deployment (optimised) build, arm64, macOS 26.6. A hotkey window running a steady ~9.6 lines/sec stream, toggled with the real F1 hotkey. CPU sampled as `ps` cputime deltas; the producer's line rate was verified independently on both sides so a stalled stream could not be misread as a saving.

| Hotkey window | CPU | n | sd |
| --- | --- | --- | --- |
| Hidden (`orderOut`) | **11.88%** | 41 | 0.51 |
| Visible | **14.20%** | 49 | 0.57 |

**2.33 points / 16.4% saved while hidden** (Welch t = 20.5).

### Scope — what this does not fix

Against a measured idle floor of ~1.9%, the excess while visible is 12.3 points. This patch removes 2.33 of them; **~10 points (81%) still burn while the window is off screen.**

That remainder is not in the render path. `TokenExecutor` schedules side effects on the main queue at a fixed `1/30.0` period regardless of visibility, and the VT/read path has no visibility awareness at all. Making token execution coalesce into larger, less frequent batches when the window is not visible looks like the larger remaining win, but it needs care around high-priority side effects (bells, notifications) and is deliberately out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
