### PR TITLE
Improve clipboard image pasting and upload performance over SSH

### DIFF
--- a/ModernTests/ConductorUploadTests.swift
+++ b/ModernTests/ConductorUploadTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+@testable import iTerm2SharedARC
+
+@MainActor
+final class ConductorUploadTests: XCTestCase {
+    func testScreenshotUsesThirtyOneRequestsAndPreservesBytes() async throws {
+        let data = Data((0..<(490 * 1024)).map { UInt8(truncatingIfNeeded: $0) })
+        var chunks = [Data]()
+        var progress = 0
+        try await ConductorUpload.send(data, checkCancellation: {}) { chunk in
+            chunks.append(chunk)
+        } didTransfer: { count in
+            progress += count
+        }
+        XCTAssertEqual(chunks.count, 31)
+        XCTAssertTrue(chunks.allSatisfy { $0.count <= 16 * 1024 })
+        XCTAssertEqual(chunks.reduce(into: Data()) { $0.append($1) }, data)
+        XCTAssertEqual(progress, data.count)
+    }
+
+    func testCancellationDuringFinalAppendDoesNotFinishUpload() async {
+        var cancelled = false
+        var progress = 0
+        do {
+            try await ConductorUpload.send(Data([1, 2, 3]), checkCancellation: {
+                if cancelled { throw CancellationError() }
+            }) { _ in
+                cancelled = true
+            } didTransfer: { progress += $0 }
+            XCTFail("Cancellation during the final append must reach the cleanup path")
+        } catch is CancellationError {
+            XCTAssertEqual(progress, 0)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testCancellationBetweenChunksDoesNotSendAnotherRequest() async {
+        var cancelled = false
+        var requests = 0
+        do {
+            try await ConductorUpload.send(Data(count: 128 * 1024), checkCancellation: {
+                if cancelled { throw CancellationError() }
+            }) { _ in
+                requests += 1
+            } didTransfer: { _ in
+                cancelled = true
+            }
+            XCTFail("Expected cancellation")
+        } catch is CancellationError {
+            XCTAssertEqual(requests, 1)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testAppendFailureDoesNotReportProgressOrSendAnotherChunk() async {
+        var requests = 0
+        var progress = 0
+        do {
+            try await ConductorUpload.send(Data(count: 128 * 1024), checkCancellation: {}) { _ in
+                requests += 1
+                throw CocoaError(.fileWriteUnknown)
+            } didTransfer: { progress += $0 }
+            XCTFail("Expected append error")
+        } catch {
+            XCTAssertEqual(requests, 1)
+            XCTAssertEqual(progress, 0)
+        }
+    }
+
+    func testEmptyUploadStillChecksCancellation() async {
+        do {
+            try await ConductorUpload.send(Data(), checkCancellation: {
+                throw CancellationError()
+            }) { _ in
+                XCTFail("Empty upload must not append")
+            } didTransfer: { _ in
+                XCTFail("Empty upload must not report progress")
+            }
+            XCTFail("Expected cancellation")
+        } catch is CancellationError {
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+}

--- a/ModernTests/NonTextPasteImageTests.swift
+++ b/ModernTests/NonTextPasteImageTests.swift
@@ -1,0 +1,52 @@
+import AppKit
+import XCTest
+@testable import iTerm2SharedARC
+
+final class NonTextPasteImageTests: XCTestCase {
+    func testTIFFScreenshotBecomesPNGWithoutChangingDimensions() throws {
+        let bitmap = try XCTUnwrap(NSBitmapImageRep(bitmapDataPlanes: nil,
+                                                   pixelsWide: 3,
+                                                   pixelsHigh: 2,
+                                                   bitsPerSample: 8,
+                                                   samplesPerPixel: 4,
+                                                   hasAlpha: true,
+                                                   isPlanar: false,
+                                                   colorSpaceName: .deviceRGB,
+                                                   bytesPerRow: 0,
+                                                   bitsPerPixel: 0))
+        let pixels = try XCTUnwrap(bitmap.bitmapData)
+        for x in 0..<3 {
+            for y in 0..<2 {
+                let offset = y * bitmap.bytesPerRow + x * 4
+                pixels[offset] = 255
+                pixels[offset + 1] = 0
+                pixels[offset + 2] = 0
+                pixels[offset + 3] = 255
+            }
+        }
+        let tiff = try XCTUnwrap(bitmap.representation(using: .tiff, properties: [:]))
+        let result = try XCTUnwrap(iTermNonTextPasteHelper.imageForFile(tiff, fileExtension: "tiff"))
+        XCTAssertEqual(result.fileExtension, "png")
+        XCTAssertEqual(Array(result.data.prefix(8)), [137, 80, 78, 71, 13, 10, 26, 10])
+        let decoded = try XCTUnwrap(NSBitmapImageRep(data: result.data))
+        XCTAssertEqual(decoded.pixelsWide, 3)
+        XCTAssertEqual(decoded.pixelsHigh, 2)
+        var pixel = [UInt](repeating: 0, count: 4)
+        decoded.getPixel(&pixel, atX: 1, y: 1)
+        XCTAssertEqual(pixel, [255, 0, 0, 255])
+    }
+
+    func testSupportedFormatsPreserveOriginalBytes() throws {
+        // Existing compressed images should not be recompressed or lose animation.
+        let original = Data([1, 2, 3, 4])
+        for ext in ["PNG", "JPEG", "jpg", "gif", "webp"] {
+            let result = try XCTUnwrap(iTermNonTextPasteHelper.imageForFile(original, fileExtension: ext))
+            XCTAssertEqual(result.data, original)
+            XCTAssertEqual(result.fileExtension, ext.lowercased())
+        }
+    }
+
+    func testInvalidTIFFDoesNotBecomeAnImagePath() {
+        XCTAssertNil(iTermNonTextPasteHelper.imageForFile(Data([1, 2, 3]), fileExtension: "tiff"))
+    }
+}

--- a/docs/notes-3.7.txt
+++ b/docs/notes-3.7.txt
@@ -592,6 +592,14 @@ Shell Integration Improvements:
   It's automatically in your path.
 
 SSH Integration Improvements:
+- Speed up uploads with larger transfer chunks.
+- Fix cancelled uploads leaving temporary files
+  or getting stuck while finishing the transfer.
+- Upload and paste image paths through tmux
+  integration using the existing SSH connection.
+- Convert pasted TIFF screenshots to PNG and use
+  unique filenames for remote image uploads.
+- Do not paste paths after cancelling an upload.
 - Better passphrase handling for SCP and
   private keys. Wrong passphrases now retry
   instead of falling through to an empty

--- a/iTerm2.xcodeproj/project.pbxproj
+++ b/iTerm2.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		0B05CA460519B96060210386 /* AIChatWireLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88578347A529CFE749B6F433 /* AIChatWireLogger.swift */; };
 		0BC580AF4D2AB9C3E952CB01 /* ShuffleDeck.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46A873D7F2EFCF8441303D1 /* ShuffleDeck.swift */; };
 		0C026664CE3F52A755A333FF /* OrchestrationMentionRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB54728D976B5A56B887ED5 /* OrchestrationMentionRenderer.swift */; };
+		0C1B7AF329EFE71B706E946C /* ConductorUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E9FF32118246D33BBE5EF45 /* ConductorUpload.swift */; };
 		0C345F530667B5539D6243B5 /* CompanionPriorityOutbox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 751FAD7033C9A3DC31ABE2F3 /* CompanionPriorityOutbox.swift */; };
 		0C8691424C40627F505DDE94 /* PTYSessionPeerPort.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8721B9515977EC8CB513CDAA /* PTYSessionPeerPort.swift */; };
 		0C9EC47197770F9F682B6F8D /* RemoteCommandToolProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E7BADF8FB7DD7E1B851F797 /* RemoteCommandToolProvider.swift */; };
@@ -6812,6 +6813,7 @@
 		6D70E7DE7E81B39DC29CC27B /* VT100PromptKind.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VT100PromptKind.h; sourceTree = "<group>"; };
 		6E2F6A9024607073D194DA5A /* iTermConfigGenerationTracker.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = iTermConfigGenerationTracker.m; sourceTree = "<group>"; };
 		6E8BB76193334BC38C90EC4C /* mul */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; name = mul; path = mul.lproj/InstantReplay.xcstrings; sourceTree = "<group>"; };
+		6E9FF32118246D33BBE5EF45 /* ConductorUpload.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConductorUpload.swift; sourceTree = "<group>"; };
 		6EFD41B9F2C6F53723CDF88B /* iTermArrangementKeys.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = iTermArrangementKeys.h; sourceTree = "<group>"; };
 		6F6AD8136D2E4D2EB86E9ABC /* mul */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; name = mul; path = mul.lproj/AITerm.xcstrings; sourceTree = "<group>"; };
 		6F87CB3CBFBF0D0E8781513C /* VT100StringConversionConfig.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VT100StringConversionConfig.h; sourceTree = "<group>"; };
@@ -12795,6 +12797,7 @@
 				A6069F352DF79A5100EE6CC7 /* SystemFolderIconProvider.swift */,
 				A6EC8096282EBFB000493544 /* TarJob.swift */,
 				A1B19743799E1009AC26E7F4 /* Conductor+IT2.swift */,
+				6E9FF32118246D33BBE5EF45 /* ConductorUpload.swift */,
 			);
 			path = SSH;
 			sourceTree = "<group>";
@@ -22419,6 +22422,7 @@
 				DDC6A04E4BD124950415EFEA /* iTermHDREngager.swift in Sources */,
 				FB47A51FE147AA2BDA2FFFD4 /* SendCompanionNotificationBuiltInFunction.swift in Sources */,
 				3566BF95446653BE5BBB96EB /* iTermSettingsTruncationChecker.swift in Sources */,
+				0C1B7AF329EFE71B706E946C /* ConductorUpload.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/sources/Localizable.xcstrings
+++ b/sources/Localizable.xcstrings
@@ -97480,6 +97480,17 @@
         }
       }
     },
+    "NonTextPaste.CouldNotEncodeImage" : {
+      "comment" : "Error when clipboard image data cannot be converted to a PNG file",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Could not convert the clipboard image to PNG."
+          }
+        }
+      }
+    },
     "NonTextPaste.CouldNotCreateTempDir" : {
       "comment" : "Error when a temporary directory cannot be created",
       "extractionState" : "stale",

--- a/sources/PTYSession/PTYSession+Private.h
+++ b/sources/PTYSession/PTYSession+Private.h
@@ -87,6 +87,7 @@ TriggerDelegate> {
     AITermControllerObjC *_aiterm;
     iTermNonTextPasteHelper *_nonTextPasteHelper;
     TransferrableFile *_uploadAndPasteTransfer;  // Current upload for "upload and paste path" feature
+    NSUUID *_uploadAndPasteIdentifier;
 }
 
 @property(nonatomic, retain) Interval *currentMarkOrNotePosition;

--- a/sources/PTYSession/PTYSession.m
+++ b/sources/PTYSession/PTYSession.m
@@ -1176,6 +1176,7 @@ ITERM_WEAKLY_REFERENCEABLE
     [_pasteHelper release];
     _nonTextPasteHelper.delegate = nil;
     [_nonTextPasteHelper release];
+    [_uploadAndPasteIdentifier release];
     [_backgroundImage release];
     [_antiIdleTimer invalidate];
     [_cadenceController release];
@@ -15211,10 +15212,11 @@ typedef NS_ENUM(NSUInteger, PTYSessionTmuxReport) {
         path.path = [destinationPath.path stringByAppendingPathComponent:filename];
         DLog(@"Will upload local:%@ to remote:%@", file, path.path);
 
-        if ([_conductor canTransferFilesTo:path]) {
+        iTermConductor *conductor = [self nonTextPasteConductor];
+        if ([conductor canTransferFilesTo:path]) {
             DLog(@"Using conductor for upload");
-            [_conductor uploadFile:file to:path];
-            break;
+            [conductor uploadFile:file to:path];
+            continue;
         }
         DLog(@"Using SCPFile for upload");
         SCPFile *scpFile = [[[SCPFile alloc] init] autorelease];
@@ -20436,23 +20438,36 @@ static const NSTimeInterval PTYSessionFocusReportBellSquelchTimeIntervalThreshol
 }
 
 - (BOOL)nonTextPasteHelperCanUpload:(iTermNonTextPasteHelper *)sender {
-    // Can upload if we have SSH integration (conductor) in framing mode, or if
-    // shell integration detected we're on a remote host.
-    DLog(@"nonTextPasteHelperCanUpload: conductor=%@ framing=%@ currentHost=%@ isLocalhost=%@",
-         self.conductor, @(self.conductor.framing), self.currentHost, @(self.currentHost.isLocalhost));
-    if (self.conductor.framing) {
-        DLog(@"Can upload via conductor");
-        return YES;
+    return [self scpPathForCurrentRemoteHost] != nil;
+}
+
+// A control-mode pane has no conductor of its own. Its gateway owns the SSH
+// connection, but pasted input must still go to this pane.
+- (iTermConductor *)nonTextPasteConductor {
+    if (_conductor) {
+        return _conductor.framing ? _conductor : nil;
     }
-    BOOL canUpload = self.currentHost != nil && !self.currentHost.isLocalhost;
-    DLog(@"canUpload=%@", @(canUpload));
-    return canUpload;
+    PTYSession *gateway = self.tmuxGatewaySession;
+    if (self.isTmuxClient && !_tmuxController.serverIsLocal && gateway != self) {
+        return [gateway nonTextPasteConductor];
+    }
+    return nil;
 }
 
 // Returns an SCPPath for the current remote host and working directory, or nil if not available.
 - (SCPPath *)scpPathForCurrentRemoteHost {
     id<VT100RemoteHostReading> remoteHost = self.currentHost;
+    iTermConductor *conductor = [self nonTextPasteConductor];
     DLog(@"scpPathForCurrentRemoteHost: remoteHost=%@", remoteHost);
+    // SSH integration knows the destination even before shell integration has
+    // reported a host or working directory (including inside ordinary tmux).
+    if (!remoteHost && conductor) {
+        SCPPath *path = [[[SCPPath alloc] init] autorelease];
+        path.hostname = conductor.sshIdentity.hostname;
+        path.username = conductor.sshIdentity.username;
+        path.path = conductor.homeDirectory;
+        return path.path.length ? path : nil;
+    }
     if (!remoteHost || !remoteHost.username || !remoteHost.hostname) {
         DLog(@"No remote host or missing username/hostname");
         return nil;
@@ -20462,7 +20477,13 @@ static const NSTimeInterval PTYSessionFocusReportBellSquelchTimeIntervalThreshol
         return nil;
     }
     NSString *workingDirectory = self.variablesScope.path;
-    if (!workingDirectory) {
+    SCPPath *identityPath = [[[SCPPath alloc] init] autorelease];
+    identityPath.hostname = remoteHost.hostname;
+    identityPath.username = remoteHost.username;
+    if (!workingDirectory.length && [conductor canTransferFilesTo:identityPath]) {
+        workingDirectory = conductor.homeDirectory;
+    }
+    if (!workingDirectory.length) {
         DLog(@"No working directory");
         return nil;
     }
@@ -20517,6 +20538,10 @@ static const NSTimeInterval PTYSessionFocusReportBellSquelchTimeIntervalThreshol
 
     // Show upload indicator
     __weak __typeof(self) weakSelf = self;
+    NSUUID *identifier = [NSUUID UUID];
+    [_uploadAndPasteIdentifier release];
+    _uploadAndPasteIdentifier = [identifier retain];
+    iTermConductor *conductor = [self nonTextPasteConductor];
     [_view showUploadIndicatorWithFilename:filename onCancel:^{
         DLog(@"Upload cancelled by user");
         [weakSelf cancelUploadAndPaste];
@@ -20527,13 +20552,20 @@ static const NSTimeInterval PTYSessionFocusReportBellSquelchTimeIntervalThreshol
         DLog(@"Upload completed: success=%d error=%@", success, error);
         __strong __typeof(self) strongSelf = [[weakSelf retain] autorelease];
         
-        if (!strongSelf) {
+        if (!strongSelf || strongSelf->_uploadAndPasteIdentifier != identifier) {
             return;
         }
+        NSString *actualPath = [strongSelf->_uploadAndPasteTransfer isKindOfClass:ConductorFileTransfer.class] ?
+            [strongSelf->_uploadAndPasteTransfer destination] : remotePath;
         strongSelf->_uploadAndPasteTransfer = nil;
+        [strongSelf->_uploadAndPasteIdentifier release];
+        strongSelf->_uploadAndPasteIdentifier = nil;
         [strongSelf.view hideUploadIndicator];
-        if (success) {
-            NSString *escapedPath = [remotePath quotedStringForPaste];
+        SCPPath *currentPath = [strongSelf scpPathForCurrentRemoteHost];
+        BOOL sameHost = [currentPath.hostname isEqualToString:scpPath.hostname] &&
+            (currentPath.username == scpPath.username || [currentPath.username isEqualToString:scpPath.username]);
+        if (success && !strongSelf.exited && sameHost && [strongSelf nonTextPasteConductor] == conductor) {
+            NSString *escapedPath = [actualPath quotedStringForPaste];
             DLog(@"Pasting escaped path: %@", escapedPath);
             [strongSelf pasteString:escapedPath flags:0];
         } else {
@@ -20543,6 +20575,8 @@ static const NSTimeInterval PTYSessionFocusReportBellSquelchTimeIntervalThreshol
 }
 
 - (void)cancelUploadAndPaste {
+    [_uploadAndPasteIdentifier release];
+    _uploadAndPasteIdentifier = nil;
     if (_uploadAndPasteTransfer) {
         DLog(@"Cancelling upload and paste transfer");
         [_uploadAndPasteTransfer stop];
@@ -20562,9 +20596,10 @@ static const NSTimeInterval PTYSessionFocusReportBellSquelchTimeIntervalThreshol
     path.path = [destinationPath.path stringByAppendingPathComponent:filename];
     DLog(@"Will upload local:%@ to remote:%@", localPath, path.path);
 
-    if ([_conductor canTransferFilesTo:path]) {
+    iTermConductor *conductor = [self nonTextPasteConductor];
+    if ([conductor canTransferFilesTo:path]) {
         DLog(@"Using conductor for upload with completion");
-        return [_conductor uploadFile:localPath to:path withCompletion:completion];
+        return [conductor uploadFile:localPath to:path withCompletion:completion];
     }
 
     DLog(@"Using SCPFile for upload with completion");

--- a/sources/Pasting/iTermNonTextPasteHelper.swift
+++ b/sources/Pasting/iTermNonTextPasteHelper.swift
@@ -361,24 +361,46 @@ class iTermNonTextPasteHelper: NSObject {
 
     private func saveImageToTempFile(imageData: Data, fileExtension: String) -> String? {
         DLog("saveImageToTempFile: \(imageData.count) bytes, extension=\(fileExtension)")
+        // Screenshots often offer TIFF. Agent image readers commonly accept PNG/JPEG,
+        // so convert other bitmap formats before handing them a filename.
+        guard let image = Self.imageForFile(imageData, fileExtension: fileExtension) else {
+            showError(String(localized: "NonTextPaste.CouldNotEncodeImage", defaultValue: "Could not convert the clipboard image to PNG.", comment: "Error when clipboard image data cannot be converted to a PNG file"))
+            return nil
+        }
         guard let tempDir = FileManager.default.it_temporaryDirectory() else {
             RLog("saveImageToTempFile: failed to get temporary directory")
             showError(String(localized: "NonTextPaste.CouldNotCreateTempDir", defaultValue: "Could not create temporary directory.", comment: "Error when a temporary directory cannot be created"))
             return nil
         }
-
         let timestamp = Self.timestampFormatter.string(from: Date())
-        let filename = "pasted-image-\(timestamp).\(fileExtension)"
+        // The basename must also be unique on the remote host, where multiple local
+        // temporary directories all upload to the same directory.
+        let filename = "pasted-image-\(timestamp)-\(UUID().uuidString).\(image.fileExtension)"
         let tempPath = (tempDir as NSString).appendingPathComponent(filename)
 
         do {
-            try imageData.write(to: URL(fileURLWithPath: tempPath))
+            try image.data.write(to: URL(fileURLWithPath: tempPath), options: .atomic)
+            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: tempPath)
             DLog("saveImageToTempFile: saved to \(tempPath)")
             return tempPath
         } catch {
+            try? FileManager.default.removeItem(atPath: tempDir)
             RLog("saveImageToTempFile: failed to write: \(error)")
             showError(String(localized: "NonTextPaste.CouldNotSaveImage", defaultValue: "Could not save image to temporary file: \(error.localizedDescription)", comment: "Error when a pasted image cannot be written to a temporary file"))
             return nil
+        }
+    }
+
+    static func imageForFile(_ data: Data, fileExtension: String) -> (data: Data, fileExtension: String)? {
+        switch fileExtension.lowercased() {
+        case "png", "jpg", "jpeg", "gif", "webp":
+            return (data, fileExtension.lowercased())
+        default:
+            guard let bitmap = NSBitmapImageRep(data: data),
+                  let png = bitmap.representation(using: .png, properties: [:]) else {
+                return nil
+            }
+            return (png, "png")
         }
     }
 

--- a/sources/SSH/Conductor+ConductorFileTransferDelegate.swift
+++ b/sources/SSH/Conductor+ConductorFileTransferDelegate.swift
@@ -366,7 +366,14 @@ extension Conductor: ConductorFileTransferDelegate {
     private func reallyBeginUpload(fileTransfer: ConductorFileTransfer,
                                    of choice: Either<String, Data>) async {
         let tempfile = fileTransfer.path.path + ".uploading-\(UUID().uuidString)"
+        var renamedPath: String?
+        func checkCancellation() throws {
+            if fileTransfer.isStopped {
+                throw CancellationError()
+            }
+        }
         do {
+            try checkCancellation()
             let data = try choice.handle { path in
                 let fileURL = URL(fileURLWithPath: path)
                 return try Data(contentsOf: fileURL)
@@ -377,23 +384,17 @@ extension Conductor: ConductorFileTransferDelegate {
             try await create(tempfile,
                              content: Data())
             fileTransfer.fileSize = data.count
-            var offset = 0
-            while offset < data.count {
-                if fileTransfer.isStopped {
-                    fileTransfer.abort()
-                    return
-                }
-                let maxChunkSize = 1024
-                let chunk = data.subdata(in: offset..<min(data.count, offset + maxChunkSize))
-                offset += chunk.count
-                try await append(tempfile, content: chunk)
-                fileTransfer.didTransferBytes(UInt(chunk.count))
+            try await ConductorUpload.send(data, checkCancellation: checkCancellation) { chunk in
+                try await self.append(tempfile, content: chunk)
+            } didTransfer: { count in
+                fileTransfer.didTransferBytes(UInt(count))
             }
             // Find a good name
             var proposedName = fileTransfer.path.path!
             var remoteName: String?
             for i in 0..<100 {
                 let info = try? await stat(proposedName)
+                try checkCancellation()
                 if info == nil {
                     remoteName = proposedName
                     break
@@ -409,11 +410,20 @@ extension Conductor: ConductorFileTransferDelegate {
                 tempfile,
                 newParent: remoteName.deletingLastPathComponent,
                 newName: remoteName.lastPathComponent)
+            renamedPath = remoteName
+            try checkCancellation()
             fileTransfer.didFinishSuccessfully()
         } catch {
             // Delete the temp file
             try? await rm(tempfile, recursive: false)
-            fileTransfer.fail(reason: error.localizedDescription)
+            if fileTransfer.isStopped {
+                if let renamedPath {
+                    try? await rm(renamedPath, recursive: false)
+                }
+                fileTransfer.abort()
+            } else {
+                fileTransfer.fail(reason: error.localizedDescription)
+            }
         }
     }
 }

--- a/sources/SSH/ConductorFileTransfer.swift
+++ b/sources/SSH/ConductorFileTransfer.swift
@@ -258,6 +258,7 @@ class ConductorFileTransfer: TransferrableFile {
     }
 
     override func stop() {
+        guard !isStopped else { return }
         FileTransferManager.sharedInstance().transferrableFileWillStop(self)
         state = .failed
     }

--- a/sources/SSH/ConductorUpload.swift
+++ b/sources/SSH/ConductorUpload.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+// Bound each request so terminal input can be serviced between chunks. Waiting
+// for an acknowledgement per KiB makes upload speed depend almost entirely on RTT.
+@MainActor
+enum ConductorUpload {
+    // 16 KiB balances round trips against the framer’s line parsing overhead.
+    static let chunkSize = 16 * 1024
+
+    static func send(_ data: Data,
+                     checkCancellation: () throws -> Void,
+                     append: (Data) async throws -> Void,
+                     didTransfer: (Int) -> Void) async throws {
+        try checkCancellation()
+        var offset = 0
+        while offset < data.count {
+            try checkCancellation()
+            let end = offset + min(chunkSize, data.count - offset)
+            let chunk = data.subdata(in: offset..<end)
+            try await append(chunk)
+            // Cancellation during the final request must be observed too.
+            try checkCancellation()
+            didTransfer(chunk.count)
+            offset = end
+        }
+    }
+}

--- a/tests/benchmark_conductor_upload.py
+++ b/tests/benchmark_conductor_upload.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Compare sequential upload chunks over the real framer and an SSH PTY.
+
+Usage: python3 tests/benchmark_conductor_upload.py ai
+Creates and removes an isolated remote temporary directory. Uses synthetic data;
+never reads the clipboard or touches existing sessions. Excludes SSH setup time.
+"""
+import base64
+import hashlib
+import os
+from pathlib import Path
+import re
+import select
+import shlex
+import subprocess
+import sys
+import time
+
+
+def b64(value):
+    if isinstance(value, str):
+        value = value.encode()
+    return base64.b64encode(value).decode() or "="
+
+
+def main():
+    host = sys.argv[1]
+    ssh = ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=10", host]
+    root = subprocess.check_output(ssh + ["mktemp -d /tmp/iterm2-upload-bench.XXXXXXXX"], text=True).strip()
+    if not re.fullmatch(r"/tmp/iterm2-upload-bench\.[A-Za-z0-9]+", root):
+        raise RuntimeError("Unexpected temporary directory")
+    proc = None
+    try:
+        source = (Path(__file__).resolve().parents[1] / "OtherResources/framer.py").read_text()
+        source = source.replace("#{SUB}", "DEPTH=0")
+        subprocess.run(ssh + [f"cat > {shlex.quote(root + '/framer.py')}"], input=source, text=True, check=True)
+        proc = subprocess.Popen(ssh[:-1] + ["-tt", host, f"stty -echo; python3 -u {root}/framer.py"], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+        def request(verb, *args):
+            command = "\n".join(b64(arg) for arg in ["file", verb, *args])
+            wire = "\n".join(command[i:i+128] + ("\\" if i+128 < len(command) else "") for i in range(0, len(command), 128)) + "\n\n"
+            proc.stdin.write(wire.encode())
+            proc.stdin.flush()
+            response = b""
+            deadline = time.monotonic() + 30
+            while time.monotonic() < deadline:
+                if select.select([proc.stdout], [], [], max(0, deadline-time.monotonic()))[0]:
+                    part = os.read(proc.stdout.fileno(), 65536)
+                    if not part:
+                        raise RuntimeError("SSH closed: " + proc.stderr.read().decode())
+                    response += part
+                    match = re.search(rb"\x1b\]134;:end \S+ (\d+) [rf]\x1b\\", response)
+                    if match:
+                        if match[1] != b"0":
+                            raise RuntimeError(repr(response))
+                        return
+            raise TimeoutError(repr(response[-1000:]))
+
+        request("stat", b64(root))
+        data = os.urandom(490 * 1024)
+        for size in (1024, 4096, 8192, 16384, 32768, 65536):
+            path = f"{root}/upload-{size}"
+            start = time.monotonic()
+            request("create", b64(path), b64(b""))
+            for offset in range(0, len(data), size):
+                request("append", b64(path), b64(data[offset:offset+size]))
+            request("mv", b64(path), b64(path + ".done"))
+            elapsed = time.monotonic() - start
+            digest = subprocess.check_output(ssh + [f"sha256sum {path}.done"], text=True).split()[0]
+            if digest != hashlib.sha256(data).hexdigest():
+                raise RuntimeError("Upload checksum mismatch")
+            print(f"{size//1024:2} KiB chunks: {elapsed:.3f}s; {(len(data)+size-1)//size} appends; SHA-256 verified", flush=True)
+    finally:
+        if proc:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()
+        subprocess.run(ssh + [f"rm -rf -- {shlex.quote(root)}"], check=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Clipboard screenshots commonly arrive as TIFF, which remote coding agents may not accept. This improves the existing “Upload and Paste Path” action by converting TIFF/other bitmap formats to PNG, preserving supported compressed formats, and giving pasted images unique filenames. Uploads resolve the SSH Integration conductor through tmux control-mode gateways and can use its home directory before shell integration reports a working directory, including inside ordinary tmux. Successful uploads paste the actual destination after collision renaming; cancelled or obsolete completions cannot paste a path into a different session/connection.

SSH Integration uploads now send sequential 16 KiB chunks instead of 1 KiB. A 490 KiB image requires 31 append requests instead of 490. The included benchmark runs the real remote framer over an SSH PTY: measured upload time fell from approximately 4.2 seconds to 1.4–1.7 seconds, with SHA-256 verification. Larger 64 KiB chunks took approximately 3 seconds because of parser overhead. Cancellation now cleans up temporary files, handles cancellation during the final rename, and avoids leaving finished transfers in “Cancelling…”.

Validation:
- Development build succeeded locally.
- `ConductorUploadTests`: 5 passed, covering chunk boundaries, byte preservation, progress, cancellation, and append errors.
- `NonTextPasteImageTests`: 3 passed; `NSStringQuotedStringForPasteTests`: 22 passed.
- Clipboard image upload/paste manually confirmed over SSH Integration with ordinary tmux. The tmux control-mode gateway path has not been manually exercised.
- `python3 tests/benchmark_conductor_upload.py <host>` verified synthetic uploads across 1, 4, 8, 16, 32, and 64 KiB chunk sizes.
- `git diff --check` passed.

Local build/test validation used separate Xcode 27 compatibility changes and rebuilt dependencies. Those changes, generated binaries, and local fish/it2ssh setup are excluded from this PR; the isolated PR branch has not been built independently with an older toolchain. Release notes and the new localized error string are included.
