### PR TITLE
Notify tmux when tab bar visibility changes without a window resize

### DIFF
--- a/docs/notes-3.7.txt
+++ b/docs/notes-3.7.txt
@@ -715,6 +715,11 @@ Settings Improvements:
   changes.
 
 Bug Fixes:
+- Fix tmux integration sessions not resizing
+  when the tab bar hides or shows in full
+  screen with “Hide tab bar when there is only
+  one tab” enabled, which left an unused strip
+  at the bottom of the window.
 - In the tmux Dashboard, “Open in Tabs” is now
   enabled when a single hidden window is
   selected, matching “Open in Window.” Issue

--- a/sources/TerminalView/PseudoTerminal.m
+++ b/sources/TerminalView/PseudoTerminal.m
@@ -6674,6 +6674,7 @@ hidingToolbeltShouldResizeWindow:(BOOL)hidingToolbeltShouldResizeWindow
             __weak __typeof(self) weakSelf = self;
             dispatch_async(dispatch_get_main_queue(), ^{
                 [weakSelf repositionWidgets];
+                [weakSelf notifyTmuxOfWindowResize];
             });
         }
     } else if (_contentView.tabBarControlOnLoan) {
@@ -7883,6 +7884,7 @@ hidingToolbeltShouldResizeWindow:(BOOL)hidingToolbeltShouldResizeWindow
         DLog(@"View hierarchy after tab count change:\n%@", [_contentView.tabBarControl.window.contentView iterm_recursiveDescription]);
 
         [self repositionWidgets];
+        [self notifyTmuxOfWindowResize];
         if (wasDraggedFromAnotherWindow_) {
             wasDraggedFromAnotherWindow_ = NO;
             [firstTab setReportIdealSizeAsCurrent:NO];


### PR DESCRIPTION
In tmux integration mode, in full screen with “Hide tab bar when there is only one tab”, going from two tabs to one hid the tab bar but the remaining tmux session kept its old size, leaving a dead strip at the bottom.

Hiding or showing the tab bar in full screen doesn't change the window frame, so `-windowDidResize:` never runs and tmux is never told the available size changed. This notifies tmux after re-laying out, as `-windowDidResize:` does.