### PR TITLE
Fix Kitty base-layout key reporting

### DIFF
--- a/ModernTests/ModernKeyMapperTests.swift
+++ b/ModernTests/ModernKeyMapperTests.swift
@@ -1,0 +1,75 @@
+//
+//  ModernKeyMapperTests.swift
+//  iTerm2
+//
+
+import Carbon.HIToolbox
+import XCTest
+@testable import iTerm2SharedARC
+
+final class ModernKeyMapperTests: XCTestCase {
+    func testPC101BaseLayoutMapsANSIKeys() {
+        let expected: [(virtualKeyCode: Int, scalar: Unicode.Scalar)] = [
+            (kVK_ANSI_A, "a"),
+            (kVK_ANSI_S, "s"),
+            (kVK_ANSI_D, "d"),
+            (kVK_ANSI_F, "f"),
+            (kVK_ANSI_H, "h"),
+            (kVK_ANSI_G, "g"),
+            (kVK_ANSI_Z, "z"),
+            (kVK_ANSI_X, "x"),
+            (kVK_ANSI_C, "c"),
+            (kVK_ANSI_V, "v"),
+            (kVK_ANSI_B, "b"),
+            (kVK_ANSI_Q, "q"),
+            (kVK_ANSI_W, "w"),
+            (kVK_ANSI_E, "e"),
+            (kVK_ANSI_R, "r"),
+            (kVK_ANSI_Y, "y"),
+            (kVK_ANSI_T, "t"),
+            (kVK_ANSI_1, "1"),
+            (kVK_ANSI_2, "2"),
+            (kVK_ANSI_3, "3"),
+            (kVK_ANSI_4, "4"),
+            (kVK_ANSI_6, "6"),
+            (kVK_ANSI_5, "5"),
+            (kVK_ANSI_Equal, "="),
+            (kVK_ANSI_9, "9"),
+            (kVK_ANSI_7, "7"),
+            (kVK_ANSI_Minus, "-"),
+            (kVK_ANSI_8, "8"),
+            (kVK_ANSI_0, "0"),
+            (kVK_ANSI_RightBracket, "]"),
+            (kVK_ANSI_O, "o"),
+            (kVK_ANSI_U, "u"),
+            (kVK_ANSI_LeftBracket, "["),
+            (kVK_ANSI_I, "i"),
+            (kVK_ANSI_P, "p"),
+            (kVK_ANSI_L, "l"),
+            (kVK_ANSI_J, "j"),
+            (kVK_ANSI_Quote, "'"),
+            (kVK_ANSI_K, "k"),
+            (kVK_ANSI_Semicolon, ";"),
+            (kVK_ANSI_Backslash, "\\"),
+            (kVK_ANSI_Comma, ","),
+            (kVK_ANSI_Slash, "/"),
+            (kVK_ANSI_N, "n"),
+            (kVK_ANSI_M, "m"),
+            (kVK_ANSI_Period, "."),
+            (kVK_Space, " "),
+            (kVK_ANSI_Grave, "`")
+        ]
+
+        for item in expected {
+            XCTAssertEqual(
+                pc101BaseLayoutKeyCode(for: UInt16(item.virtualKeyCode)),
+                item.scalar.value,
+                "virtual key code \(item.virtualKeyCode)"
+            )
+        }
+    }
+
+    func testPC101BaseLayoutRejectsNonANSIKey() {
+        XCTAssertNil(pc101BaseLayoutKeyCode(for: UInt16(kVK_ISO_Section)))
+    }
+}

--- a/docs/notes-3.7.txt
+++ b/docs/notes-3.7.txt
@@ -103,6 +103,11 @@ Major New Features:
   always sent the temperature parameter,
   failing against endpoints that reject it.
 
+- Fixed Kitty keyboard protocol base-layout
+  reporting for non-US keyboard layouts, so
+  shortcuts such as Ctrl-C work without
+  switching layouts.
+
 - Fixed a bug where, if the AI asked for
   permission in a chat and you ignored the
   request and sent a new message instead, the

--- a/sources/Keyboard/iTermModernKeyMapper.swift
+++ b/sources/Keyboard/iTermModernKeyMapper.swift
@@ -1494,6 +1494,62 @@ extension String {
     }
 }
 
+/// Returns the unshifted Unicode codepoint at a macOS virtual key’s
+/// physical position in the standard PC-101 layout.
+func pc101BaseLayoutKeyCode(for virtualKeyCode: UInt16) -> UInt32? {
+    switch Int(virtualKeyCode) {
+    case kVK_ANSI_A: return UnicodeScalar("a").value
+    case kVK_ANSI_S: return UnicodeScalar("s").value
+    case kVK_ANSI_D: return UnicodeScalar("d").value
+    case kVK_ANSI_F: return UnicodeScalar("f").value
+    case kVK_ANSI_H: return UnicodeScalar("h").value
+    case kVK_ANSI_G: return UnicodeScalar("g").value
+    case kVK_ANSI_Z: return UnicodeScalar("z").value
+    case kVK_ANSI_X: return UnicodeScalar("x").value
+    case kVK_ANSI_C: return UnicodeScalar("c").value
+    case kVK_ANSI_V: return UnicodeScalar("v").value
+    case kVK_ANSI_B: return UnicodeScalar("b").value
+    case kVK_ANSI_Q: return UnicodeScalar("q").value
+    case kVK_ANSI_W: return UnicodeScalar("w").value
+    case kVK_ANSI_E: return UnicodeScalar("e").value
+    case kVK_ANSI_R: return UnicodeScalar("r").value
+    case kVK_ANSI_Y: return UnicodeScalar("y").value
+    case kVK_ANSI_T: return UnicodeScalar("t").value
+    case kVK_ANSI_1: return UnicodeScalar("1").value
+    case kVK_ANSI_2: return UnicodeScalar("2").value
+    case kVK_ANSI_3: return UnicodeScalar("3").value
+    case kVK_ANSI_4: return UnicodeScalar("4").value
+    case kVK_ANSI_6: return UnicodeScalar("6").value
+    case kVK_ANSI_5: return UnicodeScalar("5").value
+    case kVK_ANSI_Equal: return UnicodeScalar("=").value
+    case kVK_ANSI_9: return UnicodeScalar("9").value
+    case kVK_ANSI_7: return UnicodeScalar("7").value
+    case kVK_ANSI_Minus: return UnicodeScalar("-").value
+    case kVK_ANSI_8: return UnicodeScalar("8").value
+    case kVK_ANSI_0: return UnicodeScalar("0").value
+    case kVK_ANSI_RightBracket: return UnicodeScalar("]").value
+    case kVK_ANSI_O: return UnicodeScalar("o").value
+    case kVK_ANSI_U: return UnicodeScalar("u").value
+    case kVK_ANSI_LeftBracket: return UnicodeScalar("[").value
+    case kVK_ANSI_I: return UnicodeScalar("i").value
+    case kVK_ANSI_P: return UnicodeScalar("p").value
+    case kVK_ANSI_L: return UnicodeScalar("l").value
+    case kVK_ANSI_J: return UnicodeScalar("j").value
+    case kVK_ANSI_Quote: return UnicodeScalar("'").value
+    case kVK_ANSI_K: return UnicodeScalar("k").value
+    case kVK_ANSI_Semicolon: return UnicodeScalar(";").value
+    case kVK_ANSI_Backslash: return UnicodeScalar("\\").value
+    case kVK_ANSI_Comma: return UnicodeScalar(",").value
+    case kVK_ANSI_Slash: return UnicodeScalar("/").value
+    case kVK_ANSI_N: return UnicodeScalar("n").value
+    case kVK_ANSI_M: return UnicodeScalar("m").value
+    case kVK_ANSI_Period: return UnicodeScalar(".").value
+    case kVK_Space: return UnicodeScalar(" ").value
+    case kVK_ANSI_Grave: return UnicodeScalar("`").value
+    default: return nil
+    }
+}
+
 extension NSEvent {
     private var it_functionalKeyCode: UInt32? {
         if let functional = FunctionalKeyDefinition(virtualKeyCode: keyCode) {
@@ -1593,19 +1649,7 @@ extension NSEvent {
         if let functional = it_functionalKeyCode {
             return functional
         }
-        let optionModifiers: NSEvent.ModifierFlags = [
-            .option, .leftOption, .rightOption]
-        if let s = characters(
-            byApplyingModifiers: modifierFlags
-                .subtracting(optionModifiers)
-                .subtracting([.shift, .control])),
-           let c = s.it_firstUnicodeScalarValue {
-            return c
-        }
-        if let code = charactersIgnoringModifiers?.it_firstUnicodeScalarValue {
-            return code
-        }
-        return 0
+        return pc101BaseLayoutKeyCode(for: keyCode) ?? 0
     }
 }
 


### PR DESCRIPTION
The Kitty keyboard protocol defines the base-layout alternate as the key at the same physical position in the standard PC-101 layout. iTerm2 currently computes it by stripping modifiers and translating the key through the active layout. On a Russian layout, the physical C key therefore produces Cyrillic `с` for both the primary and base values, and the encoder omits the base alternate entirely:

- before: `CSI 1089;5u`
- after: `CSI 1089::99;5u`

This derives the base-layout value from the macOS virtual key code using the fixed ANSI/PC-101 positions instead of the active input source. Functional and keypad keys keep their existing handling. ISO/JIS-only keys, which have no PC-101 position, do not report a base alternate.

The mapping covers every ANSI letter, digit, punctuation key, and Space, with a negative test for the ISO Section key.

Specification: https://sw.kovidgoyal.net/kitty/keyboard-protocol/#key-codes

Kitty’s macOS implementation uses the same fixed virtual-key-code approach: https://github.com/kovidgoyal/kitty/blob/master/glfw/cocoa_window.m

Tested with:

`tools/run_tests.expect ModernTests/ModernKeyMapperTests`
