### PR TITLE
Honor the profile's ligature settings when preferSpeedToFullLigatureSupport is off

### DIFF
--- a/sources/Drawing/iTermAttributedStringBuilder.m
+++ b/sources/Drawing/iTermAttributedStringBuilder.m
@@ -779,16 +779,23 @@ preferSpeedToFullLigatureSupport:(BOOL)preferSpeedToFullLigatureSupport
 
     attributes->font = fontInfo.font;
     attributes->ligatureLevel = fontInfo.ligatureLevel;
-    if (_preferSpeedToFullLigatureSupport) {
-        if (!c->complexChar &&
-            iTermCharacterSupportsFastPath(c->code, _asciiLigaturesAvailable)) {
+    // The profile's Ligatures checkboxes must be honored regardless of
+    // preferSpeedToFullLigatureSupport. When that advanced setting is off no character
+    // takes the fast path, so the ligature attribute is the only thing left that can
+    // turn ligatures off.
+    if (c->complexChar || c->code > 128) {
+        if (!_nonAsciiLigatures) {
             attributes->ligatureLevel = 0;
         }
-        if (c->complexChar || c->code > 128) {
-            if (!_nonAsciiLigatures) {
-                attributes->ligatureLevel = 0;
-            }
-        }
+    } else if (!_asciiLigaturesAvailable) {
+        // The drawing helper has already ANDed this with the profile's ASCII ligature
+        // setting.
+        attributes->ligatureLevel = 0;
+    }
+    if (_preferSpeedToFullLigatureSupport &&
+        !c->complexChar &&
+        iTermCharacterSupportsFastPath(c->code, _asciiLigaturesAvailable)) {
+        attributes->ligatureLevel = 0;
     }
     if (c->underline) {
         switch (ScreenCharGetUnderlineStyle(*c)) {


### PR DESCRIPTION
## Problem

The per-profile **Ligatures** checkboxes (Settings > Profiles > Text, for both the ASCII and the non-ASCII font) are silently ignored when the advanced setting `preferSpeedToFullLigatureSupport` is turned off.

In `iTermAttributedStringBuilder`, the check that clears the ligature level for non-ASCII characters lives *inside* the `preferSpeedToFullLigatureSupport` branch:

```objc
attributes->ligatureLevel = fontInfo.ligatureLevel;
if (_preferSpeedToFullLigatureSupport) {
    if (!c->complexChar &&
        iTermCharacterSupportsFastPath(c->code, _asciiLigaturesAvailable)) {
        attributes->ligatureLevel = 0;
    }
    if (c->complexChar || c->code > 128) {
        if (!_nonAsciiLigatures) {   // <- only reachable when preferSpeed is on
            attributes->ligatureLevel = 0;
        }
    }
}
```

When `preferSpeedToFullLigatureSupport` is off, nothing takes the fast path, so the ligature attribute is the only thing that can turn ligatures off — and it is never cleared. The ASCII checkbox has the same problem: it only takes effect through `iTermCharacterSupportsFastPath`, which is likewise unreachable.

This was harmless while the default ligature level was 1. In 3.7 `PTYFontInfo.it_ligatureLevel` returns 2 when `enableContextualAlternates` is on (the default), and level 2 enables discretionary ligatures (`dlig`) — which Japanese fonts use for the CJK compatibility "squared" forms. So CJK text now gets mangled with the non-ASCII Ligatures checkbox **off**:

```
クレカ・ポイント.md   ->   クレカ・㌽.md
```

`ポイント` (4 chars) is replaced by U+333D SQUARE POINT. Verified with CoreText directly against the profile's non-ASCII font (Hiragino Maru Gothic ProN W4):

```
kCTLigatureAttributeName = 0 or 1: ク レ カ ・ ポ イ ン ト . m d   (11 glyphs)
kCTLigatureAttributeName = 2:      ク レ カ ・ ㌽ . m d            (8 glyphs)
```

It is not limited to ㌽. In the same font, level 2 also collapses センチ, キロ, キログラム, メートル, パーセント, ミリ, ページ, ドル, トン, インチ, ビル, デシ, ナノ, マイル, メガ, ギガ, ワット, 株式会社, 有限会社, 令和, 平成 — each into a single squared glyph.

### Steps to reproduce

1. Advanced settings: turn **off** `preferSpeedToFullLigatureSupport`.
2. Profile > Text: ASCII font = FiraCode Nerd Font Mono with **Ligatures on**; "Use a different font for non-ASCII text" on, non-ASCII font = Hiragino Maru Gothic ProN with **Ligatures off**.
3. `ls` a file named `クレカ・ポイント.md`.

Expected: the name is rendered as typed. Actual: `クレカ・㌽.md`.

## Fix

Apply the profile's ligature settings unconditionally, and keep the fast-path suppression as an additional condition under `preferSpeedToFullLigatureSupport`. `_asciiLigaturesAvailable` is already `(font is ligature capable) && _asciiLigatures` (see `-[iTermTextDrawingHelper computeAsciiLigaturesAvailable]`), so it is the right predicate for the ASCII side.

The behavior changes only where a checkbox says "off" and the old code ignored it. Re-implementing both versions of the decision and enumerating every combination of (ASCII punctuation / ASCII alphanumeric / non-ASCII) x preferSpeed x asciiLigatures x nonAsciiLigatures gives 24 cases, of which 6 change — all of them cases where the user had turned the relevant checkbox off:

| char | preferSpeed | ASCII lig | non-ASCII lig | before | after |
| --- | --- | --- | --- | --- | --- |
| `ポ` | off | on | **off** | 2 | **0** |
| `ポ` | off | off | **off** | 2 | **0** |
| `-` | off | **off** | on | 2 | **0** |
| `-` | off | **off** | off | 2 | **0** |
| `a` | off | **off** | on | 2 | **0** |
| `a` | off | **off** | off | 2 | **0** |
| (other 18) | | | | unchanged | unchanged |

## Testing

Built `make Development` and ran it against a profile matching the report (FiraCode Nerd Font Mono with Ligatures on for ASCII, Hiragino Maru Gothic ProN with Ligatures off for non-ASCII, `preferSpeedToFullLigatureSupport` off):

- With the non-ASCII Ligatures checkbox off, `クレカ・ポイント.md` renders as typed and FiraCode's `->`, `!=`, `===` are still ligated.
- Toggling that checkbox back on brings the squared forms back, i.e. the setting now works in both directions.

## Note

I kept the existing `c->code > 128` boundary for "non-ASCII" so the diff stays scoped to this bug, but it is worth a look: `iTermCharacterSupportsFastPath` uses `isascii()` (< 128) and the segmentation code near line 655 uses `c.code < 127`, so the three disagree about U+007F/U+0080.

Related: the same level-2 `dlig` surprise for Latin fonts was reported as issue 12847 (Monaspace rendering `[]` as a checkbox) and addressed with the per-font Contextual Alternates toggle in the font picker. This report is the CJK counterpart, but here the user had already asked for ligatures to be off and was not obeyed.
