### PR TITLE
Fix framework builds on case-sensitive filesystems

### DIFF
--- a/BetterFontPicker/Makefile
+++ b/BetterFontPicker/Makefile
@@ -13,8 +13,8 @@ endif
 all:
 	xcodebuild -parallelizeTargets -target BetterFontPicker -configuration Release 'CONFIGURATION_BUILD_DIR=$$(SRCROOT)/Build/$$(CONFIGURATION)' $(SIGNING_FLAGS) $(ARCH_FLAGS)
 	rm -rf BetterFontPicker.framework
-	mv build/Release/BetterFontPicker.framework .
+	mv Build/Release/BetterFontPicker.framework .
 dev:
 	xcodebuild -parallelizeTargets -target BetterFontPicker -configuration Debug 'CONFIGURATION_BUILD_DIR=$$(SRCROOT)/Build/$$(CONFIGURATION)' $(SIGNING_FLAGS) $(ARCH_FLAGS)
 	rm -rf BetterFontPicker.framework
-	mv build/Debug/BetterFontPicker.framework .
+	mv Build/Debug/BetterFontPicker.framework .

--- a/ColorPicker/Makefile
+++ b/ColorPicker/Makefile
@@ -13,4 +13,4 @@ endif
 all:
 	xcodebuild -parallelizeTargets -target ColorPicker -configuration Release 'CONFIGURATION_BUILD_DIR=$$(SRCROOT)/Build/$$(CONFIGURATION)' $(SIGNING_FLAGS) $(ARCH_FLAGS)
 	rm -rf ColorPicker.framework
-	mv build/Release/ColorPicker.framework .
+	mv Build/Release/ColorPicker.framework .

--- a/Makefile
+++ b/Makefile
@@ -638,12 +638,12 @@ SearchableComboListView: force
 SwiftyMarkdown: force
 	cd submodules/SwiftyMarkdown && xcodebuild -configuration Release 'CONFIGURATION_BUILD_DIR=$$(SRCROOT)/Build/$$(CONFIGURATION)' $(SIGNING_FLAGS) $(ARCH_FLAGS)
 	rm -rf ThirdParty/SwiftyMarkdown.framework
-	mv submodules/SwiftyMarkdown/build/Release/SwiftyMarkdown.framework ThirdParty/SwiftyMarkdown.framework
+	mv submodules/SwiftyMarkdown/Build/Release/SwiftyMarkdown.framework ThirdParty/SwiftyMarkdown.framework
 
 Highlightr: force
 	cd submodules/Highlightr && xcodebuild -project Highlightr.xcodeproj -target Highlightr-macOS 'CONFIGURATION_BUILD_DIR=$$(SRCROOT)/Build/$$(CONFIGURATION)' $(SIGNING_FLAGS) $(ARCH_FLAGS)
 	rm -rf ThirdParty/Highlightr.framework
-	mv submodules/Highlightr/build/Release/Highlightr.framework ThirdParty/Highlightr.framework
+	mv submodules/Highlightr/Build/Release/Highlightr.framework ThirdParty/Highlightr.framework
 
 cleandeps: force
 	cd submodules/CoreParse/ && git clean -f -d .

--- a/SearchableComboListView/Makefile
+++ b/SearchableComboListView/Makefile
@@ -13,6 +13,6 @@ endif
 all: force
 	rm -rf SearchableComboListView.framework
 	xcodebuild -target SearchableComboListView -configuration Release 'CONFIGURATION_BUILD_DIR=$$(SRCROOT)/Build/$$(CONFIGURATION)' $(SIGNING_FLAGS) $(ARCH_FLAGS)
-	mv build/Release/SearchableComboListView.framework .
+	mv Build/Release/SearchableComboListView.framework .
 
 force:


### PR DESCRIPTION
Every framework sub-build passes `CONFIGURATION_BUILD_DIR=$(SRCROOT)/Build/$(CONFIGURATION)` to
xcodebuild, so the products land in `Build/Release` (or `Build/Debug`) — but the `mv` that collects
each product reads from lowercase `build/Release`. On the default case-insensitive APFS those are
the same directory, so this has always worked; on a case-sensitive volume the `mv` fails with
"No such file or directory" immediately after a **successful** build, which makes the failure
confusing to diagnose.

Affected recipes, all with the same one-word fix (`build/` → `Build/`, matching what xcodebuild
was told to do):

| File | Recipes |
|---|---|
| `Makefile` | `SwiftyMarkdown`, `Highlightr` |
| `BetterFontPicker/Makefile` | `all`, `dev` |
| `ColorPicker/Makefile` | `all` |
| `SearchableComboListView/Makefile` | `all` |

The change is byte-for-byte a no-op on case-insensitive filesystems.

**How found / verified:** building the repo on Case-sensitive APFS (an external volume).
`make paranoid-deps` failed at SwiftyMarkdown, then Highlightr, then BetterFontPicker, each time
after `** BUILD SUCCEEDED **`; with these fixes, a clean `make paranoid-deps` followed by
`make Development` completes on the same volume, and the resulting app runs.

Related but filed separately: the CoreParse submodule has a case-mismatched `#import` that breaks
the *app* build on case-sensitive filesystems in a subtler way (duplicate `CPToken` interface).
That fix is a PR against `gnachman/CoreParse`; this PR is independent of it.
