### PR TITLE
Remove obsolete macOS 10.x compatibility code

### DIFF
--- a/iTerm2XCTests/VT100ScreenTest.m
+++ b/iTerm2XCTests/VT100ScreenTest.m
@@ -2073,16 +2073,8 @@ NSLog(@"Known bug: %s should be true, but %s is.", #expressionThatShouldBeTrue, 
     XCTAssert([ScreenCharToStr(line + i++) isEqualToString:@"ł"]);
 
     XCTAssert([ScreenCharToStr(line + i++) isEqualToString:@"🖕🏾"]);
-    BOOL lettersHaveSkin = NO;
-    if (@available(macOS 10.15, *)) { } else {
-        lettersHaveSkin = YES;
-    }
-    if (lettersHaveSkin) {
-        XCTAssert([ScreenCharToStr(line + i++) isEqualToString:@"g\U0001F3FE"]);  // macOS 10.14 does a silly thing
-    } else {
-        XCTAssert([ScreenCharToStr(line + i++) isEqualToString:@"g"]);
-        XCTAssert([ScreenCharToStr(line + i++) isEqualToString:@"🏾"]);  // Skin tone modifier only combines with certain emoji
-    }
+    XCTAssert([ScreenCharToStr(line + i++) isEqualToString:@"g"]);
+    XCTAssert([ScreenCharToStr(line + i++) isEqualToString:@"🏾"]);  // Skin tone modifier only combines with certain emoji
     XCTAssert(line[i++].code == 0);
 }
 

--- a/sources/API/iTermAPIHelper.m
+++ b/sources/API/iTermAPIHelper.m
@@ -1515,7 +1515,7 @@ static BOOL iTermAPIHelperLastApplescriptAuthRequiredSetting;
 }
 
 - (NSMenuItem *)menuItemWithIdentifier:(NSString *)identifier
-                                inMenu:(NSMenu *)menu NS_AVAILABLE_MAC(10_12) {
+                                inMenu:(NSMenu *)menu {
     for (NSMenuItem *item in [menu itemArray]) {
         if ([item hasSubmenu]) {
             NSMenuItem *result = [self menuItemWithIdentifier:identifier inMenu:item.submenu];

--- a/sources/Browser/LocalPages/iTermBrowserErrorHandler.swift
+++ b/sources/Browser/LocalPages/iTermBrowserErrorHandler.swift
@@ -204,26 +204,8 @@ private func sslErrorDescription(for status: Int) -> String? {
 
 /// Get human-friendly subject summaries for the chain.
 private func certificateSubjects(from trust: SecTrust) -> [String] {
-    if #available(macOS 10.15, *) {
-        guard let chain = SecTrustCopyCertificateChain(trust) as? [SecCertificate] else {
-            return []
-        }
-        return chain.compactMap { SecCertificateCopySubjectSummary($0) as String? }
-    } else {
-        var out: [String] = []
-        let count = SecTrustGetCertificateCount(trust)
-        if count <= 0 {
-            return out
-        }
-        for i in 0..<count {
-            if let cert = SecTrustGetCertificateAtIndex(trust, i) {
-                if let s = SecCertificateCopySubjectSummary(cert) as String? {
-                    out.append(s)
-                } else {
-                    out.append("(no subject summary)")
-                }
-            }
-        }
-        return out
+    guard let chain = SecTrustCopyCertificateChain(trust) as? [SecCertificate] else {
+        return []
     }
+    return chain.compactMap { SecCertificateCopySubjectSummary($0) as String? }
 }

--- a/sources/Categories/NSAppearance+iTerm.m
+++ b/sources/Categories/NSAppearance+iTerm.m
@@ -67,7 +67,7 @@
     }
 }
 
-- (iTermPreferencesTabStyle)it_mojaveTabStyle NS_AVAILABLE_MAC(10_14) {
+- (iTermPreferencesTabStyle)it_mojaveTabStyle {
     NSString *name = [self bestMatchFromAppearancesWithNames:@[ NSAppearanceNameAqua,
                                                                 NSAppearanceNameDarkAqua,
                                                                 NSAppearanceNameAccessibilityHighContrastAqua,

--- a/sources/Categories/NSFont+iTerm.m
+++ b/sources/Categories/NSFont+iTerm.m
@@ -57,10 +57,7 @@
     if (font) {
         return font;
     }
-    if (@available(macOS 10.15, *)) {
-        return [NSFont monospacedSystemFontOfSize:points weight:NSFontWeightRegular];
-    }
-    return [NSFont fontWithName:@"Menlo" size:points];
+    return [NSFont monospacedSystemFontOfSize:points weight:NSFontWeightRegular];
 }
 
 - (BOOL)it_hasStylisticAlternatives {

--- a/sources/Hacks/FutureMethods.h
+++ b/sources/Hacks/FutureMethods.h
@@ -45,7 +45,7 @@ MTActuatorCloseFunction *iTermGetMTActuatorCloseFunction(void);
 MTActuatorActuateFunction *iTermGetMTActuatorActuateFunction(void);
 MTActuatorIsOpenFunction *iTermGetMTActuatorIsOpenFunction(void);
 
-NS_INLINE BOOL iTermTextIsMonochromeOnMojave(void) NS_AVAILABLE_MAC(10_14) {
+NS_INLINE BOOL iTermTextIsMonochromeOnMojave(void) {
     if (@available(macOS 10.16, *)) {
         // Issue 9209
         return YES;

--- a/sources/Language/iTermGlobalScopeController.m
+++ b/sources/Language/iTermGlobalScopeController.m
@@ -23,7 +23,6 @@ static char iTermGlobalScopeControllerKVOContext;
 - (NSString *)effectiveTheme;
 @end
 
-NS_CLASS_AVAILABLE_MAC(10_14)
 @interface iTermGlobalScopeControllerModernImpl: iTermGlobalScopeController
 @end
 

--- a/sources/Logging/SwiftDebugLogging.swift
+++ b/sources/Logging/SwiftDebugLogging.swift
@@ -307,7 +307,6 @@ public extension Data {
     }
 }
 
-@available(macOS 10.15, *)
 public func logging<T>(_ prefix: String, closure: () async throws -> T) async rethrows -> T {
     return try await LogContext.$logContexts.withValue(LogContext.logContexts + [prefix]) {
         log("begin")

--- a/sources/MetalRenderer/Glue/iTermCharacterSource.m
+++ b/sources/MetalRenderer/Glue/iTermCharacterSource.m
@@ -126,7 +126,7 @@ static const CGFloat iTermCharacterSourceAliasedFakeBoldShiftPoints = 1;
     BOOL _fakeItalic;
 
     // Large enough to hold glyphSize * maxParts in both horizontal and vertical direction.
-    BOOL _postprocessed NS_AVAILABLE_MAC(10_14);
+    BOOL _postprocessed;
 
     // These have size _bytesPerRow * _numberOfRows.
     NSMutableArray<NSMutableData *> *_datas;

--- a/sources/MetalRenderer/Glue/iTermMetalGlue.h
+++ b/sources/MetalRenderer/Glue/iTermMetalGlue.h
@@ -14,7 +14,6 @@ NS_ASSUME_NONNULL_BEGIN
 @class VT100Screen;
 @class PTYTextView;
 
-NS_CLASS_AVAILABLE(10_11, NA)
 @protocol iTermMetalGlueDelegate<NSObject>
 - (void)metalGlueDidDrawFrameAndNeedsRedraw:(BOOL)redrawAsap;
 - (CGContextRef)metalGlueContext;
@@ -25,7 +24,6 @@ NS_CLASS_AVAILABLE(10_11, NA)
 
 @end
 
-NS_CLASS_AVAILABLE(10_11, NA)
 @interface iTermMetalGlue : NSObject<iTermMetalDriverDataSource>
 
 @property (nullable, nonatomic, strong) PTYTextView *textView;

--- a/sources/MetalRenderer/Infrastructure/iTermASCIITexture.h
+++ b/sources/MetalRenderer/Infrastructure/iTermASCIITexture.h
@@ -58,7 +58,6 @@ typedef NS_OPTIONS(int, iTermASCIITextureParts) {
 @class iTermCharacterBitmap;
 @class iTermCharacterSourceDescriptor;
 
-NS_CLASS_AVAILABLE(10_11, NA)
 @interface iTermASCIITexture : NSObject
 
 @property (nonatomic, readonly) iTermTextureArray *textureArray;
@@ -91,7 +90,6 @@ NS_INLINE int iTermASCIITextureIndexOfCode(char code, iTermASCIITextureOffset of
 }
 
 // Implements isEqual:
-NS_CLASS_AVAILABLE(10_11, NA)
 @interface iTermASCIITextureGroup : NSObject {
 @public
     iTermASCIITexture *_textures[iTermASCIITextureAttributesMax * 2];

--- a/sources/MetalRenderer/Infrastructure/iTermMetalBufferPool.h
+++ b/sources/MetalRenderer/Infrastructure/iTermMetalBufferPool.h
@@ -13,7 +13,6 @@ NS_ASSUME_NONNULL_BEGIN
 @class iTermHistogram;
 @protocol MTLBuffer;
 
-NS_CLASS_AVAILABLE(10_11, NA)
 @interface iTermMetalBufferPoolContext : NSObject
 @property (nonatomic, readonly) iTermHistogram *histogram;
 @property (nonatomic, readonly) iTermHistogram *textureHistogram;
@@ -27,7 +26,6 @@ NS_CLASS_AVAILABLE(10_11, NA)
 @end
 
 // Creating a new buffer can be very slow. Try to reuse them.
-NS_CLASS_AVAILABLE(10_11, NA)
 @interface iTermMetalBufferPool : NSObject
 
 @property (nonatomic) size_t bufferSize;
@@ -46,7 +44,6 @@ NS_CLASS_AVAILABLE(10_11, NA)
 // Keeps up to `capacity` buffers in the pool. If it exceeds that size the smallest ones are released.
 // This might use more texture memory than necessary but it will stabilize quickly and stop creating
 // new buffers, which is terribly slow.
-NS_CLASS_AVAILABLE(10_11, NA)
 @interface iTermMetalMixedSizeBufferPool : NSObject
 @property (nonatomic, copy, readonly) NSString *name;
 

--- a/sources/MetalRenderer/Infrastructure/iTermMetalCellRenderer.h
+++ b/sources/MetalRenderer/Infrastructure/iTermMetalCellRenderer.h
@@ -11,7 +11,6 @@ extern const CGFloat BOTTOM_MARGIN;
 
 @class iTermMetalCellRendererTransientState;
 
-NS_CLASS_AVAILABLE(10_11, NA)
 @interface iTermCellRenderConfiguration : iTermRenderConfiguration
 // This is the size of a cell on screen--the distance from the beginning of one character to the next.
 @property (nonatomic, readonly) CGSize cellSize;
@@ -56,7 +55,6 @@ maximumExtendedDynamicRangeColorComponentValue:(CGFloat)maximumExtendedDynamicRa
 
 @end
 
-NS_CLASS_AVAILABLE(10_11, NA)
 @protocol iTermMetalCellRenderer<NSObject>
 @property (nonatomic, readonly) BOOL rendererDisabled;
 
@@ -72,7 +70,6 @@ NS_CLASS_AVAILABLE(10_11, NA)
 
 @end
 
-NS_CLASS_AVAILABLE(10_11, NA)
 @interface iTermMetalCellRendererTransientState : iTermMetalRendererTransientState
 @property (nonatomic, readonly) __kindof iTermCellRenderConfiguration *cellConfiguration;
 @property (nonatomic, readonly) id<MTLBuffer> offsetBuffer;
@@ -88,7 +85,6 @@ NS_CLASS_AVAILABLE(10_11, NA)
 
 @end
 
-NS_CLASS_AVAILABLE(10_11, NA)
 @interface iTermMetalCellRenderer : iTermMetalRenderer
 
 - (nullable instancetype)initWithDevice:(id<MTLDevice>)device NS_UNAVAILABLE;

--- a/sources/MetalRenderer/Infrastructure/iTermMetalDebugInfo.h
+++ b/sources/MetalRenderer/Infrastructure/iTermMetalDebugInfo.h
@@ -9,7 +9,6 @@
 
 #import <MetalKit/MetalKit.h>
 
-NS_CLASS_AVAILABLE(10_11, NA)
 @protocol iTermMetalDebugInfoFormatter<NSObject>
 
 @optional
@@ -21,7 +20,6 @@ NS_CLASS_AVAILABLE(10_11, NA)
 
 @class iTermMetalRowData;
 
-NS_CLASS_AVAILABLE(10_11, NA)
 @interface iTermMetalDebugDrawInfo : NSObject
 
 @property (nonatomic, copy) NSString *fragmentFunctionName;
@@ -40,13 +38,12 @@ NS_CLASS_AVAILABLE(10_11, NA)
 @protocol iTermMetalCellRenderer;
 @class iTermMetalRendererTransientState;
 
-NS_CLASS_AVAILABLE(10_11, NA)
 @interface iTermMetalDebugInfo : NSObject
 
 @property (nonatomic, readonly) NSUInteger numberOfRecordedDraws;
 
 - (void)setRenderPassDescriptor:(MTLRenderPassDescriptor *)renderPassDescriptor;
-- (void)setPostmultipliedRenderPassDescriptor:(MTLRenderPassDescriptor *)renderPassDescriptor NS_AVAILABLE_MAC(10_14);
+- (void)setPostmultipliedRenderPassDescriptor:(MTLRenderPassDescriptor *)renderPassDescriptor;
 - (void)setIntermediateRenderPassDescriptor:(MTLRenderPassDescriptor *)renderPassDescriptor;
 - (void)setTemporaryRenderPassDescriptor:(MTLRenderPassDescriptor *)renderPassDescriptor;
 - (void)addRowData:(iTermMetalRowData *)rowData;

--- a/sources/MetalRenderer/Infrastructure/iTermMetalDeviceProvider.h
+++ b/sources/MetalRenderer/Infrastructure/iTermMetalDeviceProvider.h
@@ -11,7 +11,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 extern NSString *const iTermMetalDeviceProviderPreferredDeviceDidChangeNotification;
 
-NS_CLASS_AVAILABLE(10_11, NA)
 @interface iTermMetalDeviceProvider : NSObject
 
 @property (nonatomic, readonly, strong) id<MTLDevice> preferredDevice;

--- a/sources/MetalRenderer/Infrastructure/iTermMetalFrameData.h
+++ b/sources/MetalRenderer/Infrastructure/iTermMetalFrameData.h
@@ -127,7 +127,6 @@ extern void iTermMetalFrameDataStatsBundleAdd(iTermPreciseTimerStats *dest, iTer
 @class MTLRenderPassDescriptor;
 @protocol CAMetalDrawable;
 
-NS_CLASS_AVAILABLE(10_11, NA)
 @interface iTermMetalFrameData : NSObject
 @property (atomic, readonly) iTermTexturePool *fullSizeTexturePool;
 @property (atomic, strong, nullable) id<iTermMetalDriverDataSourcePerFrameState> perFrameState;
@@ -166,7 +165,7 @@ NS_CLASS_AVAILABLE(10_11, NA)
 @property (nonatomic) BOOL deferCurrentDrawable;
 // Helper to acquire drawable from any thread and validate context before presentation.
 @property (nonatomic, strong, nullable) iTermDrawableAcquisitionHelper *drawableAcquisitionHelper;
-@property (nonatomic, strong, nullable) MTLCaptureDescriptor *captureDescriptor NS_AVAILABLE_MAC(10_15);
+@property (nonatomic, strong, nullable) MTLCaptureDescriptor *captureDescriptor;
 #if ENABLE_UNFAMILIAR_TEXTURE_WORKAROUND
 @property (nonatomic) BOOL textureIsFamiliar;
 #endif  // ENABLE_UNFAMILIAR_TEXTURE_WORKAROUND

--- a/sources/MetalRenderer/Infrastructure/iTermMetalRenderer.h
+++ b/sources/MetalRenderer/Infrastructure/iTermMetalRenderer.h
@@ -18,7 +18,6 @@ extern const NSInteger iTermMetalDriverMaximumNumberOfFramesInFlight;
 @class iTermImageWrapper;
 @class iTermMetalRendererTransientState;
 
-NS_CLASS_AVAILABLE(10_11, NA)
 @interface iTermRenderConfiguration : NSObject
 @property (nonatomic, readonly) vector_uint2 viewportSize;
 @property (nonatomic, readonly) vector_uint2 viewportSizeExcludingLegacyScrollbars;
@@ -47,7 +46,6 @@ maximumExtendedDynamicRangeColorComponentValue:(CGFloat)maximumExtendedDynamicRa
               panelReservationPixels:(CGFloat)panelReservationPixels NS_DESIGNATED_INITIALIZER;
 @end
 
-NS_CLASS_AVAILABLE(10_11, NA)
 @protocol iTermMetalRenderer<NSObject>
 @property (nonatomic, readonly) BOOL rendererDisabled;
 
@@ -60,7 +58,6 @@ NS_CLASS_AVAILABLE(10_11, NA)
 
 @end
 
-NS_CLASS_AVAILABLE(10_11, NA)
 @interface iTermMetalRendererTransientState : NSObject
 @property (nonatomic, strong, readonly) __kindof iTermRenderConfiguration *configuration;
 @property (nonatomic, strong) id<MTLBuffer> vertexBuffer;
@@ -94,7 +91,6 @@ NS_CLASS_AVAILABLE(10_11, NA)
 
 @class iTermMetalBufferPoolContext;
 
-NS_CLASS_AVAILABLE(10_11, NA)
 @interface iTermMetalBlending : NSObject
 @property (nonatomic) MTLBlendOperation rgbBlendOperation;
 @property (nonatomic) MTLBlendOperation alphaBlendOperation;
@@ -114,7 +110,6 @@ NS_CLASS_AVAILABLE(10_11, NA)
 
 @end
 
-NS_CLASS_AVAILABLE(10_11, NA)
 @interface iTermMetalRenderer : NSObject <iTermMetalDebugInfoFormatter>
 
 @property (nonatomic, readonly) id<MTLDevice> device;

--- a/sources/MetalRenderer/Infrastructure/iTermMetalRowData.h
+++ b/sources/MetalRenderer/Infrastructure/iTermMetalRowData.h
@@ -16,7 +16,6 @@
 @class iTermKittyImageRun;
 @class iTermMetalImageRun;
 
-NS_CLASS_AVAILABLE(10_11, NA)
 @interface iTermMetalRowData : NSObject
 @property (nonatomic) int y;  // 0 = top of screen
 @property (nonatomic) long long absLine;

--- a/sources/MetalRenderer/Infrastructure/iTermTexture.h
+++ b/sources/MetalRenderer/Infrastructure/iTermTexture.h
@@ -8,7 +8,6 @@
 #import <Foundation/Foundation.h>
 #import <MetalKit/MetalKit.h>
 
-NS_CLASS_AVAILABLE(10_11, NA)
 @interface iTermTexture : NSObject
 
 + (void)setBytesPerRow:(int)bytesPerRow

--- a/sources/MetalRenderer/Infrastructure/iTermTextureArray.h
+++ b/sources/MetalRenderer/Infrastructure/iTermTextureArray.h
@@ -3,7 +3,6 @@
 #import "iTermCharacterBitmap.h"
 #import "iTermCharacterParts.h"
 
-NS_CLASS_AVAILABLE(10_11, NA)
 @interface iTermTextureArray : NSObject {
 @public
     uint32_t _width;
@@ -41,7 +40,6 @@ NS_CLASS_AVAILABLE(10_11, NA)
 
 @end
 
-NS_CLASS_AVAILABLE(10_11, NA)
 NS_INLINE MTLOrigin iTermTextureArrayOffsetForIndex(iTermTextureArray *self, const NSInteger index) {
     return MTLOriginMake(self->_width * (index % self->_cellsPerRow),
                          self->_height * (index / self->_cellsPerRow),

--- a/sources/MetalRenderer/Infrastructure/iTermTexturePool.h
+++ b/sources/MetalRenderer/Infrastructure/iTermTexturePool.h
@@ -12,7 +12,6 @@
 NS_ASSUME_NONNULL_BEGIN
 
 // Pools textures of a particular size.
-NS_CLASS_AVAILABLE(10_11, NA)
 @interface iTermTexturePool : NSObject
 - (nullable id<MTLTexture>)requestTextureOfSize:(vector_uint2)size;
 - (void)returnTexture:(id<MTLTexture>)texture;
@@ -21,7 +20,6 @@ NS_CLASS_AVAILABLE(10_11, NA)
 
 // Store this wrapper object in your renderer's transient state. It returns its texture to the
 // pool on dealloc.
-NS_CLASS_AVAILABLE(10_11, NA)
 @interface iTermPooledTexture : NSObject
 
 @property (nonatomic, strong, readonly) id<MTLTexture> texture;

--- a/sources/MetalRenderer/Renderers/iTermBackgroundColorRenderer.mm
+++ b/sources/MetalRenderer/Renderers/iTermBackgroundColorRenderer.mm
@@ -55,12 +55,12 @@
 
 @implementation iTermBackgroundColorRenderer {
     iTermMetalCellRenderer *_blendingRenderer;
-    iTermMetalCellRenderer *_nonblendingRenderer NS_AVAILABLE_MAC(10_14);
+    iTermMetalCellRenderer *_nonblendingRenderer;
     iTermMetalBufferPool *_infoPool;
     iTermMetalBufferPool *_suppressedRegionVertexBufferPool;
 
 #if ENABLE_TRANSPARENT_METAL_WINDOWS
-    iTermMetalCellRenderer *_compositeOverRenderer NS_AVAILABLE_MAC(10_14);
+    iTermMetalCellRenderer *_compositeOverRenderer;
 #endif
     iTermMetalMixedSizeBufferPool *_piuPool;
 }

--- a/sources/MetalRenderer/Renderers/iTermFullScreenFlashRenderer.h
+++ b/sources/MetalRenderer/Renderers/iTermFullScreenFlashRenderer.h
@@ -10,12 +10,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-NS_CLASS_AVAILABLE(10_11, NA)
 @interface iTermFullScreenFlashRendererTransientState : iTermMetalRendererTransientState
 @property (nonatomic) vector_float4 color;
 @end
 
-NS_CLASS_AVAILABLE(10_11, NA)
 @interface iTermFullScreenFlashRenderer : NSObject<iTermMetalRenderer>
 - (nullable instancetype)initWithDevice:(id<MTLDevice>)device NS_DESIGNATED_INITIALIZER;
 - (instancetype)init NS_UNAVAILABLE;

--- a/sources/MetalRenderer/Renderers/iTermImageRenderer.h
+++ b/sources/MetalRenderer/Renderers/iTermImageRenderer.h
@@ -8,7 +8,6 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol iTermImageInfoReading;
 
 // Describes a horizontal run of image cells for the same image.
-NS_CLASS_AVAILABLE(10_11, NA)
 @interface iTermMetalImageRun : NSObject
 @property (nonatomic) VT100GridCoord startingCoordInImage;
 @property (nonatomic) VT100GridCoord startingCoordOnScreen;
@@ -18,7 +17,6 @@ NS_CLASS_AVAILABLE(10_11, NA)
 @end
 
 
-NS_CLASS_AVAILABLE(10_11, NA)
 @interface iTermImageRendererTransientState : iTermMetalCellRendererTransientState
 
 @property (nonatomic, readonly) NSSet<NSString *> *missingImageUniqueIdentifiers;
@@ -32,7 +30,6 @@ NS_CLASS_AVAILABLE(10_11, NA)
 
 @end
 
-NS_CLASS_AVAILABLE(10_11, NA)
 @interface iTermImageRenderer : NSObject<iTermMetalCellRenderer>
 
 - (instancetype)initWithDevice:(id<MTLDevice>)device NS_DESIGNATED_INITIALIZER;

--- a/sources/MetalRenderer/Renderers/iTermIndicatorRenderer.h
+++ b/sources/MetalRenderer/Renderers/iTermIndicatorRenderer.h
@@ -18,11 +18,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) BOOL dark;
 @end
 
-NS_CLASS_AVAILABLE(10_11, NA)
 @interface iTermIndicatorRendererTransientState : iTermMetalRendererTransientState
 @end
 
-NS_CLASS_AVAILABLE(10_11, NA)
 @interface iTermIndicatorRenderer : NSObject<iTermMetalRenderer>
 
 - (nullable instancetype)initWithDevice:(id<MTLDevice>)device NS_DESIGNATED_INITIALIZER;

--- a/sources/MetalRenderer/Renderers/iTermMarkRenderer.h
+++ b/sources/MetalRenderer/Renderers/iTermMarkRenderer.h
@@ -16,7 +16,6 @@ typedef NS_ENUM(int, iTermMarkStyle) {
 
 NS_ASSUME_NONNULL_BEGIN
 
-NS_CLASS_AVAILABLE(10_11, NA)
 @interface iTermMarkRendererTransientState : iTermMetalCellRendererTransientState
 - (void)setMarkStyle:(iTermMarkStyle)markStyle row:(int)row;
 @end

--- a/sources/MetalRenderer/Renderers/iTermTextRenderer.h
+++ b/sources/MetalRenderer/Renderers/iTermTextRenderer.h
@@ -5,7 +5,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-NS_CLASS_AVAILABLE(10_11, NA)
 @interface iTermTextRenderer : NSObject<iTermMetalCellRenderer>
 @property (nonatomic, readonly) CGSize asciiOffset;
 

--- a/sources/MetalRenderer/Renderers/iTermTextRendererTransientState.h
+++ b/sources/MetalRenderer/Renderers/iTermTextRendererTransientState.h
@@ -15,7 +15,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class iTermCharacterBitmap;
 
-NS_CLASS_AVAILABLE(10_11, NA)
 @interface iTermTextRendererTransientState : iTermMetalCellRendererTransientState
 @property (nonatomic, strong) NSMutableData *modelData;
 @property (nonatomic, strong) id<MTLTexture> backgroundTexture;

--- a/sources/MetalRenderer/iTermMetalDriver.h
+++ b/sources/MetalRenderer/iTermMetalDriver.h
@@ -22,7 +22,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-NS_CLASS_AVAILABLE(10_11, NA)
 @interface iTermMetalCursorInfo : NSObject
 @property (nonatomic) BOOL cursorVisible;
 @property (nonatomic) VT100GridCoord coord;
@@ -63,7 +62,6 @@ NS_CLASS_AVAILABLE(10_11, NA)
 
 @end
 
-NS_CLASS_AVAILABLE(10_11, NA)
 @protocol iTermMetalDriverDataSourcePerFrameState<NSObject>
 @property (nonatomic, readonly) NSRect adjustedDocumentVisibleRect;
 @property (nonatomic, readonly) VT100GridSize gridSize;
@@ -182,7 +180,6 @@ NS_CLASS_AVAILABLE(10_11, NA)
 
 @end
 
-NS_CLASS_AVAILABLE(10_11, NA)
 @protocol iTermMetalDriverDataSource<NSObject>
 
 - (BOOL)metalDriverShouldDrawFrame;
@@ -199,7 +196,6 @@ NS_CLASS_AVAILABLE(10_11, NA)
 @end
 
 // Our platform independent render class
-NS_CLASS_AVAILABLE(10_11, NA)
 @interface iTermMetalDriver : NSObject<iTermMetalViewDelegate>
 
 @property (nullable, nonatomic, weak) id<iTermMetalDriverDataSource> dataSource;

--- a/sources/MetalRenderer/iTermMetalDriver.m
+++ b/sources/MetalRenderer/iTermMetalDriver.m
@@ -90,7 +90,7 @@ typedef struct {
 #if ENABLE_UNFAMILIAR_TEXTURE_WORKAROUND
     NSInteger unfamiliarTextureCount;
 #endif
-    CGFloat maximumExtendedDynamicRangeColorComponentValue NS_AVAILABLE_MAC(10_15);
+    CGFloat maximumExtendedDynamicRangeColorComponentValue;
     CGFloat legacyScrollbarWidth;
     CGFloat rightExtraPixels;
     CGFloat panelReservationPixels;
@@ -488,7 +488,7 @@ panelReservationPoints:(CGFloat)panelReservationPoints {
     });
 }
 
-- (MTLCaptureDescriptor *)triggerProgrammaticCapture:(id<MTLDevice>)device NS_AVAILABLE_MAC(10_15) {
+- (MTLCaptureDescriptor *)triggerProgrammaticCapture:(id<MTLDevice>)device {
     MTLCaptureManager* captureManager = [MTLCaptureManager sharedCaptureManager];
     MTLCaptureDescriptor* captureDescriptor = [[MTLCaptureDescriptor alloc] init];
     NSString *filename = [NSString stringWithFormat:@"/tmp/%@.gputrace", [[NSUUID UUID] UUIDString]];
@@ -517,9 +517,7 @@ panelReservationPoints:(CGFloat)panelReservationPoints {
         [self scheduleDrawIfNeededInView:view];
         return NO;
     }
-    if (@available(macOS 10.15, *)) {
-        self.mainThreadState->maximumExtendedDynamicRangeColorComponentValue = view.window.screen.maximumPotentialExtendedDynamicRangeColorComponentValue;
-    }
+    self.mainThreadState->maximumExtendedDynamicRangeColorComponentValue = view.window.screen.maximumPotentialExtendedDynamicRangeColorComponentValue;
 
 #if ENABLE_FLAKY_METAL
 #warning DO NOT SUBMIT - FLAKY MODE ENABLED
@@ -568,9 +566,7 @@ panelReservationPoints:(CGFloat)panelReservationPoints {
 
     if (self.captureDebugInfoForNextFrame) {
         frameData.debugInfo = [[iTermMetalDebugInfo alloc] init];
-        if (@available(macOS 10.15, *)) {
-            frameData.captureDescriptor = [self triggerProgrammaticCapture:frameData.device];
-        }
+        frameData.captureDescriptor = [self triggerProgrammaticCapture:frameData.device];
         self.captureDebugInfoForNextFrame = NO;
     }
     if (_total > 1) {
@@ -670,9 +666,7 @@ panelReservationPoints:(CGFloat)panelReservationPoints {
                                                   pointInsets.bottom * scale,
                                                   pointInsets.right * scale);
         frameData.vmargin = [iTermPreferences topBottomMargins];
-        if (@available(macOS 10.15, *)) {
-            frameData.maximumExtendedDynamicRangeColorComponentValue = self.mainThreadState->maximumExtendedDynamicRangeColorComponentValue;
-        }
+        frameData.maximumExtendedDynamicRangeColorComponentValue = self.mainThreadState->maximumExtendedDynamicRangeColorComponentValue;
     }];
     return frameData;
 }
@@ -2598,12 +2592,10 @@ extraIdentifyingInfoForIcon:button.extraIdentifyingInfoForIcon];
         DLog(@"first time completed %@", frameData);
         if (frameData.debugInfo) {
             DLog(@"have debug info %@", frameData);
-            if (@available(macOS 10.15, *)) {
-                if (frameData.captureDescriptor) {
-                    MTLCaptureManager* captureManager = [MTLCaptureManager sharedCaptureManager];
-                    [captureManager stopCapture];
-                    [frameData.debugInfo addMetalCapture:frameData.captureDescriptor.outputURL];
-                }
+            if (frameData.captureDescriptor) {
+                MTLCaptureManager* captureManager = [MTLCaptureManager sharedCaptureManager];
+                [captureManager stopCapture];
+                [frameData.debugInfo addMetalCapture:frameData.captureDescriptor.outputURL];
             }
             NSData *archive = [frameData.debugInfo newArchive];
             dispatch_async(dispatch_get_main_queue(), ^{

--- a/sources/PTYSession/PTYSession.h
+++ b/sources/PTYSession/PTYSession.h
@@ -1254,8 +1254,8 @@ webViewConfiguration:(nullable WKWebViewConfiguration *)webViewConfiguration
 
 - (void)jumpToLocationWhereCurrentStatusChanged;
 - (void)updateMetalDriver;
-- (id)temporarilyDisableMetal NS_AVAILABLE_MAC(10_11);
-- (void)drawFrameAndRemoveTemporarilyDisablementOfMetalForToken:(nullable id)token NS_AVAILABLE_MAC(10_11);
+- (id)temporarilyDisableMetal;
+- (void)drawFrameAndRemoveTemporarilyDisablementOfMetalForToken:(nullable id)token;
 
 - (BOOL)willEnableMetal;
 - (BOOL)metalAllowed:(out nullable iTermMetalUnavailableReason *)reason;

--- a/sources/PTYSession/PTYSession.m
+++ b/sources/PTYSession/PTYSession.m
@@ -625,7 +625,7 @@ typedef NS_ENUM(NSUInteger, PTYSessionTurdType) {
 
     iTermUpdateCadenceController *_cadenceController;
 
-    iTermMetalGlue *_metalGlue NS_AVAILABLE_MAC(10_11);
+    iTermMetalGlue *_metalGlue;
 
     int _updateCount;
     BOOL _metalFrameChangePending;
@@ -1108,9 +1108,7 @@ ITERM_WEAKLY_REFERENCEABLE
     }
     [_view release];
     [_logging stop];
-    if (@available(macOS 10.11, *)) {
-        [_metalGlue release];
-    }
+    [_metalGlue release];
     [_nameController release];
     [_tailFindController stopTailFind];  // This frees the substring in the tail find context, if needed.
     _shell.delegate = nil;
@@ -6382,10 +6380,7 @@ webViewConfiguration:(WKWebViewConfiguration *)webViewConfiguration
         _customIcon = [[iTermCacheableImage alloc] init];
     }
     NSString *path = [iTermProfilePreferences stringForKey:KEY_ICON_PATH inProfile:profile];
-    BOOL flipped = YES;
-    if (@available(macOS 10.15, *)) {
-        flipped = NO;
-    }
+    BOOL flipped = NO;
     return [_customIcon imageAtPath:path ofSize:NSMakeSize(16, 16) flipped:flipped];
 }
 
@@ -8850,7 +8845,7 @@ extendResultsAcrossSoftBoundaries:(BOOL)extendResultsAcrossSoftBoundaries {
     return [self effectiveBlend];
 }
 
-- (void)metalGlueDidDrawFrameAndNeedsRedraw:(BOOL)redrawAsap NS_AVAILABLE_MAC(10_11) {
+- (void)metalGlueDidDrawFrameAndNeedsRedraw:(BOOL)redrawAsap {
     if (_view.useMetal) {
         if (redrawAsap) {
             [_textview requestDelegateRedraw];
@@ -9109,7 +9104,7 @@ extendResultsAcrossSoftBoundaries:(BOOL)extendResultsAcrossSoftBoundaries {
     return _useMetal && _view.metalView.alphaValue == 1 && _wrapper.useMetal && _textview.suppressDrawing;
 }
 
-- (BOOL)metalViewSizeIsLegal NS_AVAILABLE_MAC(10_11) {
+- (BOOL)metalViewSizeIsLegal {
     NSSize size = _view.frame.size;
     // See "Maximum 2D texture width and height" in "Implementation Limits". Pick the smallest value
     // among the "Mac" columns.
@@ -9176,7 +9171,7 @@ extendResultsAcrossSoftBoundaries:(BOOL)extendResultsAcrossSoftBoundaries {
     }
 }
 
-- (void)renderTwoMetalFramesAndShowMetalView NS_AVAILABLE_MAC(10_11) {
+- (void)renderTwoMetalFramesAndShowMetalView {
     // The first frame will be slow to draw. The second frame will be very
     // recent to minimize jitter. For reasons I haven't understood yet it seems
     // the first frame is sometimes transparent. I haven't seen that issue with
@@ -9244,7 +9239,7 @@ extendResultsAcrossSoftBoundaries:(BOOL)extendResultsAcrossSoftBoundaries {
     _view.metalView.enableSetNeedsDisplay = YES;
 }
 
-- (void)showMetalAndStopDrawingTextView NS_AVAILABLE_MAC(10_11) {
+- (void)showMetalAndStopDrawingTextView {
     // If the legacy view had been visible, hide it. Hiding it before the
     // first frame is drawn causes a flash of gray.
     DLog(@"showMetalAndStopDrawingTextView");
@@ -9273,7 +9268,7 @@ extendResultsAcrossSoftBoundaries:(BOOL)extendResultsAcrossSoftBoundaries {
     [self.delegate sessionDidChangeMetalViewAlphaValue:self to:alphaValue];
 }
 
-- (void)setUseMetal:(BOOL)useMetal dataSource:(id<iTermMetalDriverDataSource>)dataSource NS_AVAILABLE_MAC(10_11) {
+- (void)setUseMetal:(BOOL)useMetal dataSource:(id<iTermMetalDriverDataSource>)dataSource {
     [_view setUseMetal:useMetal dataSource:dataSource];
     if (!useMetal) {
         _textview.suppressDrawing = NO;
@@ -9286,7 +9281,7 @@ extendResultsAcrossSoftBoundaries:(BOOL)extendResultsAcrossSoftBoundaries {
     }
 }
 
-- (void)updateMetalDriver NS_AVAILABLE_MAC(10_11) {
+- (void)updateMetalDriver {
     DLog(@"%@", self);
     const CGSize cellSize = CGSizeMake(_textview.charWidth, _textview.lineHeight);
     CGSize glyphSize;
@@ -21324,7 +21319,7 @@ static const NSTimeInterval PTYSessionFocusReportBellSquelchTimeIntervalThreshol
     [self.delegate sessionUpdateMetalAllowed];
 }
 
-- (id)temporarilyDisableMetal NS_AVAILABLE_MAC(10_11) {
+- (id)temporarilyDisableMetal {
     assert(_useMetal);
     _wrapper.useMetal = NO;
     _textview.suppressDrawing = NO;
@@ -21341,7 +21336,7 @@ static const NSTimeInterval PTYSessionFocusReportBellSquelchTimeIntervalThreshol
     return token;
 }
 
-- (void)drawFrameAndRemoveTemporarilyDisablementOfMetalForToken:(id)token NS_AVAILABLE_MAC(10_11) {
+- (void)drawFrameAndRemoveTemporarilyDisablementOfMetalForToken:(id)token {
     DLog(@"drawFrameAndRemoveTemporarilyDisablementOfMetal %@", token);
     if (!_useMetal) {
         DLog(@"drawFrameAndRemoveTemporarilyDisablementOfMetal returning early because useMetal is off");

--- a/sources/Pasting/PasteView.m
+++ b/sources/Pasting/PasteView.m
@@ -37,7 +37,7 @@
 @end
 
 @implementation MinimalPasteView {
-    NSVisualEffectView *_vev NS_AVAILABLE_MAC(10_14);
+    NSVisualEffectView *_vev;
 }
 
 - (void)awakeFromNib {

--- a/sources/ProcessInfo/iTermLSOF.m
+++ b/sources/ProcessInfo/iTermLSOF.m
@@ -653,15 +653,10 @@ static NSString *iTermSocketEndpointString(const struct in_sockinfo *in, BOOL lo
             block(nil);
             return;
         }
-        if (@available(macOS 10.15, *)) {
-            NSString *dir = [[iTermSyntheticConfParser sharedInstance] pathByReplacingPrefixWithSyntheticRoot:rawDir];
-            DLog(@"Result: %@ -> %@", rawDir, dir);
-            block(dir);
-            return;
-        }
-        // pre-10.15 code path - no synthetics existed
-        DLog(@"Result: %@", rawDir);
-        block(rawDir);
+        NSString *dir = [[iTermSyntheticConfParser sharedInstance] pathByReplacingPrefixWithSyntheticRoot:rawDir];
+        DLog(@"Result: %@ -> %@", rawDir, dir);
+        block(dir);
+        return;
     }];
 }
 

--- a/sources/ProcessInfo/iTermSyntheticConfParser.m
+++ b/sources/ProcessInfo/iTermSyntheticConfParser.m
@@ -63,20 +63,16 @@ static NSString *iTermSyntheticDirectoryStringByPrependingSlashIfNotPresent(NSSt
 }
 
 + (NSString *)contents {
-    if (@available(macOS 10.15, *)) {
-        NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSFileManager *fileManager = [NSFileManager defaultManager];
 
-        if (![fileManager fileExistsAtPath:@"/etc/synthetic.conf"]) {
-            return @"";
-        }
-
-        NSString *contents = [NSString stringWithContentsOfFile:@"/etc/synthetic.conf"
-                                                       encoding:NSUTF8StringEncoding
-                                                          error:nil];
-        return contents;
+    if (![fileManager fileExistsAtPath:@"/etc/synthetic.conf"]) {
+        return @"";
     }
 
-    return @"";
+    NSString *contents = [NSString stringWithContentsOfFile:@"/etc/synthetic.conf"
+                                                   encoding:NSUTF8StringEncoding
+                                                      error:nil];
+    return contents;
 }
 
 + (void)enumerateLinesInContent:(NSString *)contents block:(void (^)(NSString *))block {

--- a/sources/SearchingFiltering/FindView.m
+++ b/sources/SearchingFiltering/FindView.m
@@ -69,7 +69,7 @@
 @end
 
 @implementation MinimalFindView {
-    NSVisualEffectView *_vev NS_AVAILABLE_MAC(10_14);
+    NSVisualEffectView *_vev;
 }
 
 - (void)awakeFromNib {

--- a/sources/SearchingFiltering/iTermFindOnPageHelper.m
+++ b/sources/SearchingFiltering/iTermFindOnPageHelper.m
@@ -81,9 +81,9 @@ typedef struct {
 
     iTermFindOnPageCachedCounts _cachedCounts;
 
-    NSMutableIndexSet *_locations NS_AVAILABLE_MAC(10_14);
+    NSMutableIndexSet *_locations;
 
-    BOOL _locationsHaveChanged NS_AVAILABLE_MAC(10_14);
+    BOOL _locationsHaveChanged;
 }
 
 - (instancetype)init {
@@ -96,7 +96,7 @@ typedef struct {
     return self;
 }
 
-- (void)locationsDidChange NS_AVAILABLE_MAC(10_14) {
+- (void)locationsDidChange {
     if (_locationsHaveChanged) {
         return;
     }
@@ -794,11 +794,11 @@ extendResultsAcrossSoftBoundaries:(BOOL)extendResultsAcrossSoftBoundaries {
 
 #pragma mark - iTermSearchResultsMinimapViewDelegate
 
-- (NSIndexSet *)searchResultsMinimapViewLocations:(iTermSearchResultsMinimapView *)view NS_AVAILABLE_MAC(10_14) {
+- (NSIndexSet *)searchResultsMinimapViewLocations:(iTermSearchResultsMinimapView *)view {
     return _locations;
 }
 
-- (NSRange)searchResultsMinimapViewRangeOfVisibleLines:(iTermSearchResultsMinimapView *)view NS_AVAILABLE_MAC(10_14) {
+- (NSRange)searchResultsMinimapViewRangeOfVisibleLines:(iTermSearchResultsMinimapView *)view {
     return [_delegate findOnPageRangeOfVisibleLines];
 }
 

--- a/sources/Settings/ProfilesWindowPreferencesViewController.m
+++ b/sources/Settings/ProfilesWindowPreferencesViewController.m
@@ -747,12 +747,10 @@ typedef NS_ENUM(NSUInteger, iTermWindowUnitsTag) {
 }
 
 - (void)updateBlurRadiusWarning {
-    if (@available(macOS 10.15, *)) {
-        // It seems to get slow around this point on some machines circa 2017.
-        if ([self boolForKey:KEY_BLUR] && [self floatForKey:KEY_BLUR_RADIUS] > 26) {
-            _largeBlurRadiusWarning.hidden = NO;
-            return;
-        }
+    // It seems to get slow around this point on some machines circa 2017.
+    if ([self boolForKey:KEY_BLUR] && [self floatForKey:KEY_BLUR_RADIUS] > 26) {
+        _largeBlurRadiusWarning.hidden = NO;
+        return;
     }
     _largeBlurRadiusWarning.hidden = YES;
 }

--- a/sources/Settings/iTermAdvancedSettingsModel.m
+++ b/sources/Settings/iTermAdvancedSettingsModel.m
@@ -258,10 +258,7 @@ DEFINE_SETTABLE_BOILERPLATE(name, capitalizedName, NSString *, kiTermAdvancedSet
 #pragma mark - Custom Defaults
 
 BOOL UseSystemCursorWhenPossibleDefault(void) {
-    if (@available(macOS 10.15, *)) {
-        return YES;
-    }
-    return NO;
+    return YES;
 }
 
 #pragma mark - iTermAdvancedSettingsModel

--- a/sources/SlowOperationXPC/CPUGovernor.swift
+++ b/sources/SlowOperationXPC/CPUGovernor.swift
@@ -67,8 +67,7 @@ private class AtomicFlag {
         if value <= 0 {
             return
         }
-        // When 10.14 support is dropped we can use DispatchTime.advanced(by:)
-        _gracePeriodEndTime = DispatchTime(uptimeNanoseconds: DispatchTime.now().uptimeNanoseconds + UInt64(value) * NSEC_PER_SEC)
+        _gracePeriodEndTime = DispatchTime.now() + value
     }
 
     @objc public func incr() -> Int {

--- a/sources/StatusBar/Setup/iTermStatusBarSetupViewController.h
+++ b/sources/StatusBar/Setup/iTermStatusBarSetupViewController.h
@@ -10,7 +10,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-NS_CLASS_AVAILABLE(10_11, NA)
 @interface iTermStatusBarSetupViewController : NSViewController
 @property (nonatomic, readonly) NSDictionary *layoutDictionary;
 @property (nonatomic, readonly) BOOL ok;

--- a/sources/StatusBar/iTermGenericStatusBarContainer.m
+++ b/sources/StatusBar/iTermGenericStatusBarContainer.m
@@ -19,7 +19,7 @@
 @end
 
 @implementation iTermGenericStatusBarContainer {
-    iTermStatusBarBacking *_backing NS_AVAILABLE_MAC(10_14);
+    iTermStatusBarBacking *_backing;
 }
 
 @synthesize statusBarViewController = _statusBarViewController;

--- a/sources/StatusWindowsViews/iTermUnobtrusiveMessage.h
+++ b/sources/StatusWindowsViews/iTermUnobtrusiveMessage.h
@@ -9,7 +9,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-NS_CLASS_AVAILABLE_MAC(10_14)
 @interface iTermUnobtrusiveMessage : NSView
 @property (nonatomic) NSTimeInterval duration;
 

--- a/sources/StatusWindowsViews/iTermUnobtrusiveMessage.m
+++ b/sources/StatusWindowsViews/iTermUnobtrusiveMessage.m
@@ -9,7 +9,6 @@
 #import "NSTextField+iTerm.h"
 #import "NSView+iTerm.h"
 
-NS_CLASS_AVAILABLE_MAC(10_14)
 @implementation iTermUnobtrusiveMessage {
     NSVisualEffectView *_vev;
     NSTextField *_textField;

--- a/sources/StatusWindowsViews/iTermWindowSizeView.h
+++ b/sources/StatusWindowsViews/iTermWindowSizeView.h
@@ -10,7 +10,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-NS_CLASS_AVAILABLE_MAC(10_14)
 @interface iTermWindowSizeView : NSView
 @property (nullable, nonatomic, readonly) NSString *detail;
 

--- a/sources/Tasks/iTermFileDescriptorMultiClient.m
+++ b/sources/Tasks/iTermFileDescriptorMultiClient.m
@@ -968,10 +968,8 @@ static NSString *iTermMultiServerStringForMessageFromClient(iTermMultiServerClie
 #pragma mark - Janitorial
 
 - (void)deleteDisusedServerBinaries {
-    if (@available(macOS 10.15, *)) {
-        [iTermServerDeleter deleteDisusedServersIn:[self serverFolders]
-                                          provider:[iTermProcessCache newProcessCollection]];
-    }
+    [iTermServerDeleter deleteDisusedServersIn:[self serverFolders]
+                                      provider:[iTermProcessCache newProcessCollection]];
 }
 
 #pragma mark - Tear Down

--- a/sources/Tasks/iTermServerDeleter.swift
+++ b/sources/Tasks/iTermServerDeleter.swift
@@ -18,7 +18,6 @@ class iTermServerName: NSObject {
 }
 
 @objc
-@available(macOS 10.15, *)
 class iTermServerDeleter: NSObject {
     static var started = false
     @objc static func deleteDisusedServers(in folders: [String],

--- a/sources/TerminalView/PTYScrollView.h
+++ b/sources/TerminalView/PTYScrollView.h
@@ -38,7 +38,7 @@ typedef NS_ENUM(NSUInteger, PTYScrollerState) {
 
 @protocol PTYScrollerDelegate<NSObject>
 - (void)userScrollDidChange:(BOOL)userScroll;
-- (NSScrollView *)ptyScrollerScrollView NS_AVAILABLE_MAC(10_14);
+- (NSScrollView *)ptyScrollerScrollView;
 - (void)ptyScrollerDidTransitionToState:(PTYScrollerState)state;
 - (void)ptyScrollerFrameDidChange;
 @end
@@ -53,7 +53,7 @@ typedef NS_ENUM(NSUInteger, PTYScrollerState) {
 
 @interface PTYScrollView : NSScrollView
 
-+ (BOOL)shouldDismember NS_AVAILABLE_MAC(10_14);
++ (BOOL)shouldDismember;
 
 // More specific type for the base class's method.
 - (PTYScroller *)ptyVerticalScroller;

--- a/sources/TerminalView/PTYScrollView.m
+++ b/sources/TerminalView/PTYScrollView.m
@@ -84,7 +84,7 @@
 }
 
 // rdar://45295749/
-- (void)dismemberForScrollerStyle:(NSScrollerStyle)scrollerStyle NS_AVAILABLE_MAC(10_14) {
+- (void)dismemberForScrollerStyle:(NSScrollerStyle)scrollerStyle {
     DLog(@"Begin dismembering the scroll bar");
     NSView *reparent = nil;
     NSInteger index = NSNotFound;
@@ -204,7 +204,7 @@
     NSScroller *_scroller;
 }
 
-+ (BOOL)shouldDismember NS_AVAILABLE_MAC(10_14) {
++ (BOOL)shouldDismember {
     return [iTermAdvancedSettingsModel dismemberScrollView];
 }
 

--- a/sources/TerminalView/PTYTab.h
+++ b/sources/TerminalView/PTYTab.h
@@ -351,7 +351,7 @@ extern NSString *const PTYTabArrangementOptionsPendingJumps;
 - (NSString *)tmuxPerTabSetting;
 - (void)setPerTabSettings:(NSString *)setting;
 
-- (void)updateUseMetal NS_AVAILABLE_MAC(10_11);
+- (void)updateUseMetal;
 - (ITMSplitTreeNode *)rootSplitTreeNode;
 
 - (void)setSizesFromSplitTreeNode:(ITMSplitTreeNode *)node;

--- a/sources/TerminalView/PTYTab.m
+++ b/sources/TerminalView/PTYTab.m
@@ -7059,7 +7059,7 @@ typedef struct {
 }
 
 // Note this is a notification handler
-- (void)updateUseMetal NS_AVAILABLE_MAC(10_11) {
+- (void)updateUseMetal {
     DLog(@"begin");
     const BOOL resizing = self.realParentWindow.windowIsResizing;
     const BOOL powerOK = [[iTermPowerManager sharedInstance] metalAllowed];

--- a/sources/TerminalView/PTYTextView+Private.h
+++ b/sources/TerminalView/PTYTextView+Private.h
@@ -62,7 +62,7 @@ NSPopoverDelegate> {
 @property(nonatomic, strong) iTermFindCursorView *findCursorView;
 @property(nonatomic, strong) NSWindow *findCursorWindow;  // For find-cursor animation
 @property(nonatomic, strong) iTermQuickLookController *quickLookController;
-@property(strong, readwrite) NSTouchBar *touchBar NS_AVAILABLE_MAC(10_12_2);
+@property(strong, readwrite) NSTouchBar *touchBar;
 @property(nonatomic, readonly) BOOL hasUnderline;
 @property(nonatomic, strong) id<iTermCancelable> lastUrlActionCanceler;
 @property(nonatomic, readonly, strong) NSMutableArray<id<Porthole>> *portholes;

--- a/sources/TerminalView/PTYTextView.m
+++ b/sources/TerminalView/PTYTextView.m
@@ -2014,17 +2014,15 @@ static NSString *iTermStringForEventPhase(NSEventPhase eventPhase) {
     DLog(@"Set suppressDrawing to %@ from %@", @(suppressDrawing), [NSThread callStackSymbols]);
     _suppressDrawing = suppressDrawing;
     if (PTYTextView.useLayerForBetterPerformance) {
-        if (@available(macOS 10.15, *)) {} {
-            // Using a layer in a view inside a scrollview is a disaster, per macOS
-            // tradition (insane drawing artifacts, especially when scrolling). But
-            // not using a layer makes it godawful slow (see note about
-            // rdar://45295749). So use a layer when the view is hidden, and
-            // remove it when visible.
-            if (suppressDrawing) {
-                self.layer = [[[CALayer alloc] init] autorelease];
-            } else {
-                self.layer = nil;
-            }
+        // Using a layer in a view inside a scrollview is a disaster, per macOS
+        // tradition (insane drawing artifacts, especially when scrolling). But
+        // not using a layer makes it godawful slow (see note about
+        // rdar://45295749). So use a layer when the view is hidden, and
+        // remove it when visible.
+        if (suppressDrawing) {
+            self.layer = [[[CALayer alloc] init] autorelease];
+        } else {
+            self.layer = nil;
         }
     }
     PTYScrollView *scrollView = (PTYScrollView *)self.enclosingScrollView;

--- a/sources/TerminalView/PseudoTerminal.m
+++ b/sources/TerminalView/PseudoTerminal.m
@@ -371,7 +371,7 @@ typedef NS_ENUM(int, iTermShouldHaveTitleSeparator) {
     // the window's frame.
     BOOL hidingToolbeltShouldResizeWindowInitialized_;
 
-    iTermTabBarAccessoryViewController *_titleBarAccessoryTabBarViewController NS_AVAILABLE_MAC(10_14);
+    iTermTabBarAccessoryViewController *_titleBarAccessoryTabBarViewController;
 
     // Number of tabs since last change.
     NSInteger _previousNumberOfTabs;
@@ -5411,7 +5411,7 @@ hidingToolbeltShouldResizeWindow:(BOOL)hidingToolbeltShouldResizeWindow
     return [self tabBarInsetsForCompactWindow];
 }
 
-- (NSEdgeInsets)tabBarInsetsForCompactWindow NS_AVAILABLE_MAC(10_14) {
+- (NSEdgeInsets)tabBarInsetsForCompactWindow {
     CGFloat stoplightButtonsWidth = MAX(0, [iTermAdvancedSettingsModel compactTabBarStoplightButtonsWidth]);
     if (@available(macOS 26, *)) {
         stoplightButtonsWidth += 3;
@@ -6480,7 +6480,7 @@ hidingToolbeltShouldResizeWindow:(BOOL)hidingToolbeltShouldResizeWindow
     [self updateUseMetalInAllTabs];
 }
 
-- (NSTitlebarAccessoryViewController *)titleBarAccessoryTabBarViewController NS_AVAILABLE_MAC(10_14) {
+- (NSTitlebarAccessoryViewController *)titleBarAccessoryTabBarViewController {
     if (!_titleBarAccessoryTabBarViewController) {
         _titleBarAccessoryTabBarViewController = [[iTermTabBarAccessoryViewController alloc] initWithView:[_contentView borrowTabBarControl]];
         _titleBarAccessoryTabBarViewController.layoutAttribute = NSLayoutAttributeBottom;
@@ -8769,7 +8769,7 @@ hidingToolbeltShouldResizeWindow:(BOOL)hidingToolbeltShouldResizeWindow
     self.window.appearance = appearance;
 }
 
-- (void)setMojaveBackgroundColor:(nullable NSColor *)backgroundColor NS_AVAILABLE_MAC(10_14) {
+- (void)setMojaveBackgroundColor:(nullable NSColor *)backgroundColor {
     switch ((iTermPreferencesTabStyle)[iTermPreferences intForKey:kPreferenceKeyTabStyle]) {
         case TAB_STYLE_AUTOMATIC:
         case TAB_STYLE_COMPACT:
@@ -15223,7 +15223,7 @@ backgroundColor:(NSColor *)backgroundColor {
 
 - (void)setSharedBackgroundImage:(iTermImageWrapper *)image
                             mode:(iTermBackgroundImageMode)imageMode
-                 backgroundColor:(NSColor *)backgroundColor NS_AVAILABLE_MAC(10_14) {
+                 backgroundColor:(NSColor *)backgroundColor {
     RLog(@"setSharedBackgroundImage:%@", image);
     _contentView.backgroundImage.image = image;
     _contentView.backgroundImage.contentMode = imageMode;

--- a/sources/TerminalView/SessionView.h
+++ b/sources/TerminalView/SessionView.h
@@ -193,13 +193,13 @@ typedef NS_ENUM(NSUInteger, iTermSessionViewFindDriver) {
 @property(nonatomic, assign) int ordinal;
 @property(nonatomic, readonly, nullable) iTermAnnouncementViewController *currentAnnouncement;
 @property(nonatomic, weak, nullable) id<iTermSessionViewDelegate> delegate;
-@property(nonatomic, readonly, nullable) iTermSearchResultsMinimapView *searchResultsMinimap NS_AVAILABLE_MAC(10_14);
-@property(nonatomic, readonly, nullable) iTermIncrementalMinimapView *marksMinimap NS_AVAILABLE_MAC(10_14);
+@property(nonatomic, readonly, nullable) iTermSearchResultsMinimapView *searchResultsMinimap;
+@property(nonatomic, readonly, nullable) iTermIncrementalMinimapView *marksMinimap;
 @property(nonatomic, readonly) PTYScrollView *scrollview;
 @property(nonatomic, readonly, nullable) PTYScroller *verticalScroller;
-@property(nonatomic, readonly, nullable) iTermMetalDriver *driver NS_AVAILABLE_MAC(10_11);
-@property(nonatomic, readonly, nullable) iTermMTKView *metalView NS_AVAILABLE_MAC(10_11);
-@property(nonatomic, readonly) BOOL useMetal NS_AVAILABLE_MAC(10_11);
+@property(nonatomic, readonly, nullable) iTermMetalDriver *driver;
+@property(nonatomic, readonly, nullable) iTermMTKView *metalView;
+@property(nonatomic, readonly) BOOL useMetal;
 
 @property(nonatomic, readonly) BOOL isDropDownSearchVisible;
 @property(nonatomic, weak, nullable) id<iTermFindDriverDelegate> findDriverDelegate;
@@ -209,7 +209,7 @@ typedef NS_ENUM(NSUInteger, iTermSessionViewFindDriver) {
 @property(nonatomic, readonly, nullable) iTermFindDriver *findDriverCreatingIfNeeded;
 @property(nonatomic, readonly) NSSize internalDecorationSize;
 @property(nonatomic, readonly) iTermSessionViewFindDriver findDriverType;
-@property(nonatomic, weak, nullable) id<iTermSearchResultsMinimapViewDelegate> searchResultsMinimapViewDelegate NS_AVAILABLE_MAC(10_14);
+@property(nonatomic, weak, nullable) id<iTermSearchResultsMinimapViewDelegate> searchResultsMinimapViewDelegate;
 @property(nonatomic, strong, nullable) iTermImageWrapper *image;
 @property(nonatomic) iTermBackgroundImageMode imageMode;
 @property(nonatomic, readonly) BOOL statusBarIsInPaneTitleBar;
@@ -266,7 +266,7 @@ typedef NS_ENUM(NSUInteger, iTermSessionViewFindDriver) {
 
 - (void)findViewDidHide;
 - (void)findDriverInvalidateFrame;
-- (void)setUseMetal:(BOOL)useMetal dataSource:(id<iTermMetalDriverDataSource>)dataSource NS_AVAILABLE_MAC(10_11);;
+- (void)setUseMetal:(BOOL)useMetal dataSource:(id<iTermMetalDriverDataSource>)dataSource;;
 - (void)didChangeMetalViewAlpha;
 - (void)setTransparencyAlpha:(CGFloat)transparencyAlpha
                        blend:(CGFloat)blend;
@@ -355,7 +355,7 @@ typedef NS_ENUM(NSUInteger, iTermSessionViewFindDriver) {
 - (void)smearCursorFrom:(NSRect)from to:(NSRect)to color:(NSColor *)color;
 
 // Uses the Metal debug offscreen rendering path to capture a frame as an NSImage.
-- (nullable NSImage *)drawMetalFrameToImage NS_AVAILABLE_MAC(10_11);
+- (nullable NSImage *)drawMetalFrameToImage;
 
 // Session note
 - (void)showSessionNoteWithModel:(iTermSessionNoteModel *)model;

--- a/sources/TerminalView/SessionView.m
+++ b/sources/TerminalView/SessionView.m
@@ -67,7 +67,7 @@ NSString *const SessionViewWasSelectedForInspectionNotification = @"SessionViewW
 @end
 
 @implementation iTermHoverContainerView {
-    NSVisualEffectView *_vev NS_AVAILABLE_MAC(10_14);
+    NSVisualEffectView *_vev;
 }
 
 - (instancetype)initWithFrame:(NSRect)frame {
@@ -149,7 +149,7 @@ NSString *const SessionViewWasSelectedForInspectionNotification = @"SessionViewW
     iTermFindDriver *_permanentStatusBarFindDriver;
     iTermFindDriver *_temporaryStatusBarFindDriver;
     iTermGenericStatusBarContainer *_genericStatusBarContainer;
-    iTermImageView *_imageView NS_AVAILABLE_MAC(10_14);
+    iTermImageView *_imageView;
     NSColor *_terminalBackgroundColor;
 
     // For macOS 10.14+ when subpixel AA is turned on and the scroller style is legacy, this draws
@@ -555,7 +555,7 @@ NSString *const SessionViewWasSelectedForInspectionNotification = @"SessionViewW
     [CATransaction commit];
 }
 
-- (NSRect)frameForScroller NS_AVAILABLE_MAC(10_14) {
+- (NSRect)frameForScroller {
     [_scrollview.verticalScroller sizeToFit];
     NSSize size = _scrollview.verticalScroller.frame.size;
     NSSize mySize = self.bounds.size;
@@ -838,7 +838,7 @@ NSString *const SessionViewWasSelectedForInspectionNotification = @"SessionViewW
     return _useMetal;
 }
 
-- (void)setUseMetal:(BOOL)useMetal dataSource:(id<iTermMetalDriverDataSource>)dataSource NS_AVAILABLE_MAC(10_11) {
+- (void)setUseMetal:(BOOL)useMetal dataSource:(id<iTermMetalDriverDataSource>)dataSource {
     if (useMetal != _useMetal) {
         _useMetal = useMetal;
         RLog(@"setUseMetal:%@ dataSource:%@", @(useMetal), dataSource);
@@ -858,7 +858,7 @@ NSString *const SessionViewWasSelectedForInspectionNotification = @"SessionViewW
     }
 }
 
-- (void)preferredMetalDeviceDidChange:(NSNotification *)notification NS_AVAILABLE_MAC(10_11) {
+- (void)preferredMetalDeviceDidChange:(NSNotification *)notification {
     if (_metalView) {
         [self.delegate sessionViewRecreateMetalView];
     }
@@ -957,7 +957,7 @@ NSString *const SessionViewWasSelectedForInspectionNotification = @"SessionViewW
         [self addSubview:_activePaneBorderView positioned:NSWindowBelow relativeTo:_progressBar];
     }
 }
-- (void)installMetalViewWithDataSource:(id<iTermMetalDriverDataSource>)dataSource NS_AVAILABLE_MAC(10_11) {
+- (void)installMetalViewWithDataSource:(id<iTermMetalDriverDataSource>)dataSource {
     if (_metalView) {
         [self removeMetalView];
     }
@@ -1002,7 +1002,7 @@ NSString *const SessionViewWasSelectedForInspectionNotification = @"SessionViewW
     [self metalViewVisibilityDidChange];
 }
 
-- (void)removeMetalView NS_AVAILABLE_MAC(10_11) {
+- (void)removeMetalView {
     _metalView.delegate = nil;
     [_metalView removeFromSuperview];
     _metalView = nil;
@@ -2606,13 +2606,11 @@ typedef NS_OPTIONS(NSUInteger, iTermCornerFlags) {
         frame.origin.x += 5;
     }
     frame = NSInsetRect(frame, 0, 2);
-    if (@available(macOS 10.15, *)) {
-        if ([[NSApp effectiveAppearance] it_isDark]) {
-            // Avoid overlapping the border on the right. It looks ugly
-            // when the window's dark because the part that overlaps the
-            // border is extra bright.
-            frame.size.width -= 1;
-        }
+    if ([[NSApp effectiveAppearance] it_isDark]) {
+        // Avoid overlapping the border on the right. It looks ugly
+        // when the window's dark because the part that overlaps the
+        // border is extra bright.
+        frame.size.width -= 1;
     }
     if (animated) {
         [NSView animateWithDuration:5.0 / 60.0
@@ -2992,7 +2990,7 @@ extendResultsAcrossSoftBoundaries:(BOOL)extendResultsAcrossSoftBoundaries {
     return [self backgroundColorForDecorativeSubviews];
 }
 
-- (NSScrollView *)ptyScrollerScrollView NS_AVAILABLE_MAC(10_14) {
+- (NSScrollView *)ptyScrollerScrollView {
     return _scrollview;
 }
 
@@ -3004,11 +3002,11 @@ extendResultsAcrossSoftBoundaries:(BOOL)extendResultsAcrossSoftBoundaries {
 
 #pragma mark - iTermSearchResultsMinimapViewDelegate
 
-- (NSIndexSet *)searchResultsMinimapViewLocations:(iTermSearchResultsMinimapView *)view NS_AVAILABLE_MAC(10_14) {
+- (NSIndexSet *)searchResultsMinimapViewLocations:(iTermSearchResultsMinimapView *)view {
     return [self.searchResultsMinimapViewDelegate searchResultsMinimapViewLocations:view];
 }
 
-- (NSRange)searchResultsMinimapViewRangeOfVisibleLines:(iTermSearchResultsMinimapView *)view NS_AVAILABLE_MAC(10_14) {
+- (NSRange)searchResultsMinimapViewRangeOfVisibleLines:(iTermSearchResultsMinimapView *)view {
     return [self.searchResultsMinimapViewDelegate searchResultsMinimapViewRangeOfVisibleLines:view];
 }
 

--- a/sources/TerminalView/iTermRootTerminalView.h
+++ b/sources/TerminalView/iTermRootTerminalView.h
@@ -113,9 +113,9 @@ extern const NSInteger iTermRootTerminalViewWindowNumberLabelWidth;
 @property(nonatomic, readonly) CGFloat leftTabBarPreferredWidth;
 
 @property(nonatomic) BOOL useMetal;
-@property(nonatomic, readonly) BOOL tabBarControlOnLoan NS_AVAILABLE_MAC(10_14);
+@property(nonatomic, readonly) BOOL tabBarControlOnLoan;
 @property(nonatomic, strong, readonly) iTermStatusBarViewController *statusBarViewController;
-@property(nonatomic, readonly) iTermImageView *backgroundImage NS_AVAILABLE_MAC(10_14);
+@property(nonatomic, readonly) iTermImageView *backgroundImage;
 // Excludes the window number
 @property(nonatomic, readonly) NSString *windowTitle;
 
@@ -148,16 +148,16 @@ extern const NSInteger iTermRootTerminalViewWindowNumberLabelWidth;
 - (void)windowTitleDidChangeTo:(NSString *)title;
 - (void)windowNumberDidChangeTo:(NSNumber *)number;
 - (void)setWindowTitleIcon:(NSImage *)icon;
-- (iTermTabBarControlView *)borrowTabBarControl NS_AVAILABLE_MAC(10_14);
-- (void)returnTabBarControlView:(iTermTabBarControlView *)tabBarControl NS_AVAILABLE_MAC(10_14);
+- (iTermTabBarControlView *)borrowTabBarControl;
+- (void)returnTabBarControlView:(iTermTabBarControlView *)tabBarControl;
 - (CGFloat)maximumToolbeltWidthForViewWidth:(CGFloat)viewWidth;
 - (void)updateToolbeltProportionsIfNeeded;
 - (void)setToolbeltProportions:(NSDictionary *)proportions;
 - (void)invalidateAutomaticTabBarBackingHiding;
-- (void)setShowsWindowSize:(BOOL)showsWindowSize NS_AVAILABLE_MAC(10_14);
+- (void)setShowsWindowSize:(BOOL)showsWindowSize;
 - (void)windowDidResize;
 - (CGFloat)leftTabBarWidthForPreferredWidth:(CGFloat)preferredWidth contentWidth:(CGFloat)contentWidth;
-- (void)updateTitleAndBorderViews NS_AVAILABLE_MAC(10_14);
+- (void)updateTitleAndBorderViews;
 - (void)setSubtitle:(NSString *)subtitle;
 - (void)setCurrentSessionAlpha:(CGFloat)alpha;
 - (void)updateProxyIcon;

--- a/sources/TerminalView/iTermRootTerminalView.m
+++ b/sources/TerminalView/iTermRootTerminalView.m
@@ -75,7 +75,6 @@ typedef struct {
 
 @end
 
-NS_CLASS_AVAILABLE_MAC(10_14)
 @interface iTermTabBarBacking : NSView<iTermTabBarControlViewContainer>
 @property (nonatomic) BOOL hidesWhenTabBarHidden;
 @property (nonatomic, readonly) NSVisualEffectView *visualEffectView;
@@ -139,19 +138,18 @@ NS_CLASS_AVAILABLE_MAC(10_14)
     NSNumber *_windowNumber;
     NSTextField *_windowNumberLabel;
     iTermFakeWindowTitleLabel *_windowTitleLabel;
-    iTermTabBarBacking *_tabBarBacking NS_AVAILABLE_MAC(10_14);
+    iTermTabBarBacking *_tabBarBacking;
     iTermGenericStatusBarContainer *_statusBarContainer;
     NSDictionary *_desiredToolbeltProportions;
-    iTermWindowSizeView *_windowSizeView NS_AVAILABLE_MAC(10_14);
+    iTermWindowSizeView *_windowSizeView;
 
-    iTermLayerBackedSolidColorView *_titleBackgroundView NS_AVAILABLE_MAC(10_14);
-    NSVisualEffectView *_titleBackgroundVEV NS_AVAILABLE_MAC(10_14);
+    iTermLayerBackedSolidColorView *_titleBackgroundView;
+    NSVisualEffectView *_titleBackgroundVEV;
 
-    iTermWindowBorderView *_windowBorderView NS_AVAILABLE_MAC(10_14);
-    BOOL _cornerRadiusDetectionFailed NS_AVAILABLE_MAC(10_14);
+    iTermWindowBorderView *_windowBorderView;
+    BOOL _cornerRadiusDetectionFailed;
 
-    iTermImageView *_backgroundImage NS_AVAILABLE_MAC(10_14);
-    NSView *_workaroundView;  // 10.14 only. See issue 8701.
+    iTermImageView *_backgroundImage;
     iTermLayerBackedSolidColorView *_notchMask NS_AVAILABLE_MAC(12_0);
     iTermCompactProxyIconView *_compactProxyIconView;
 }
@@ -279,11 +277,6 @@ NS_CLASS_AVAILABLE_MAC(10_14)
             [iTermAdvancedSettingsModel squareWindowCorners] ? 0 : [iTermWindowCornerRadiusDetector fallbackCornerRadius];
         [self addSubview:_windowBorderView];
 
-        if (@available(macOS 10.15, *)) {} else {
-            // 10.14 only
-            _workaroundView = [[SolidColorView alloc] initWithFrame:NSMakeRect(0, 0, 1, 1) color:[NSColor clearColor]];
-            [self addSubview:_workaroundView];
-        }
         if (@available(macOS 12.0, *)) {
             _notchMask = [[iTermLayerBackedSolidColorView alloc] initWithFrame:NSMakeRect(0, 0, 0, 0) color:[NSColor blackColor]];
             _notchMask.hidden = YES;
@@ -303,7 +296,7 @@ NS_CLASS_AVAILABLE_MAC(10_14)
     _verticalTabBarDragHandle.delegate = nil;
 }
 
-- (void)advancedSettingsDidChange:(NSNotification *)notification NS_AVAILABLE_MAC(10_14) {
+- (void)advancedSettingsDidChange:(NSNotification *)notification {
     [self updateBorderViews];
 }
 
@@ -748,7 +741,7 @@ NS_CLASS_AVAILABLE_MAC(10_14)
     return NSMakeRect(0, 0, self.bounds.size.width, 1);
 }
 
-- (void)updateTitleAndBorderViews NS_AVAILABLE_MAC(10_14) {
+- (void)updateTitleAndBorderViews {
     const BOOL wantsTitleBackgroundView = [_delegate rootTerminalViewShouldDrawWindowTitleInPlaceOfTabBar];
     if (wantsTitleBackgroundView) {
         if (!_titleBackgroundView) {
@@ -833,7 +826,7 @@ static NSColor *iTermWindowBorderColorFromSetting(NSString *setting) {
     return [color colorWithAlphaComponent:alpha];
 }
 
-- (NSColor *)resolvedWindowBorderColor NS_AVAILABLE_MAC(10_14) {
+- (NSColor *)resolvedWindowBorderColor {
     NSColor *focused = iTermWindowBorderColorFromSetting([iTermAdvancedSettingsModel windowBorderColor]);
     NSColor *unfocused = iTermWindowBorderColorFromSetting([iTermAdvancedSettingsModel windowBorderColorUnfocused]);
     NSColor *base = self.window.isKeyWindow ? (focused ?: unfocused) : (unfocused ?: focused);
@@ -847,7 +840,7 @@ static NSColor *iTermWindowBorderColorFromSetting(NSString *setting) {
 // The border is drawn fully inside the window, so updateBorderViews subtracts
 // half the border width to get the stroke's centerline radius. Updated on
 // cache miss by the early-return path in updateBorderViews.
-- (CGFloat)resolvedWindowBorderCornerRadius NS_AVAILABLE_MAC(10_14) {
+- (CGFloat)resolvedWindowBorderCornerRadius {
     if ([iTermAdvancedSettingsModel squareWindowCorners]) {
         return 0;
     }
@@ -859,7 +852,7 @@ static NSColor *iTermWindowBorderColorFromSetting(NSString *setting) {
     return MAX(0, cached.doubleValue);
 }
 
-- (void)updateBorderViews NS_AVAILABLE_MAC(10_14) {
+- (void)updateBorderViews {
     NSWindow *window = self.window;
 
     // Hide the border until the detector has cached a radius for this window
@@ -916,15 +909,6 @@ static NSColor *iTermWindowBorderColorFromSetting(NSString *setting) {
     }
     _useMetal = useMetal;
     self.tabView.drawsBackground = NO;
-    if (@available(macOS 10.15, *)) { } else {
-        if (useMetal) {
-            self.wantsLayer = YES;
-            self.layer = [[CALayer alloc] init];
-        } else {
-            self.wantsLayer = NO;
-            self.layer = nil;
-        }
-    }
     [self updateTitleAndBorderViews];
 
     [_divisionView removeFromSuperview];
@@ -933,7 +917,7 @@ static NSColor *iTermWindowBorderColorFromSetting(NSString *setting) {
     [self updateDivisionViewAndWindowNumberLabel];
 }
 
-- (void)viewDidChangeEffectiveAppearance NS_AVAILABLE_MAC(10_14) {
+- (void)viewDidChangeEffectiveAppearance {
     RLog(@"iTermRootTerminalView viewDidChangeEffectiveAppearance -> %@ (window key=%@ main=%@ appActive=%@)",
          self.effectiveAppearance.name,
          @(self.window.isKeyWindow), @(self.window.isMainWindow), @(NSApp.isActive));
@@ -1620,9 +1604,6 @@ static NSColor *iTermWindowBorderColorFromSetting(NSString *setting) {
     DLog(@"Before:\n%@", [self iterm_recursiveDescription]);
     [self.delegate rootTerminalViewWillLayoutSubviews];
 
-    if (@available(macOS 10.15, *)) { } else {
-        _workaroundView.frame = NSMakeRect(0, self.bounds.size.height - 1, 1, 1);
-    }
     const BOOL showToolbeltInline = self.shouldShowToolbelt;
     NSWindow *thisWindow = _delegate.window;
     if (!_tabBarControlOnLoan) {

--- a/sources/TerminalView/iTermSearchResultsMinimapView.h
+++ b/sources/TerminalView/iTermSearchResultsMinimapView.h
@@ -12,7 +12,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class iTermSearchResultsMinimapView;
 
-NS_CLASS_AVAILABLE_MAC(10_14)
 @protocol iTermSearchResultsMinimapViewDelegate<NSObject>
 - (NSIndexSet *)searchResultsMinimapViewLocations:(iTermSearchResultsMinimapView *)view;
 - (NSRange)searchResultsMinimapViewRangeOfVisibleLines:(iTermSearchResultsMinimapView *)view;
@@ -26,7 +25,6 @@ NS_CLASS_AVAILABLE_MAC(10_14)
 - (void)invalidate;
 @end
 
-NS_CLASS_AVAILABLE_MAC(10_14)
 @interface iTermSearchResultsMinimapView : iTermBaseMinimapView
 @property (nonatomic, weak) id<iTermSearchResultsMinimapViewDelegate> delegate;
 @end

--- a/sources/TerminalView/iTermTabBarAccessoryViewController.h
+++ b/sources/TerminalView/iTermTabBarAccessoryViewController.h
@@ -9,7 +9,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-NS_CLASS_AVAILABLE_MAC(10_14)
 @interface iTermTabBarAccessoryViewController : NSTitlebarAccessoryViewController
 @property (nonatomic, readonly) __kindof NSView *realView;
 

--- a/sources/Toolbelt/CapturedOutput/ToolCapturedOutputView.m
+++ b/sources/Toolbelt/CapturedOutput/ToolCapturedOutputView.m
@@ -230,10 +230,7 @@ static NSString *const iTermCapturedOutputToolTableViewCellIdentifier = @"ToolCa
 
     // Clear button
     {
-        CGFloat fudgeFactor = 1;
-        if (@available(macOS 10.15, *)) {
-            fudgeFactor = 0;
-        }
+        CGFloat fudgeFactor = 0;
         _clearButton.frame = NSMakeRect(help_.frame.origin.x - _clearButton.frame.size.width - kMargin,
                                         fudgeFactor,
                                         _clearButton.frame.size.width,

--- a/sources/Toolbelt/iTermToolbeltView.m
+++ b/sources/Toolbelt/iTermToolbeltView.m
@@ -49,7 +49,6 @@ NSString *const iTermToolbeltDidRegisterDynamicToolNotification = @"iTermToolbel
 
 static NSString *const iTermToolbeltProportionsUserDefaultsKey = @"NoSyncToolbeltProportions";
 
-NS_CLASS_AVAILABLE_MAC(10_14)
 @interface iTermToolbeltVibrantVisualEffectView : NSVisualEffectView
 @end
 
@@ -65,7 +64,7 @@ NS_CLASS_AVAILABLE_MAC(10_14)
     // Tool name to wrapper
     NSMutableDictionary<NSString *, iTermToolWrapper *> *_tools;
     NSDictionary *_proportions;
-    iTermToolbeltVibrantVisualEffectView *_vev NS_AVAILABLE_MAC(10_14);
+    iTermToolbeltVibrantVisualEffectView *_vev;
     iTermHamburgerButton *_menuButton;
     BOOL _inSplitViewDidResizeSubviews;
     NSTextField *_noToolsMessage;
@@ -355,7 +354,7 @@ static NSString *const kDynamicToolURL = @"URL";
     [self updateColors];
 }
 
-- (void)updateColors NS_AVAILABLE_MAC(10_14) {
+- (void)updateColors {
     if (@available(macOS 10.16, *)) {
         _vev.blendingMode = NSVisualEffectBlendingModeBehindWindow;
     } else {


### PR DESCRIPTION
The macOS deployment target is now 13.0. Remove obsolete macOS 10.x compatibility code.