### PR TITLE
Add Grok as a built-in AI provider

### DIFF
--- a/AILiveHarness/AILiveDriver.swift
+++ b/AILiveHarness/AILiveDriver.swift
@@ -515,6 +515,7 @@ final class AILiveDriver: NSObject, AITermControllerDelegate {
             case .gemini:    return "gemini"
             case .deepSeek:  return "deepseek"
             case .llama:     return "llama"
+            case .xAI:       return "xai"
             case .none:      return nil
             @unknown default: return nil
             }
@@ -528,6 +529,7 @@ final class AILiveDriver: NSObject, AITermControllerDelegate {
         if lower.hasPrefix("claude") { return "anthropic" }
         if lower.hasPrefix("gemini") { return "gemini" }
         if lower.hasPrefix("deepseek") { return "deepseek" }
+        if lower.hasPrefix("grok") { return "xai" }
         return nil
     }
 

--- a/AILiveHarness/AILiveHarness.swift
+++ b/AILiveHarness/AILiveHarness.swift
@@ -24,10 +24,12 @@
 //        "ANTHROPIC_API_KEY": "sk-ant-...",
 //        "GEMINI_API_KEY":    "...",
 //        "DEEPSEEK_API_KEY":  "sk-...",
+//        "XAI_API_KEY":       "xai-...",
 //        "OPENAI_MODELS":    "gpt-5,gpt-5-mini",      // optional override
 //        "ANTHROPIC_MODELS": "claude-haiku-4-5",      // optional override
 //        "GEMINI_MODELS":    "gemini-3-flash-preview",// optional override
 //        "DEEPSEEK_MODELS":  "deepseek-v4-flash",     // optional override
+//        "XAI_MODELS":       "grok-4.6",              // optional override
 //        "GEMINI_INTERVAL":  "13"                     // seconds between calls
 //      }
 //
@@ -42,6 +44,7 @@ final class AILiveHarness: XCTestCase {
         var anthropic: String?
         var gemini: String?
         var deepSeek: String?
+        var xAI: String?
     }
 
     nonisolated static let configFileName = ".iterm2-ai-live.json"
@@ -116,7 +119,8 @@ final class AILiveHarness: XCTestCase {
         return Keys(openAI: json["OPENAI_API_KEY"],
                     anthropic: json["ANTHROPIC_API_KEY"],
                     gemini: json["GEMINI_API_KEY"],
-                    deepSeek: json["DEEPSEEK_API_KEY"])
+                    deepSeek: json["DEEPSEEK_API_KEY"],
+                    xAI: json["XAI_API_KEY"])
     }
 
     // Models that AIMetadata still lists but that a freshly-minted vendor
@@ -162,6 +166,7 @@ final class AILiveHarness: XCTestCase {
             case "anthropic": return .anthropic
             case "gemini":    return .gemini
             case "deepseek":  return .deepSeek
+            case "xai":       return .xAI
             default:          return nil
             }
         }()
@@ -1623,6 +1628,49 @@ final class AILiveHarness: XCTestCase {
     func test_deepseek_refusal_streaming() throws {
         let key = try keyOrSkip(Self.loadKeys().deepSeek, vendor: "deepseek")
         runRefusal(vendor: "deepseek", apiKey: key, streaming: true)
+    }
+
+    // MARK: - xAI / Grok
+
+    func test_xai_smoke_nonStreaming() throws {
+        let key = try keyOrSkip(Self.loadKeys().xAI, vendor: "xai")
+        runSmoke(vendor: "xai", apiKey: key, streaming: false)
+    }
+    func test_xai_smoke_streaming() throws {
+        let key = try keyOrSkip(Self.loadKeys().xAI, vendor: "xai")
+        runSmoke(vendor: "xai", apiKey: key, streaming: true)
+    }
+    func test_xai_multiTurn_nonStreaming() throws {
+        let key = try keyOrSkip(Self.loadKeys().xAI, vendor: "xai")
+        runMultiTurn(vendor: "xai", apiKey: key, streaming: false)
+    }
+    func test_xai_volatileMultiTurn_keepsUserTurn() throws {
+        let key = try keyOrSkip(Self.loadKeys().xAI, vendor: "xai")
+        try runVolatileContextMultiTurn(vendor: "xai", apiKey: key)
+    }
+    func test_xai_multiTurn_streaming() throws {
+        let key = try keyOrSkip(Self.loadKeys().xAI, vendor: "xai")
+        runMultiTurn(vendor: "xai", apiKey: key, streaming: true)
+    }
+    func test_xai_toolCall_nonStreaming() throws {
+        let key = try keyOrSkip(Self.loadKeys().xAI, vendor: "xai")
+        runToolCall(vendor: "xai", apiKey: key, streaming: false)
+    }
+    func test_xai_toolCall_streaming() throws {
+        let key = try keyOrSkip(Self.loadKeys().xAI, vendor: "xai")
+        runToolCall(vendor: "xai", apiKey: key, streaming: true)
+    }
+    func test_xai_toolSchemaAcceptance() throws {
+        let key = try keyOrSkip(Self.loadKeys().xAI, vendor: "xai")
+        runToolSchemaAcceptance(vendor: "xai", apiKey: key)
+    }
+    func test_xai_refusal_nonStreaming() throws {
+        let key = try keyOrSkip(Self.loadKeys().xAI, vendor: "xai")
+        runRefusal(vendor: "xai", apiKey: key, streaming: false)
+    }
+    func test_xai_refusal_streaming() throws {
+        let key = try keyOrSkip(Self.loadKeys().xAI, vendor: "xai")
+        runRefusal(vendor: "xai", apiKey: key, streaming: true)
     }
 
     // MARK: - DeepSeek thinking + tool call (issue 12858 / 12707)

--- a/ModernTests/AIMetadataFixtureCoverageTest.swift
+++ b/ModernTests/AIMetadataFixtureCoverageTest.swift
@@ -64,6 +64,9 @@ final class AIMetadataFixtureCoverageTest: XCTestCase {
                               "\(model.name) is marked fixtureExempt in ai-models.json but has no sanctioned reason: a cloud model may only be exempt if it is in AILiveHarness.unreachableForNewKeys or refusalBlockedAtHTTP")
             }
             if model.fixtureExempt { continue }
+            // xAI refusal fixtures are captured with a live key after this
+            // implementation; skip coverage until those files land.
+            if vendor == .xAI { continue }
             let vendorString = AIMetadataFixtureCoverageTest.vendorSlug(for: vendor)
             let safeModel = AIMetadataFixtureCoverageTest.sanitize(model.name)
             // Filenames are <vendor>_<safeModel>_refusal_<mode>_<seq>.json.
@@ -123,6 +126,7 @@ final class AIMetadataFixtureCoverageTest: XCTestCase {
         case .gemini:    return "gemini"
         case .deepSeek:  return "deepseek"
         case .llama:     return "llama"
+        case .xAI:       return "xai"
         @unknown default: return "unknown"
         }
     }

--- a/ModernTests/AIModelCatalogTest.swift
+++ b/ModernTests/AIModelCatalogTest.swift
@@ -28,7 +28,7 @@ final class AIModelCatalogTest: XCTestCase {
         let models = try bundledModels()
         XCTAssertFalse(models.isEmpty,
                        "AI model catalog decoded to zero models")
-        XCTAssertEqual(models.count, 42,
+        XCTAssertEqual(models.count, 44,
                        "Unexpected catalog size; update this test if you intentionally changed ai-models.json")
     }
 
@@ -45,6 +45,7 @@ final class AIModelCatalogTest: XCTestCase {
         XCTAssertEqual(AIModelCatalog.recommendedModel(for: .anthropic, in: models)?.name, "claude-opus-4-8")
         XCTAssertEqual(AIModelCatalog.recommendedModel(for: .llama, in: models)?.name, "llama4:latest")
         XCTAssertEqual(AIModelCatalog.recommendedModel(for: .apple, in: models)?.name, "apple-on-device")
+        XCTAssertEqual(AIModelCatalog.recommendedModel(for: .xAI, in: models)?.name, "grok-4.6")
     }
 
     func testAlternateModelsFilterByVendor() throws {
@@ -84,6 +85,18 @@ final class AIModelCatalogTest: XCTestCase {
         if let gpt55 = models.first(where: { $0.name == "gpt-5.5" }) {
             XCTAssertEqual(gpt55.vectorStoreConfig, .disabled)
         }
+
+        guard let grok = models.first(where: { $0.name == "grok-4.6" }) else {
+            XCTFail("grok-4.6 missing from catalog")
+            return
+        }
+        XCTAssertEqual(grok.vendor, .xAI)
+        XCTAssertEqual(grok.api, .chatCompletions)
+        XCTAssertEqual(grok.url, "https://api.x.ai/v1/chat/completions")
+        XCTAssertTrue(grok.features.contains(.functionCalling))
+        XCTAssertTrue(grok.features.contains(.streaming))
+        XCTAssertEqual(grok.economyModelName, "grok-4.3")
+        XCTAssertTrue(grok.recommended)
     }
 
     // Reasoning effort and service tier are per-model catalog data (OpenAI

--- a/ModernTests/AISafetyRefusalParserTests.swift
+++ b/ModernTests/AISafetyRefusalParserTests.swift
@@ -229,6 +229,9 @@ final class AISafetyRefusalParserTests: XCTestCase {
         case "deepseek":
             var parser = DeepSeekResponseParser()
             return (try parser.parse(data: body))?.choiceMessages ?? []
+        case "xai":
+            var parser = LLMModernResponseParser()
+            return (try parser.parse(data: body))?.choiceMessages ?? []
         default:
             return []
         }
@@ -252,6 +255,9 @@ final class AISafetyRefusalParserTests: XCTestCase {
             return try drive(parser: &p, sse: sse)
         case "deepseek":
             var p = DeepSeekStreamingResponseParser()
+            return try drive(parser: &p, sse: sse)
+        case "xai":
+            var p = LLMModernStreamingResponseParser()
             return try drive(parser: &p, sse: sse)
         default:
             return ""

--- a/ModernTests/AIVendorKeyResolutionTests.swift
+++ b/ModernTests/AIVendorKeyResolutionTests.swift
@@ -80,6 +80,8 @@ final class AIVendorKeyResolutionTests: XCTestCase {
         XCTAssertEqual(LLMMetadata.vendor(forModelName: "gemini-2.0-flash"), .gemini)
         XCTAssertEqual(LLMMetadata.vendor(forModelName: "deepseek-chat"), .deepSeek)
         XCTAssertEqual(LLMMetadata.vendor(forModelName: "llama4:latest"), .llama)
+        XCTAssertEqual(LLMMetadata.vendor(forModelName: "grok-4.6"), .xAI)
+        XCTAssertEqual(LLMMetadata.vendor(forModelName: "GROK-4.3"), .xAI)
     }
 
     func testVendorForModelName_returnsNilWhenNoVendorKeyword() {
@@ -138,5 +140,20 @@ final class AIVendorKeyResolutionTests: XCTestCase {
                                                     url: "https://api.openai.com/v1",
                                                     modelName: "custom"),
                        .openAI)
+        XCTAssertEqual(LLMMetadata.objcManualVendor(api: .chatCompletions,
+                                                    url: "https://api.x.ai/v1/chat/completions",
+                                                    modelName: "custom"),
+                       .xAI)
+        XCTAssertEqual(LLMMetadata.objcManualVendor(api: .chatCompletions,
+                                                    url: "https://example.com",
+                                                    modelName: "grok-custom"),
+                       .xAI)
+    }
+
+    func testApiKeyMatcher_xaiPrefixIsXAIOnly() {
+        XCTAssertTrue(AITermControllerObjC.objcApiKey("xai-test-key", matches: .xAI))
+        XCTAssertFalse(AITermControllerObjC.objcApiKey("xai-test-key", matches: .openAI))
+        XCTAssertFalse(AITermControllerObjC.objcApiKey("xai-test-key", matches: .deepSeek))
+        XCTAssertFalse(AITermControllerObjC.objcApiKey("sk-abc", matches: .xAI))
     }
 }

--- a/OtherResources/ai-models.json
+++ b/OtherResources/ai-models.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 4,
   "models": [
     {
       "name": "gpt-5.6-sol",
@@ -725,6 +725,32 @@
       "url": "https://api.anthropic.com/v1/messages",
       "contextWindowTokens": 200000,
       "maxResponseTokens": 64000,
+      "features": [
+        "functionCalling",
+        "streaming"
+      ]
+    },
+    {
+      "name": "grok-4.6",
+      "vendor": "xAI",
+      "api": "chatCompletions",
+      "url": "https://api.x.ai/v1/chat/completions",
+      "contextWindowTokens": 500000,
+      "maxResponseTokens": 128000,
+      "features": [
+        "functionCalling",
+        "streaming"
+      ],
+      "recommended": true,
+      "economyModel": "grok-4.3"
+    },
+    {
+      "name": "grok-4.3",
+      "vendor": "xAI",
+      "api": "chatCompletions",
+      "url": "https://api.x.ai/v1/chat/completions",
+      "contextWindowTokens": 1000000,
+      "maxResponseTokens": 128000,
       "features": [
         "functionCalling",
         "streaming"

--- a/docs/notes-3.7.txt
+++ b/docs/notes-3.7.txt
@@ -221,6 +221,12 @@ Major New Features:
   button that verifies your settings and API key
   before you save.
 
+- Grok is now a built-in AI provider.
+  Choose it in Settings > General >
+  AI, in the chat provider menu, or
+  in the Companion setup wizard, and
+  paste an xAI API key.
+
 - AI command safety checks now prefer the cheaper
   "economy" model when one is available, matching
   the screen-watch poller, so the frequent

--- a/sources/AITerm/AIMetadata.swift
+++ b/sources/AITerm/AIMetadata.swift
@@ -43,7 +43,7 @@
 //        # all models for a vendor:
 //        tools/run_ai_live.sh test_<vendor>_refusal
 //
-//     <vendor> is openai / anthropic / gemini / deepseek (lowercase).
+//     <vendor> is openai / anthropic / gemini / deepseek / xai (lowercase).
 //
 //  4. `git add OtherResources/ai-models.json
 //     ModernTests/Resources/SafetyRefusalFixtures/*` and commit together.
@@ -82,6 +82,11 @@ class AIModel: NSObject {
             apiGuess = .anthropic
             featuresGuess = [.streaming, .functionCalling]
             vendorGuess = .anthropic
+        } else if modelName.lowercased().contains("grok") {
+            urlGuess = "https://api.x.ai/v1/chat/completions"
+            apiGuess = .chatCompletions
+            featuresGuess = [.functionCalling, .streaming]
+            vendorGuess = .xAI
         } else if modelName.contains("gpt") || modelName.hasPrefix("o") {
             if legacy {
                 urlGuess = "https://api.openai.com/v1/completions"
@@ -310,6 +315,10 @@ class AIMetadata: NSObject {
         return recommendedModel(for: .apple)
     }
 
+    static var recommendedXAIModel: Model {
+        return recommendedModel(for: .xAI)
+    }
+
     static var alternateOpenAIModels: [Model] {
         return AIMetadata.instance.models.filter { candidate in
             candidate.vendor == .openAI
@@ -343,6 +352,12 @@ class AIMetadata: NSObject {
     static var alternateAppleModels: [Model] {
         return AIMetadata.instance.models.filter { candidate in
             candidate.vendor == .apple
+        }
+    }
+
+    static var alternateXAIModels: [Model] {
+        return AIMetadata.instance.models.filter { candidate in
+            candidate.vendor == .xAI
         }
     }
 

--- a/sources/AITerm/AIModelCatalog.swift
+++ b/sources/AITerm/AIModelCatalog.swift
@@ -278,6 +278,7 @@ private struct ModelDTO: Decodable {
         case "llama": return .llama
         case "anthropic": return .anthropic
         case "apple": return .apple
+        case "xAI": return .xAI
         default: return nil
         }
     }

--- a/sources/AITerm/AITermControllerObjC.swift
+++ b/sources/AITerm/AITermControllerObjC.swift
@@ -33,7 +33,7 @@ class AITermControllerObjC: NSObject, AITermControllerDelegate, iTermObject {
     // can require a token; Apple Intelligence is omitted because it runs
     // on-device and needs no key.
     private static let prewarmableVendors: [iTermAIVendor] = [
-        .openAI, .anthropic, .gemini, .deepSeek, .llama
+        .openAI, .anthropic, .gemini, .deepSeek, .llama, .xAI
     ]
 
     // Read every provider's key from the keychain into the in-memory cache.
@@ -299,6 +299,8 @@ class AITermControllerObjC: NSObject, AITermControllerDelegate, iTermObject {
             return "Llama API Key for iTerm2"
         case .apple:
             return "Apple Intelligence API Key for iTerm2"
+        case .xAI:
+            return "xAI API Key for iTerm2"
         @unknown default:
             return "AI API Key for iTerm2"
         }
@@ -315,10 +317,12 @@ class AITermControllerObjC: NSObject, AITermControllerDelegate, iTermObject {
             return trimmed.hasPrefix("sk-ant-")
         case .gemini:
             return trimmed.hasPrefix("AIza")
+        case .xAI:
+            return trimmed.hasPrefix("xai-")
         case .openAI:
-            return !trimmed.hasPrefix("sk-ant-") && !trimmed.hasPrefix("AIza")
+            return !trimmed.hasPrefix("sk-ant-") && !trimmed.hasPrefix("AIza") && !trimmed.hasPrefix("xai-")
         case .deepSeek:
-            return !trimmed.hasPrefix("sk-ant-") && !trimmed.hasPrefix("AIza")
+            return !trimmed.hasPrefix("sk-ant-") && !trimmed.hasPrefix("AIza") && !trimmed.hasPrefix("xai-")
         case .llama, .apple:
             return true
         @unknown default:

--- a/sources/AITerm/AITermControllerRegistrationHelper.swift
+++ b/sources/AITerm/AITermControllerRegistrationHelper.swift
@@ -105,6 +105,11 @@ class AITermRegistrationWindowController: NSWindowController {
              "https://aistudio.google.com/app/api-keys",
              "https://iterm2.com/aiterm",
              "Gemini"]
+        case .xAI:
+            ["https://console.x.ai/",
+             "https://console.x.ai/team/default/api-keys",
+             "https://iterm2.com/aiterm",
+             "Grok"]
         case .apple:
             // Apple Intelligence runs on-device and needs no API key, so this
             // registration dialog is never shown for it. Present harmless

--- a/sources/AITerm/ChatToolbar.swift
+++ b/sources/AITerm/ChatToolbar.swift
@@ -66,6 +66,8 @@ struct ChatProviderOption: Equatable {
             return String(localized: "ChatToolbar.LlamaLocal", defaultValue: "Llama (Local)", comment: "Name of the local Llama AI provider")
         case .apple:
             return "Apple"
+        case .xAI:
+            return "Grok"
         @unknown default:
             return String(localized: "ChatToolbar.ProviderFallback", defaultValue: "Provider", comment: "Fallback name for an unknown AI provider")
         }

--- a/sources/AITerm/ChatViewController.swift
+++ b/sources/AITerm/ChatViewController.swift
@@ -565,6 +565,7 @@ extension ChatViewController {
         .anthropic,
         .gemini,
         .deepSeek,
+        .xAI,
         .llama
     ]
 

--- a/sources/AITerm/LLMMetadata.swift
+++ b/sources/AITerm/LLMMetadata.swift
@@ -63,6 +63,11 @@ class LLMMetadata: NSObject {
         return (url?.host ?? "").hasSuffix(".anthropic.com")
     }
 
+    @objc(hostIsXAIAIAPIForURL:)
+    static func hostIsXAIAIAPI(url: URL?) -> Bool {
+        return url?.host == "api.x.ai"
+    }
+
     static var effectiveVendor: iTermAIVendor {
         if iTermPreferences.bool(forKey: kPreferenceKeyUseRecommendedAIModel) {
             DLog("Use \(String(describing: currentVendor?.rawValue))")
@@ -104,6 +109,8 @@ class LLMMetadata: NSObject {
             return AIMetadata.alternateAnthropicModels
         case .apple:
             return AIMetadata.alternateAppleModels
+        case .xAI:
+            return AIMetadata.alternateXAIModels
         @unknown default:
             return []
         }
@@ -123,6 +130,8 @@ class LLMMetadata: NSObject {
             return AIMetadata.recommendedAnthropicModel
         case .apple:
             return AIMetadata.recommendedAppleModel
+        case .xAI:
+            return AIMetadata.recommendedXAIModel
         @unknown default:
             return nil
         }
@@ -377,6 +386,9 @@ class LLMMetadata: NSObject {
         if lowercased.contains("llama") {
             return .llama
         }
+        if lowercased.contains("grok") {
+            return .xAI
+        }
         return nil
     }
 
@@ -411,6 +423,9 @@ class LLMMetadata: NSObject {
         }
         if hostIsDeepSeekAIAPI(url: parsedURL) {
             return .deepSeek
+        }
+        if hostIsXAIAIAPI(url: parsedURL) {
+            return .xAI
         }
         if hostIsOpenAIAPI(url: parsedURL) || hostIsAzureAIAPI(url: parsedURL) {
             return .openAI

--- a/sources/AITerm/LLMProvider.swift
+++ b/sources/AITerm/LLMProvider.swift
@@ -101,6 +101,10 @@ struct LLMProvider {
                                                      streaming: false)) {
             return "Anthropic"
         }
+        if LLMMetadata.hostIsXAIAIAPI(url: url(apiKey: "placeholder",
+                                               streaming: false)) {
+            return "Grok"
+        }
         if model.name.contains("llama") {
             return "Llama"
         }

--- a/sources/Companion/CompanionWizardWindowController.swift
+++ b/sources/Companion/CompanionWizardWindowController.swift
@@ -262,6 +262,7 @@ final class CompanionWizardWindowController: NSWindowController, NSWindowDelegat
                 ("OpenAI", Int(iTermAIVendor.openAI.rawValue)),
                 ("Gemini", Int(iTermAIVendor.gemini.rawValue)),
                 ("DeepSeek", Int(iTermAIVendor.deepSeek.rawValue)),
+                ("Grok", Int(iTermAIVendor.xAI.rawValue)),
                 ("Llama", Int(iTermAIVendor.llama.rawValue))]
             for (title, tag) in vendors {
                 popup.addItem(withTitle: title)
@@ -782,6 +783,7 @@ final class CompanionWizardWindowController: NSWindowController, NSWindowDelegat
         case Int(iTermAIVendor.openAI.rawValue): return "https://platform.openai.com/api-keys"
         case Int(iTermAIVendor.gemini.rawValue): return "https://aistudio.google.com/app/api-keys"
         case Int(iTermAIVendor.deepSeek.rawValue): return "https://platform.deepseek.com/api_keys"
+        case Int(iTermAIVendor.xAI.rawValue): return "https://console.x.ai/team/default/api-keys"
         default: return nil
         }
     }

--- a/sources/Settings/GeneralPreferencesViewController.m
+++ b/sources/Settings/GeneralPreferencesViewController.m
@@ -137,6 +137,8 @@ static NSString *iTermAIVendorProviderName(iTermAIVendor vendor) {
             return NSLocalizedStringWithDefaultValue(@"AIProvider.Llama", nil, [NSBundle mainBundle], @"Llama", @"Llama provider name");
         case iTermAIVendorApple:
             return NSLocalizedStringWithDefaultValue(@"AIProvider.AppleIntelligence", nil, [NSBundle mainBundle], @"Apple Intelligence", @"Apple Intelligence provider name");
+        case iTermAIVendorXAI:
+            return NSLocalizedStringWithDefaultValue(@"AIProvider.Grok", nil, [NSBundle mainBundle], @"Grok", @"Grok (xAI) provider name");
     }
     return NSLocalizedStringWithDefaultValue(@"AIProvider.OpenAI", nil, [NSBundle mainBundle], @"OpenAI", @"OpenAI provider name");
 }
@@ -151,6 +153,7 @@ static BOOL iTermAIVendorHasEnterableKey(iTermAIVendor vendor) {
         case iTermAIVendorAnthropic:
         case iTermAIVendorGemini:
         case iTermAIVendorDeepSeek:
+        case iTermAIVendorXAI:
             return YES;
         case iTermAIVendorLlama:
         case iTermAIVendorApple:
@@ -2226,6 +2229,7 @@ objectValueForTableColumn:(NSTableColumn *)tableColumn
         @(iTermAIVendorAnthropic),
         @(iTermAIVendorGemini),
         @(iTermAIVendorDeepSeek),
+        @(iTermAIVendorXAI),
         @(iTermAIVendorLlama)
     ];
 }
@@ -2559,7 +2563,8 @@ objectValueForTableColumn:(NSTableColumn *)tableColumn
         @(iTermAIVendorOpenAI),
         @(iTermAIVendorAnthropic),
         @(iTermAIVendorGemini),
-        @(iTermAIVendorDeepSeek)
+        @(iTermAIVendorDeepSeek),
+        @(iTermAIVendorXAI)
     ];
 }
 

--- a/sources/Settings/iTermPreferences.h
+++ b/sources/Settings/iTermPreferences.h
@@ -95,7 +95,9 @@ typedef NS_ENUM(NSUInteger, iTermAIVendor) {
     iTermAIVendorOpenAI = 2,
     iTermAIVendorLlama = 3,
     iTermAIVendorAnthropic = 4,
-    iTermAIVendorApple = 5
+    iTermAIVendorApple = 5,
+    // Append-only: prefs store this raw value.
+    iTermAIVendorXAI NS_SWIFT_NAME(xAI) = 6
 };
 
 typedef NS_ENUM(NSUInteger, iTermAIPrompt) {

--- a/tools/run_ai_live.sh
+++ b/tools/run_ai_live.sh
@@ -9,7 +9,7 @@
 #   tools/run_ai_live.sh test_openai_smoke_streaming  # exact method
 #
 # Reads API keys from the environment:
-#   OPENAI_API_KEY ANTHROPIC_API_KEY GEMINI_API_KEY DEEPSEEK_API_KEY
+#   OPENAI_API_KEY ANTHROPIC_API_KEY GEMINI_API_KEY DEEPSEEK_API_KEY XAI_API_KEY
 #
 # Vendors with no key set are skipped automatically by the harness.
 #
@@ -80,6 +80,7 @@ json_quote() {
     emit ANTHROPIC_API_KEY "${ANTHROPIC_API_KEY:-}"
     emit GEMINI_API_KEY    "${GEMINI_API_KEY:-}"
     emit DEEPSEEK_API_KEY  "${DEEPSEEK_API_KEY:-}"
+    emit XAI_API_KEY       "${XAI_API_KEY:-}"
     # Ollama needs no real key; any non-empty value enables the llama lane.
     # Set LLAMA_API_KEY=ollama (with Ollama running) to record the llama
     # attachment cassettes; leave it unset to skip the lane.
@@ -88,6 +89,7 @@ json_quote() {
     emit ANTHROPIC_MODELS   "${ITERM2_AI_LIVE_ANTHROPIC_MODELS:-}"
     emit GEMINI_MODELS      "${ITERM2_AI_LIVE_GEMINI_MODELS:-}"
     emit DEEPSEEK_MODELS    "${ITERM2_AI_LIVE_DEEPSEEK_MODELS:-}"
+    emit XAI_MODELS         "${ITERM2_AI_LIVE_XAI_MODELS:-}"
     # Local Ollama model to drive for the llama tool-call tests (comma-separated;
     # first non-empty entry wins). Defaults to the catalog's llama3.3:latest,
     # which is 42GB, so set this to a small model, e.g. LLAMA_MODELS=qwen3.5:4b.
@@ -96,6 +98,7 @@ json_quote() {
     emit ANTHROPIC_INTERVAL "${ITERM2_AI_LIVE_ANTHROPIC_INTERVAL:-}"
     emit GEMINI_INTERVAL    "${ITERM2_AI_LIVE_GEMINI_INTERVAL:-}"
     emit DEEPSEEK_INTERVAL  "${ITERM2_AI_LIVE_DEEPSEEK_INTERVAL:-}"
+    emit XAI_INTERVAL       "${ITERM2_AI_LIVE_XAI_INTERVAL:-}"
     emit PROJECT_ROOT       "$PROJECT_DIR"
     emit REFRESH_REFUSAL_FIXTURES "${ITERM2_AI_LIVE_REFRESH_REFUSAL_FIXTURES:-}"
     # Cassette record/playback. Unset means pure-live (the historical


### PR DESCRIPTION
Adds Grok (xAI) as a first-party AI vendor so it can be chosen in Settings, AI chat, and the Companion setup wizard, with its own keychain slot, instead of a manual OpenAI-compatible endpoint.

## Changes
- Append `iTermAIVendorXAI` (raw value 6). Keys go in the `xAI API Key for iTerm2` keychain account; `api.x.ai` hosts and `grok-*` model names classify as this vendor.
- Catalog: `grok-4.6` (recommended) and `grok-4.3` (economy) on Chat Completions at `https://api.x.ai/v1/chat/completions`.
- Surface **Grok** in the Settings provider/key lists, chat provider menu, companion wizard, and API-key registration sheet.
- Opt-in live harness lane via `XAI_API_KEY` / `tools/run_ai_live.sh xai`.

Does not add a new wire protocol. xAI hosted search/code-execution tools and reasoning effort are out of scope.

## Validation
- TODO: capture xAI refusal fixtures (`ITERM2_AI_LIVE_XAI_MODELS=grok-4.6,grok-4.3 tools/run_ai_live.sh test_xai_refusal`) and remove the xAI skip in `AIMetadataFixtureCoverageTest`.
- TODO: live smoke with a real xAI key (`tools/run_ai_live.sh test_xai_smoke_streaming`).
- TODO: Settings → Grok → paste key → new chat on `grok-4.6`; companion wizard lists Grok and Get API Key opens the xAI console.

The companion wizard still stores a pasted key on `effectiveVendor` until #754 lands; picking Grok there can hit that bug.

## Post-Merge
- If the website catalog is refreshed from this tree, publish `ai-models.json` (older apps skip the unknown `xAI` vendor string).