### PR TITLE
✨ feat(compact-tabs): open Set Window Title on name double-click

### DIFF
--- a/docs/notes-3.7.txt
+++ b/docs/notes-3.7.txt
@@ -2960,3 +2960,10 @@ Bug Fixes:
 - Fixed the git ahead/behind arrows in the
   session toolbar staying black in dark mode
   instead of matching the text color.
+- Double-clicking the window name beside the
+  tabs now opens the same rename dialog as
+  Window > Edit Window Title, so a window can be
+  renamed where its name is shown rather than
+  only from the Window menu. Dragging the name
+  still moves the window and right-clicking it
+  still opens the tab bar menu.

--- a/sources/TerminalView/PseudoTerminal.m
+++ b/sources/TerminalView/PseudoTerminal.m
@@ -1223,6 +1223,10 @@ ITERM_WEAKLY_REFERENCEABLE
     return nil;
 }
 
+- (void)rootTerminalViewDidRequestEditWindowName {
+    [self editWindowTitle:nil];
+}
+
 - (void)rootTerminalViewDidResizeContentArea {
     // Fixes an analog of issue 4323 that happens with left-side tabs. More
     // details in -toolbeltDidFinishGrowing.

--- a/sources/TerminalView/iTermRootTerminalView.h
+++ b/sources/TerminalView/iTermRootTerminalView.h
@@ -53,6 +53,10 @@
 // Compact and minimal themes have no title bar, so without this the window name
 // is only visible when the tab bar is hidden and the title takes its place.
 - (NSString *)rootTerminalViewWindowNameBesideTabs;
+
+// The window name beside the tabs was double-clicked. Opens the rename dialog
+// that Window > Edit Window Title opens, which is otherwise the only way there.
+- (void)rootTerminalViewDidRequestEditWindowName;
 - (NSImage *)rootTerminalViewCurrentTabIcon;
 - (BOOL)rootTerminalViewShouldDrawStoplightButtons;
 - (BOOL)rootTerminalViewShouldRevealStandardWindowButtons;

--- a/sources/TerminalView/iTermRootTerminalView.m
+++ b/sources/TerminalView/iTermRootTerminalView.m
@@ -356,14 +356,40 @@ typedef struct {
     if (!_tabBarControlOnLoan && !_windowNumberLabel.hidden && view == _windowNumberLabel && !_tabBarControl.isHidden) {
         return _tabBarControl;
     } else if (!_tabBarControlOnLoan && !_windowNameBesideTabsLabel.hidden && view == _windowNameBesideTabsLabel && !_tabBarControl.isHidden) {
-        // Same as the window number: the name is painted over the strip, so
-        // clicks belong to the tab bar underneath it.
-        return _tabBarControl;
+        // Unlike the window number, the name answers one gesture of its own: a
+        // double-click opens the rename dialog, since the name is the one thing
+        // in the strip a user might want to change in place. -mouseDown: hands
+        // every other gesture straight back, so the strip is unchanged except
+        // for that one case.
+        return self;
     } else if (!_windowTitleLabel.hidden && view == _windowTitleLabel) {
         return self;
     } else {
         return view;
     }
+}
+
+- (BOOL)pointIsInWindowNameBesideTabs:(NSPoint)point {
+    return (!_tabBarControlOnLoan &&
+            !_windowNameBesideTabsLabel.hidden &&
+            !_tabBarControl.isHidden &&
+            NSPointInRect(point, _windowNameBesideTabsLabel.frame));
+}
+
+- (void)mouseDown:(NSEvent *)event {
+    if (![self pointIsInWindowNameBesideTabs:[self convertPoint:event.locationInWindow fromView:nil]]) {
+        [super mouseDown:event];
+        return;
+    }
+    if (event.clickCount == 2) {
+        [self.delegate rootTerminalViewDidRequestEditWindowName];
+        return;
+    }
+    // What makes an ordinary view behave like a title bar: the window follows
+    // the drag, and a plain click does nothing. It zooms on a double-click too,
+    // which is why the case above returns before reaching it — on the name, the
+    // double-click is spent on the title instead.
+    [self.window performWindowDragWithEvent:event];
 }
 
 - (void)mouseUp:(NSEvent *)event {
@@ -379,7 +405,11 @@ typedef struct {
 }
 
 - (NSMenu *)menuForEvent:(NSEvent *)event {
-    if (_windowTitleLabel.hidden) {
+    // Taking the name's clicks must not cost it the menu it had when those
+    // clicks went to the tab bar, so the name keeps the strip's context menu
+    // even though the fake title label is hidden.
+    if (_windowTitleLabel.hidden &&
+        ![self pointIsInWindowNameBesideTabs:[self convertPoint:event.locationInWindow fromView:nil]]) {
         return nil;
     }
     return [_tabBarControl menuForEvent:event];


### PR DESCRIPTION
### 📄 Description

#731 gives the window name a home beside the tabs, but once it's visible there's no way to change it from there — you still have to reach for the Window menu. That's an odd asymmetry: the name is right there, clickable-looking, and clicking it does nothing.

`-hitTest:` already hands the label the click naturally, because it's a subview sitting on top of the tab bar strip; #731 deliberately forwarded that hit back to `_tabBarControl` so the label wouldn't intercept drags and double-click-to-zoom. This keeps that forwarding for every other pixel of the strip but lets the name itself keep the hit. The double-click is detected in the existing `-mouseUp:`, as a sibling of the fake title label's `it_titleBarDoubleClick` branch, and asks the delegate to open Set Window Title. Nothing is added to `-mouseDown:` — deliberately, since any `-mouseDown:` override on this view switches off the automatic dragging that `mouseDownCanMoveWindow` provides, for every window style (an earlier revision of this PR did exactly that; see the discussion below). Dragging the name therefore still moves the window through the same AppKit path as the rest of the title bar, and the rest of the strip keeps zooming on double-click exactly as before; only the name itself changes behaviour.

Double-click rather than single-click is deliberate: a single click on a title bar is how you focus and drag a window, so spending it here would cost that. But the tension is worth stating plainly rather than glossing — **elsewhere in iTerm2 a double-click on chrome consistently means zoom or maximise.** On the tab bar it zooms the window; on a session title bar it maximises the pane (`-sessionDoubleClickOnTitleBar:` → `-toggleMaximizeSession:`). This change makes the window name the one place that gesture means something else. The case for it is that the name is a specific, labelled target rather than generic chrome, and that single-click is already spoken for — but if you would rather keep the double-click language uniform across the app, a context-menu item on the name is the obvious alternative and I am happy to switch. `-menuForEvent:` also now returns the tab bar's menu when the point is over the name, so taking the double-click doesn't cost the right-click menu that was there before.

Wiring is a single new delegate method, `rootTerminalViewDidRequestEditWindowName`, calling straight into the existing `-editWindowTitle:` action — no new UI, just a second way to reach the one that already exists on the Window menu. `PSMTabBarControl` stays untouched, as in #731.

### 🔍 Scope

Worth being explicit about one limitation: under the default `showWindowNameBesideTabs` setting ("When a custom name is set"), the label doesn't exist until a window already has a name, so this gesture can only ever *re*name a window — it's never how a window gets named the first time. The Window menu remains the only entry point for that.

### ✅ How to Validate

Run each of these in every configuration listed beneath them — the earlier revision broke title-bar dragging outside the one configuration it was checked in, so the matrix is the point.

1. Window → Set Window Title, give the window a name.
2. Drag the window by its title bar (or by the strip where the title sits) — it should move.
3. Double-click the name — Set Window Title should open.
4. Right-click the name — the tab bar's context menu should still appear.
5. Double-click elsewhere on the strip (not the name) — it should still zoom the window.

Configurations: Light, Dark, Minimal and Compact themes; single-tab (title drawn in place of the tab bar) and multi-tab (strip visible); full screen; tab bar at top, bottom and left.

### 🛠️ Developer Checklist

- [x] Code is readable and maintainable
- [ ] Builds clean with no new warnings (`tools/build.sh Development`) — not yet rebuilt since the `-mouseUp:` revision
- [x] Release notes updated in `docs/notes-3.7.txt`
- [ ] Manually verified end to end — the validation matrix above has not yet been run against the current revision; the earlier `-mouseDown:` revision was only exercised under Minimal with a multi-tab strip, which is how the drag regression got through
- [ ] Tests included and passing — there's no test coverage for tab bar mouse handling in this area, and none was added
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org)
