### PR TITLE
Show the Tahoe session-status ring on the first and last tab

### DIFF
--- a/ThirdParty/PSMTabBarControl/source/PSMTabBarControl.m
+++ b/ThirdParty/PSMTabBarControl/source/PSMTabBarControl.m
@@ -1637,9 +1637,18 @@ static NSString *PSMSmartTruncationPrefix(NSString *title, NSInteger length) {
             [indicator removeFromSuperview];
         }
     }
-    for (NSView *progressBar in _tabProgressBars.objectEnumerator) {
+    // A Tahoe progress ring is deliberately outset past its pill by
+    // progressRingWidth on every side (see -progressBarRectForTabCell:), so an
+    // edge tab's accessory frame reaches a couple of points past the leading or
+    // trailing margin even when the tab itself is fully inside the scroll
+    // region. Testing that outset frame wrongly hid the ring on the first and
+    // last tab. Test the owning cell's frame instead: a fully-visible edge tab
+    // keeps its ring, while a cell that has actually scrolled under the
+    // decorations (or past the trailing edge) is still caught.
+    for (PSMTabBarCell *cell in _tabProgressBars) {
+        NSView *progressBar = [_tabProgressBars objectForKey:cell];
         if (progressBar.superview == self && !progressBar.isHidden &&
-            [self frameIsOutsideScrollRegion:progressBar.frame]) {
+            [self frameIsOutsideScrollRegion:cell.frame]) {
             progressBar.hidden = YES;
         }
     }


### PR DESCRIPTION
## Summary

On macOS 26 (Tahoe-style tabs), the session status ring (the green "working" outline drawn around a tab, driven by OSC 21337 / `cell.progress`) is never drawn on the **first (leftmost) tab**, and likewise on the **last tab** when it sits flush against the trailing edge. The tab's status subtitle still reads `working`; only the ring is missing. Middle tabs get the ring correctly.

## Root cause

The Tahoe progress ring is a per-cell `iTermProgressBarView` positioned by `-[PSMTahoeTabStyle progressBarRectForTabCell:]`, which **deliberately outsets the pill by `progressRingWidth` (2pt) on every side** so it can render as a ring hugging the outside of the pill.

`-hideAccessoriesOutsideScrollRegion` (which runs whenever the tab bar is scrollable, the default via `kPreferenceKeyScrollableSideTabBar = @YES`) then tests each progress bar's own frame:

```objc
for (NSView *progressBar in _tabProgressBars.objectEnumerator) {
    if (progressBar.superview == self && !progressBar.isHidden &&
        [self frameIsOutsideScrollRegion:progressBar.frame]) {
        progressBar.hidden = YES;
    }
}
```

`-frameIsOutsideScrollRegion:` returns YES when `NSMinX(frame) < leading` or `NSMaxX(frame) > trailing`, where `leading` is `leftMarginForTabBarControl` (the first cell's own origin). Because the ring's frame is outset 2pt, the **first** cell's ring has `minX = cellMinX - 2 < leading` and the **last** cell's ring has `maxX = cellMaxX + 2 > trailing`, so both edge rings are judged "outside the scroll region" and hidden, even though the tabs themselves are fully in view. Interior tabs are unaffected because their outset frames still sit well inside the margins.

## Fix

Test the **owning cell's** frame rather than the outset accessory frame. The cell frame is the real scroll unit, so a fully-visible edge tab keeps its ring, while a cell that has genuinely scrolled under the leading decorations (or past the trailing edge) is still caught and hidden. The indicator loop just above is left as-is: the activity indicator sits inside the cell and has no such outset.

```objc
for (PSMTabBarCell *cell in _tabProgressBars) {
    NSView *progressBar = [_tabProgressBars objectForKey:cell];
    if (progressBar.superview == self && !progressBar.isHidden &&
        [self frameIsOutsideScrollRegion:cell.frame]) {
        progressBar.hidden = YES;
    }
}
```

## How to reproduce

1. macOS 26, Tahoe-style tabs, scrollable tab bar (the default).
2. Open 3+ tabs, each with a session that reports "working" status (e.g. the Claude Code integration, or any OSC 21337 progress).
3. The first (leftmost) tab shows the `working` subtitle but no ring; middle tabs show the ring.

## Note

Reported originally against 3.7.0. This is a one-line behavioral fix plus an explanatory comment; I was only able to review it statically (Command Line Tools only, no full Xcode locally), so a maintainer build check is appreciated.
