### PR TITLE
Fix notification permission crash (EXC_BAD_ACCESS in invokeAllPendingCompletions)

### DIFF
--- a/sources/Notifications/iTermNotificationController.m
+++ b/sources/Notifications/iTermNotificationController.m
@@ -69,7 +69,7 @@
 }
 
 - (void)ensureNotificationPermissionsWithCompletion:(void (^)(BOOL granted))completion {
-    [self.pendingPermissionCompletions addObject:completion];
+    [self.pendingPermissionCompletions addObject:[completion copy]];
     
     if (self.checkingPermissions) {
         return;


### PR DESCRIPTION
### Summary
Copy completion block to heap before storing in `pendingPermissionCompletions`.

Without `[completion copy]` the stack block address becomes dangling after the caller returns. Later `[array copy]` in `invokeAllPendingCompletionsWithResult:` does `objc_retain` on `0x3d76...` → `EXC_BAD_ACCESS KERN_INVALID_ADDRESS` on `com.apple.usernotifications.UNUserNotificationServiceConnection.call-out`.

### Crash
- iTerm2 3.6.1 (36dee217) macOS 15.5 incident `31AEA055-9FBA-4455-AB8A-7C470ACCB211`
- Thread 4: `objc_retain → __NSArrayI_new → -[NSArray initWithArray:range:copyItems:] → -[iTermNotificationController invokeAllPendingCompletionsWithResult:] +68 → ensureNotificationPermissionsWithCompletion:_block_invoke +292`
- Triggered via Shell Integration / ClaudeCode `notify:` paths (e.g. Muse CLI)

### Fix
```diff
- [self.pendingPermissionCompletions addObject:completion];
+ [self.pendingPermissionCompletions addObject:[completion copy]];
```
One-line, minimal. File: `sources/Notifications/iTermNotificationController.m:72`

Related GitLab issue to be filed at https://gitlab.com/gnachman/iterm2/-/issues (same crash report).

### Testing
- No new tests needed; existing notification paths covered.
- Build: verified `git diff` clean, commit builds on master.
