### PR TITLE
Use “Below” instead of “to the Right” in tab menus when the tab bar is vertical

### DIFF
--- a/docs/notes-3.7.txt
+++ b/docs/notes-3.7.txt
@@ -2819,3 +2819,7 @@ Bug Fixes:
   pieces in reading order instead of stacking
   them on separate lines. Pieces on different
   lines still copy with line breaks.
+- With the tab bar on the left or right, the tab
+  context menu now says “New Tab Below” instead
+  of “New Tab to the Right”, matching the
+  “Close Tabs Below” item just under it.

--- a/docs/notes-3.7.txt
+++ b/docs/notes-3.7.txt
@@ -2820,6 +2820,8 @@ Bug Fixes:
   them on separate lines. Pieces on different
   lines still copy with line breaks.
 - With the tab bar on the left or right, the tab
-  context menu now says “New Tab Below” instead
-  of “New Tab to the Right”, matching the
-  “Close Tabs Below” item just under it.
+  and tab group context menus now say “New Tab
+  Below” and “Close Tabs Below” instead of “to
+  the Right”, matching the direction the tabs
+  actually run. The confirmation for closing the
+  tabs after a group follows suit.

--- a/sources/TerminalView/PseudoTerminal.m
+++ b/sources/TerminalView/PseudoTerminal.m
@@ -8031,7 +8031,9 @@ hidingToolbeltShouldResizeWindow:(BOOL)hidingToolbeltShouldResizeWindow
    }
 
     // add tasks
-    item = [[[NSMenuItem alloc] initWithTitle:@"New Tab to the Right"
+    const PSMTabPosition tabPosition = [iTermPreferences intForKey:kPreferenceKeyTabPosition];
+    const BOOL verticalTabBar = (tabPosition == PSMTab_LeftTab || tabPosition == PSMTab_RightTab);
+    item = [[[NSMenuItem alloc] initWithTitle:verticalTabBar ? @"New Tab Below" : @"New Tab to the Right"
                                        action:@selector(newTabToTheRight:)
                                 keyEquivalent:@""] autorelease];
     [item setRepresentedObject:tabViewItem];
@@ -8101,13 +8103,7 @@ hidingToolbeltShouldResizeWindow:(BOOL)hidingToolbeltShouldResizeWindow
         }
 
         if (hasUnpinnedToRight) {
-            NSString *title;
-            const PSMTabPosition tabPosition = [iTermPreferences intForKey:kPreferenceKeyTabPosition];
-            if (tabPosition == PSMTab_LeftTab || tabPosition == PSMTab_RightTab) {
-                title = @"Close Tabs Below";
-            } else {
-                title = @"Close Tabs to the Right";
-            }
+            NSString *title = verticalTabBar ? @"Close Tabs Below" : @"Close Tabs to the Right";
             item = [[[NSMenuItem alloc] initWithTitle:title
                                                action:@selector(closeTabsToTheRight:)
                                         keyEquivalent:@""] autorelease];

--- a/sources/TerminalView/PseudoTerminal.m
+++ b/sources/TerminalView/PseudoTerminal.m
@@ -7997,6 +7997,13 @@ hidingToolbeltShouldResizeWindow:(BOOL)hidingToolbeltShouldResizeWindow
     return YES;
 }
 
+// A left or right tab bar runs top to bottom, so directional menu wording
+// says “Below” where a horizontal tab bar says “to the Right”.
+- (BOOL)tabBarIsVertical {
+    const PSMTabPosition tabPosition = [iTermPreferences intForKey:kPreferenceKeyTabPosition];
+    return tabPosition == PSMTab_LeftTab || tabPosition == PSMTab_RightTab;
+}
+
 - (NSMenu *)tabView:(NSTabView *)tabView menuForTabViewItem:(NSTabViewItem *)tabViewItem
 {
     NSMenuItem *item;
@@ -8031,8 +8038,7 @@ hidingToolbeltShouldResizeWindow:(BOOL)hidingToolbeltShouldResizeWindow
    }
 
     // add tasks
-    const PSMTabPosition tabPosition = [iTermPreferences intForKey:kPreferenceKeyTabPosition];
-    const BOOL verticalTabBar = (tabPosition == PSMTab_LeftTab || tabPosition == PSMTab_RightTab);
+    const BOOL verticalTabBar = [self tabBarIsVertical];
     item = [[[NSMenuItem alloc] initWithTitle:verticalTabBar ? @"New Tab Below" : @"New Tab to the Right"
                                        action:@selector(newTabToTheRight:)
                                 keyEquivalent:@""] autorelease];
@@ -9068,6 +9074,7 @@ hidingToolbeltShouldResizeWindow:(BOOL)hidingToolbeltShouldResizeWindow
     NSMenu *menu = [[[NSMenu alloc] initWithTitle:@""] autorelease];
     menu.autoenablesItems = NO;  // contextual actions are always applicable
     const BOOL collapsed = [self tabsInGroup:groupID].firstObject.tabGroupCollapsed;
+    NSString *closeAfterTitle = [self tabBarIsVertical] ? @"Close Tabs Below" : @"Close Tabs to the Right";
     NSArray<NSArray<NSString *> *> *specs = @[
         @[@"New Tab in Group", @"newTabInGroup:"],
         @[@"-", @""],
@@ -9084,7 +9091,7 @@ hidingToolbeltShouldResizeWindow:(BOOL)hidingToolbeltShouldResizeWindow
         @[@"-", @""],
         @[@"Close Group", @"closeTabGroup:"],
         @[@"Close Other Tabs", @"closeTabsOutsideGroup:"],
-        @[@"Close Tabs to the Right", @"closeTabsRightOfGroup:"],
+        @[closeAfterTitle, @"closeTabsRightOfGroup:"],
     ];
     for (NSArray<NSString *> *spec in specs) {
         if ([spec[0] isEqualToString:@"-"]) {
@@ -9506,7 +9513,9 @@ hidingToolbeltShouldResizeWindow:(BOOL)hidingToolbeltShouldResizeWindow
         return;
     }
     NSArray<PTYTab *> *toRight = [tabs subarrayWithRange:NSMakeRange(lastIndex + 1, tabs.count - lastIndex - 1)];
-    [self closeTabs:toRight confirmWith:@"Close all tabs to the right of this group?" skippingPinned:YES];
+    NSString *question = [self tabBarIsVertical] ? @"Close all tabs below this group?"
+                                                : @"Close all tabs to the right of this group?";
+    [self closeTabs:toRight confirmWith:question skippingPinned:YES];
 }
 
 // Close a batch of tabs with a single confirmation. `skipPinned` protects


### PR DESCRIPTION
With the tab bar on the left or right, the tab context menu is internally inconsistent: it offers “New Tab to the Right” directly above “Close Tabs Below”. The close item already picks its wording from `kPreferenceKeyTabPosition`; the new-tab item hardcoded its title.

The tab group menu had the same problem — “Close Tabs to the Right” on a vertical tab bar — along with its confirmation, “Close all tabs to the right of this group?”.

This routes all of them through one `-tabBarIsVertical` helper, so a left- or right-side tab bar reads “New Tab Below” and “Close Tabs Below”, and the group confirmation says “below this group”. Horizontal tab bars are unchanged.

Behavior is unaffected — only wording changes. `newTabToTheRight:` already inserts after the target tab, and `closeTabsRightOfGroup:` already closes the tabs after the group, both of which are “below” in a vertical bar.

Verified with a Development build (`tools/build.sh`).